### PR TITLE
Fix build errors and app initialization

### DIFF
--- a/ArgoBooks/App.axaml
+++ b/ArgoBooks/App.axaml
@@ -24,17 +24,21 @@
             <ResourceDictionary.MergedDictionaries>
                 <!-- Global colors (shared across themes) -->
                 <ResourceInclude Source="avares://ArgoBooks/Themes/Colors.axaml" />
-
-                <!-- Theme-specific resources -->
-                <ResourceDictionary.ThemeDictionaries>
-                    <ResourceDictionary x:Key="Light">
-                        <ResourceInclude Source="avares://ArgoBooks/Themes/LightTheme.axaml" />
-                    </ResourceDictionary>
-                    <ResourceDictionary x:Key="Dark">
-                        <ResourceInclude Source="avares://ArgoBooks/Themes/DarkTheme.axaml" />
-                    </ResourceDictionary>
-                </ResourceDictionary.ThemeDictionaries>
             </ResourceDictionary.MergedDictionaries>
+
+            <!-- Theme-specific resources -->
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <ResourceDictionary.MergedDictionaries>
+                        <ResourceInclude Source="avares://ArgoBooks/Themes/LightTheme.axaml" />
+                    </ResourceDictionary.MergedDictionaries>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <ResourceDictionary.MergedDictionaries>
+                        <ResourceInclude Source="avares://ArgoBooks/Themes/DarkTheme.axaml" />
+                    </ResourceDictionary.MergedDictionaries>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -20,12 +20,22 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            // Avoid duplicate validations from both Avalonia and the CommunityToolkit. 
+            // Avoid duplicate validations from both Avalonia and the CommunityToolkit.
             // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
             DisableAvaloniaDataAnnotationValidation();
+
+            var mainWindowViewModel = new MainWindowViewModel();
+
+            // Set the initial view to AppShell
+            var appShell = new AppShell
+            {
+                DataContext = new AppShellViewModel()
+            };
+            mainWindowViewModel.NavigateTo(appShell);
+
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainViewModel()
+                DataContext = mainWindowViewModel
             };
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewPlatform)

--- a/ArgoBooks/Controls/ModalOverlay.axaml
+++ b/ArgoBooks/Controls/ModalOverlay.axaml
@@ -44,9 +44,8 @@
                         <Animation Duration="0:0:0.2" FillMode="Forward" Easing="CubicEaseOut">
                             <KeyFrame Cue="100%">
                                 <Setter Property="Opacity" Value="1" />
-                                <Setter Property="RenderTransform">
-                                    <ScaleTransform ScaleX="1" ScaleY="1" />
-                                </Setter>
+                                <Setter Property="ScaleTransform.ScaleX" Value="1" />
+                                <Setter Property="ScaleTransform.ScaleY" Value="1" />
                             </KeyFrame>
                         </Animation>
                     </Style.Animations>

--- a/ArgoBooks/Styles/BaseStyles.axaml
+++ b/ArgoBooks/Styles/BaseStyles.axaml
@@ -1,65 +1,67 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!--
         Argo Books Base Styles
         Common dimensions, spacing, and typography values.
     -->
 
-    <!-- Spacing -->
-    <x:Double x:Key="SpacingXs">4</x:Double>
-    <x:Double x:Key="SpacingSm">8</x:Double>
-    <x:Double x:Key="SpacingMd">16</x:Double>
-    <x:Double x:Key="SpacingLg">24</x:Double>
-    <x:Double x:Key="SpacingXl">32</x:Double>
-    <x:Double x:Key="SpacingXxl">48</x:Double>
+    <Styles.Resources>
+        <!-- Spacing -->
+        <x:Double x:Key="SpacingXs">4</x:Double>
+        <x:Double x:Key="SpacingSm">8</x:Double>
+        <x:Double x:Key="SpacingMd">16</x:Double>
+        <x:Double x:Key="SpacingLg">24</x:Double>
+        <x:Double x:Key="SpacingXl">32</x:Double>
+        <x:Double x:Key="SpacingXxl">48</x:Double>
 
-    <!-- Border Radius -->
-    <CornerRadius x:Key="RadiusNone">0</CornerRadius>
-    <CornerRadius x:Key="RadiusSm">4</CornerRadius>
-    <CornerRadius x:Key="RadiusMd">8</CornerRadius>
-    <CornerRadius x:Key="RadiusLg">12</CornerRadius>
-    <CornerRadius x:Key="RadiusXl">16</CornerRadius>
-    <CornerRadius x:Key="RadiusFull">9999</CornerRadius>
+        <!-- Border Radius -->
+        <CornerRadius x:Key="RadiusNone">0</CornerRadius>
+        <CornerRadius x:Key="RadiusSm">4</CornerRadius>
+        <CornerRadius x:Key="RadiusMd">8</CornerRadius>
+        <CornerRadius x:Key="RadiusLg">12</CornerRadius>
+        <CornerRadius x:Key="RadiusXl">16</CornerRadius>
+        <CornerRadius x:Key="RadiusFull">9999</CornerRadius>
 
-    <!-- Font Sizes -->
-    <x:Double x:Key="FontSizeXs">10</x:Double>
-    <x:Double x:Key="FontSizeSm">12</x:Double>
-    <x:Double x:Key="FontSizeMd">14</x:Double>
-    <x:Double x:Key="FontSizeLg">16</x:Double>
-    <x:Double x:Key="FontSizeXl">20</x:Double>
-    <x:Double x:Key="FontSizeXxl">24</x:Double>
-    <x:Double x:Key="FontSizeXxxl">32</x:Double>
+        <!-- Font Sizes -->
+        <x:Double x:Key="FontSizeXs">10</x:Double>
+        <x:Double x:Key="FontSizeSm">12</x:Double>
+        <x:Double x:Key="FontSizeMd">14</x:Double>
+        <x:Double x:Key="FontSizeLg">16</x:Double>
+        <x:Double x:Key="FontSizeXl">20</x:Double>
+        <x:Double x:Key="FontSizeXxl">24</x:Double>
+        <x:Double x:Key="FontSizeXxxl">32</x:Double>
 
-    <!-- Icon Sizes -->
-    <x:Double x:Key="IconSizeSm">16</x:Double>
-    <x:Double x:Key="IconSizeMd">20</x:Double>
-    <x:Double x:Key="IconSizeLg">24</x:Double>
-    <x:Double x:Key="IconSizeXl">32</x:Double>
+        <!-- Icon Sizes -->
+        <x:Double x:Key="IconSizeSm">16</x:Double>
+        <x:Double x:Key="IconSizeMd">20</x:Double>
+        <x:Double x:Key="IconSizeLg">24</x:Double>
+        <x:Double x:Key="IconSizeXl">32</x:Double>
 
-    <!-- Animation Durations -->
-    <x:String x:Key="AnimationFast">0:0:0.15</x:String>
-    <x:String x:Key="AnimationNormal">0:0:0.25</x:String>
-    <x:String x:Key="AnimationSlow">0:0:0.35</x:String>
+        <!-- Animation Durations -->
+        <x:String x:Key="AnimationFast">0:0:0.15</x:String>
+        <x:String x:Key="AnimationNormal">0:0:0.25</x:String>
+        <x:String x:Key="AnimationSlow">0:0:0.35</x:String>
 
-    <!-- Sidebar Dimensions -->
-    <x:Double x:Key="SidebarExpandedWidth">240</x:Double>
-    <x:Double x:Key="SidebarCollapsedWidth">64</x:Double>
+        <!-- Sidebar Dimensions -->
+        <x:Double x:Key="SidebarExpandedWidth">240</x:Double>
+        <x:Double x:Key="SidebarCollapsedWidth">64</x:Double>
 
-    <!-- Header Dimensions -->
-    <x:Double x:Key="HeaderHeight">56</x:Double>
+        <!-- Header Dimensions -->
+        <x:Double x:Key="HeaderHeight">56</x:Double>
 
-    <!-- Thickness Values (Padding/Margin) -->
-    <Thickness x:Key="PaddingXs">4</Thickness>
-    <Thickness x:Key="PaddingSm">8</Thickness>
-    <Thickness x:Key="PaddingMd">16</Thickness>
-    <Thickness x:Key="PaddingLg">24</Thickness>
-    <Thickness x:Key="PaddingXl">32</Thickness>
+        <!-- Thickness Values (Padding/Margin) -->
+        <Thickness x:Key="PaddingXs">4</Thickness>
+        <Thickness x:Key="PaddingSm">8</Thickness>
+        <Thickness x:Key="PaddingMd">16</Thickness>
+        <Thickness x:Key="PaddingLg">24</Thickness>
+        <Thickness x:Key="PaddingXl">32</Thickness>
 
-    <!-- Border Thickness -->
-    <Thickness x:Key="BorderThin">1</Thickness>
-    <Thickness x:Key="BorderMedium">2</Thickness>
-    <Thickness x:Key="BorderThick">3</Thickness>
+        <!-- Border Thickness -->
+        <Thickness x:Key="BorderThin">1</Thickness>
+        <Thickness x:Key="BorderMedium">2</Thickness>
+        <Thickness x:Key="BorderThick">3</Thickness>
+    </Styles.Resources>
 
     <!-- Base Panel Style -->
     <Style Selector="Panel.page-container">
@@ -72,4 +74,4 @@
         <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
     </Style>
 
-</ResourceDictionary>
+</Styles>

--- a/ArgoBooks/Styles/ButtonStyles.axaml
+++ b/ArgoBooks/Styles/ButtonStyles.axaml
@@ -1,5 +1,5 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!--
         Argo Books Button Styles
@@ -138,4 +138,4 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
     </Style>
 
-</ResourceDictionary>
+</Styles>

--- a/ArgoBooks/Styles/CardStyles.axaml
+++ b/ArgoBooks/Styles/CardStyles.axaml
@@ -1,5 +1,5 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!--
         Argo Books Card Styles
@@ -145,4 +145,4 @@
         <Setter Property="Margin" Value="8,0" />
     </Style>
 
-</ResourceDictionary>
+</Styles>

--- a/ArgoBooks/Styles/TextStyles.axaml
+++ b/ArgoBooks/Styles/TextStyles.axaml
@@ -1,5 +1,5 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!--
         Argo Books Text Styles
@@ -142,4 +142,4 @@
         <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
     </Style>
 
-</ResourceDictionary>
+</Styles>


### PR DESCRIPTION
- Fix App.axaml: Move ThemeDictionaries to be sibling of MergedDictionaries (fixes AXN0002 "Dots aren't allowed in type names" error)
- Fix style files (BaseStyles, ButtonStyles, CardStyles, TextStyles): Change root element from ResourceDictionary to Styles since they are loaded via StyleInclude (fixes AVLN3000/AVLN2000 errors)
- Fix ModalOverlay.axaml: Animate ScaleTransform.ScaleX/ScaleY properties instead of RenderTransform directly (fixes "No animator registered" error)
- Fix App.axaml.cs: Use MainWindowViewModel instead of MainViewModel and set AppShell as initial view (fixes empty window on startup)