### PR TITLE
Add UnsavedChangesDialog with categorized changes list

### DIFF
--- a/ArgoBooks/Modals/UnsavedChangesDialog.axaml
+++ b/ArgoBooks/Modals/UnsavedChangesDialog.axaml
@@ -1,0 +1,364 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:ArgoBooks.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="550" d:DesignHeight="450"
+             x:Class="ArgoBooks.Modals.UnsavedChangesDialog"
+             x:DataType="vm:UnsavedChangesDialogViewModel"
+             IsVisible="{Binding IsOpen}">
+
+    <Design.DataContext>
+        <vm:UnsavedChangesDialogViewModel />
+    </Design.DataContext>
+
+    <UserControl.Resources>
+        <!-- Bool to Angle Converter for expand/collapse arrow -->
+        <vm:BoolToAngleConverter x:Key="BoolToAngleConverter" TrueAngle="90" FalseAngle="0" />
+        <!-- Change Type Converters -->
+        <vm:ChangeTypeToVisibilityConverter x:Key="IsAddedConverter" TargetType="Added" />
+        <vm:ChangeTypeToVisibilityConverter x:Key="IsModifiedConverter" TargetType="Modified" />
+        <vm:ChangeTypeToVisibilityConverter x:Key="IsDeletedConverter" TargetType="Deleted" />
+    </UserControl.Resources>
+
+    <!-- Modal Overlay -->
+    <Grid IsVisible="{Binding IsOpen}">
+        <!-- Backdrop -->
+        <Border Background="#80000000"
+                IsHitTestVisible="True"
+                PointerPressed="Backdrop_PointerPressed">
+            <Border.Transitions>
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.2" />
+                </Transitions>
+            </Border.Transitions>
+        </Border>
+
+        <!-- Modal Content -->
+        <Border x:Name="DialogBorder"
+                Background="{DynamicResource SurfaceBrush}"
+                BorderBrush="{DynamicResource BorderBrush}"
+                BorderThickness="1"
+                CornerRadius="12"
+                Width="550"
+                MaxHeight="500"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                BoxShadow="0 8 32 0 #40000000"
+                Focusable="True"
+                KeyDown="Dialog_KeyDown"
+                Opacity="0"
+                RenderTransformOrigin="0.5,0.5">
+            <Border.RenderTransform>
+                <ScaleTransform ScaleX="0.95" ScaleY="0.95" />
+            </Border.RenderTransform>
+            <Border.Transitions>
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.15" Easing="CubicEaseOut" />
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.15" Easing="CubicEaseOut" />
+                </Transitions>
+            </Border.Transitions>
+
+            <Grid RowDefinitions="Auto,Auto,*,Auto">
+                <!-- Header -->
+                <Border Grid.Row="0"
+                        Padding="24,20"
+                        BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="0,0,0,1">
+                    <Grid ColumnDefinitions="Auto,*">
+                        <!-- Warning Icon -->
+                        <Border Grid.Column="0"
+                                Width="40" Height="40"
+                                CornerRadius="20"
+                                Background="{DynamicResource WarningIconBgBrush}"
+                                Margin="0,0,16,0">
+                            <PathIcon Data="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                                       Width="20" Height="20"
+                                       Foreground="{DynamicResource WarningBrush}" />
+                        </Border>
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                            <TextBlock Text="{Binding Title}"
+                                       FontSize="18"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextPrimaryBrush}" />
+                            <TextBlock Text="{Binding TotalChangeCount, StringFormat='{}{0} unsaved change(s)'}"
+                                       FontSize="13"
+                                       Foreground="{DynamicResource TextTertiaryBrush}"
+                                       IsVisible="{Binding HasChanges}"
+                                       Margin="0,2,0,0" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Message -->
+                <Border Grid.Row="1" Padding="24,16">
+                    <TextBlock Text="{Binding Message}"
+                               FontSize="14"
+                               Foreground="{DynamicResource TextSecondaryBrush}"
+                               TextWrapping="Wrap" />
+                </Border>
+
+                <!-- Changes List (Scrollable) -->
+                <Border Grid.Row="2"
+                        IsVisible="{Binding HasChanges}"
+                        Margin="24,0"
+                        BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Background="{DynamicResource BackgroundSecondaryBrush}"
+                        ClipToBounds="True">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  MaxHeight="220">
+                        <ItemsControl ItemsSource="{Binding Categories}"
+                                      Margin="0,4">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="vm:ChangeCategory">
+                                    <StackPanel>
+                                        <!-- Category Header -->
+                                        <Button Classes="category-header"
+                                                Command="{Binding $parent[ItemsControl].((vm:UnsavedChangesDialogViewModel)DataContext).ToggleCategoryCommand}"
+                                                CommandParameter="{Binding}">
+                                            <Grid ColumnDefinitions="Auto,*,Auto,Auto">
+                                                <!-- Expand/Collapse Arrow -->
+                                                <PathIcon Grid.Column="0"
+                                                          Data="M8.25 4.5l7.5 7.5-7.5 7.5"
+                                                          Width="12" Height="12"
+                                                          Foreground="{DynamicResource TextTertiaryBrush}"
+                                                          Margin="12,0,8,0"
+                                                          RenderTransformOrigin="0.5,0.5">
+                                                    <PathIcon.RenderTransform>
+                                                        <RotateTransform Angle="{Binding IsExpanded, Converter={StaticResource BoolToAngleConverter}}" />
+                                                    </PathIcon.RenderTransform>
+                                                </PathIcon>
+
+                                                <!-- Category Name -->
+                                                <TextBlock Grid.Column="1"
+                                                           Text="{Binding Name}"
+                                                           FontSize="13"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{DynamicResource TextPrimaryBrush}"
+                                                           VerticalAlignment="Center" />
+
+                                                <!-- Change Count Badge -->
+                                                <Border Grid.Column="2"
+                                                        Background="{DynamicResource PrimaryIconBgBrush}"
+                                                        CornerRadius="10"
+                                                        Padding="8,2"
+                                                        Margin="8,0">
+                                                    <TextBlock Text="{Binding ChangeCount}"
+                                                               FontSize="11"
+                                                               FontWeight="Medium"
+                                                               Foreground="{DynamicResource PrimaryBrush}"
+                                                               VerticalAlignment="Center" />
+                                                </Border>
+
+                                                <Border Grid.Column="3" Width="12" />
+                                            </Grid>
+                                        </Button>
+
+                                        <!-- Change Items -->
+                                        <ItemsControl ItemsSource="{Binding Changes}"
+                                                      IsVisible="{Binding IsExpanded}"
+                                                      Margin="0,0,0,4">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate DataType="vm:ChangeItem">
+                                                    <Border Padding="40,6,16,6"
+                                                            Background="Transparent">
+                                                        <Border.Styles>
+                                                            <Style Selector="Border:pointerover">
+                                                                <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+                                                            </Style>
+                                                        </Border.Styles>
+                                                        <Grid ColumnDefinitions="Auto,*">
+                                                            <!-- Change Type Indicator -->
+                                                            <Panel Grid.Column="0"
+                                                                   Width="20" Height="20"
+                                                                   Margin="0,0,10,0"
+                                                                   VerticalAlignment="Center">
+                                                                <!-- Added Icon -->
+                                                                <Border Width="20" Height="20"
+                                                                        CornerRadius="10"
+                                                                        Background="{DynamicResource SuccessIconBgBrush}"
+                                                                        IsVisible="{Binding ChangeType, Converter={StaticResource IsAddedConverter}}">
+                                                                    <PathIcon Data="M12 4.5v15m7.5-7.5h-15"
+                                                                              Width="10" Height="10"
+                                                                              Foreground="{DynamicResource SuccessBrush}" />
+                                                                </Border>
+                                                                <!-- Modified Icon -->
+                                                                <Border Width="20" Height="20"
+                                                                        CornerRadius="10"
+                                                                        Background="{DynamicResource WarningIconBgBrush}"
+                                                                        IsVisible="{Binding ChangeType, Converter={StaticResource IsModifiedConverter}}">
+                                                                    <PathIcon Data="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125"
+                                                                              Width="10" Height="10"
+                                                                              Foreground="{DynamicResource WarningBrush}" />
+                                                                </Border>
+                                                                <!-- Deleted Icon -->
+                                                                <Border Width="20" Height="20"
+                                                                        CornerRadius="10"
+                                                                        Background="{DynamicResource DangerIconBgBrush}"
+                                                                        IsVisible="{Binding ChangeType, Converter={StaticResource IsDeletedConverter}}">
+                                                                    <PathIcon Data="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                                                                              Width="10" Height="10"
+                                                                              Foreground="{DynamicResource DangerBrush}" />
+                                                                </Border>
+                                                            </Panel>
+
+                                                            <!-- Change Description -->
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{Binding Description}"
+                                                                       FontSize="13"
+                                                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                                                       TextTrimming="CharacterEllipsis"
+                                                                       VerticalAlignment="Center" />
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Border>
+
+                <!-- Footer -->
+                <Border Grid.Row="3"
+                        Padding="24,16"
+                        BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="0,1,0,0"
+                        Margin="0,16,0,0">
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <!-- Expand/Collapse All (only when there are changes) -->
+                        <StackPanel Grid.Column="0"
+                                    Orientation="Horizontal"
+                                    Spacing="8"
+                                    IsVisible="{Binding HasChanges}">
+                            <Button Classes="ghost-button"
+                                    Content="Expand All"
+                                    Command="{Binding ExpandAllCommand}"
+                                    FontSize="12" />
+                            <Button Classes="ghost-button"
+                                    Content="Collapse All"
+                                    Command="{Binding CollapseAllCommand}"
+                                    FontSize="12" />
+                        </StackPanel>
+
+                        <!-- Action Buttons -->
+                        <StackPanel Grid.Column="2"
+                                    Orientation="Horizontal"
+                                    HorizontalAlignment="Right"
+                                    Spacing="12">
+                            <!-- Cancel Button -->
+                            <Button Classes="secondary-button"
+                                    Content="{Binding CancelButtonText}"
+                                    Command="{Binding CancelCommand}" />
+
+                            <!-- Don't Save Button -->
+                            <Button Classes="danger-outline-button"
+                                    Content="{Binding DontSaveButtonText}"
+                                    Command="{Binding DontSaveCommand}" />
+
+                            <!-- Save Button -->
+                            <Button Classes="primary-button"
+                                    Content="{Binding SaveButtonText}"
+                                    Command="{Binding SaveCommand}" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
+
+    <UserControl.Styles>
+        <!-- Category Header Button -->
+        <Style Selector="Button.category-header">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0,10" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.category-header /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="Button.category-header:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+        </Style>
+
+        <!-- Primary Button -->
+        <Style Selector="Button.primary-button">
+            <Setter Property="Background" Value="{DynamicResource PrimaryBrush}" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="20,10" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.primary-button /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource PrimaryBrush}" />
+        </Style>
+        <Style Selector="Button.primary-button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource PrimaryHoverBrush}" />
+        </Style>
+
+        <!-- Secondary Button -->
+        <Style Selector="Button.secondary-button">
+            <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
+            <Setter Property="Padding" Value="20,10" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.secondary-button /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
+        </Style>
+        <Style Selector="Button.secondary-button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+        </Style>
+
+        <!-- Danger Outline Button -->
+        <Style Selector="Button.danger-outline-button">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="{DynamicResource DangerBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="BorderBrush" Value="{DynamicResource DangerBrush}" />
+            <Setter Property="Padding" Value="20,10" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.danger-outline-button /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="Button.danger-outline-button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource DangerIconBgBrush}" />
+        </Style>
+
+        <!-- Ghost Button -->
+        <Style Selector="Button.ghost-button">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="{DynamicResource TextTertiaryBrush}" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="8,4" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.ghost-button /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="Button.ghost-button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+        </Style>
+        <Style Selector="Button.ghost-button:pointerover">
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+        </Style>
+    </UserControl.Styles>
+</UserControl>

--- a/ArgoBooks/Modals/UnsavedChangesDialog.axaml.cs
+++ b/ArgoBooks/Modals/UnsavedChangesDialog.axaml.cs
@@ -1,0 +1,84 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using ArgoBooks.ViewModels;
+
+namespace ArgoBooks.Modals;
+
+public partial class UnsavedChangesDialog : UserControl
+{
+    private bool _eventsSubscribed;
+
+    public UnsavedChangesDialog()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+
+        if (DataContext is UnsavedChangesDialogViewModel vm && !_eventsSubscribed)
+        {
+            _eventsSubscribed = true;
+
+            vm.PropertyChanged += (_, args) =>
+            {
+                if (args.PropertyName == nameof(UnsavedChangesDialogViewModel.IsOpen))
+                {
+                    if (vm.IsOpen)
+                    {
+                        // Animate in
+                        Dispatcher.UIThread.Post(() =>
+                        {
+                            if (DialogBorder != null)
+                            {
+                                DialogBorder.Opacity = 1;
+                                DialogBorder.RenderTransform = new ScaleTransform(1, 1);
+                            }
+                            DialogBorder?.Focus();
+                        }, DispatcherPriority.Render);
+                    }
+                    else
+                    {
+                        // Reset for next open
+                        Dispatcher.UIThread.Post(() =>
+                        {
+                            if (DialogBorder != null)
+                            {
+                                DialogBorder.Opacity = 0;
+                                DialogBorder.RenderTransform = new ScaleTransform(0.95, 0.95);
+                            }
+                        }, DispatcherPriority.Background);
+                    }
+                }
+            };
+        }
+    }
+
+    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Don't close on backdrop click for unsaved changes - user must make a choice
+        // This prevents accidental data loss
+    }
+
+    private void Dialog_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (DataContext is UnsavedChangesDialogViewModel vm)
+        {
+            switch (e.Key)
+            {
+                case Key.Escape:
+                    vm.CancelCommand.Execute(null);
+                    e.Handled = true;
+                    break;
+                case Key.Enter:
+                    vm.SaveCommand.Execute(null);
+                    e.Handled = true;
+                    break;
+            }
+        }
+    }
+}

--- a/ArgoBooks/Services/ChangeTrackingService.cs
+++ b/ArgoBooks/Services/ChangeTrackingService.cs
@@ -1,0 +1,240 @@
+using System.Collections.ObjectModel;
+using ArgoBooks.ViewModels;
+
+namespace ArgoBooks.Services;
+
+/// <summary>
+/// Interface for components that can track and report their changes.
+/// </summary>
+public interface IChangeTracker
+{
+    /// <summary>
+    /// Gets whether this component has unsaved changes.
+    /// </summary>
+    bool HasChanges { get; }
+
+    /// <summary>
+    /// Gets the category name for grouping changes.
+    /// </summary>
+    string CategoryName { get; }
+
+    /// <summary>
+    /// Gets the icon name for the category.
+    /// </summary>
+    string CategoryIcon { get; }
+
+    /// <summary>
+    /// Gets the list of individual changes.
+    /// </summary>
+    IEnumerable<ChangeItem> GetChanges();
+
+    /// <summary>
+    /// Clears all tracked changes (after save).
+    /// </summary>
+    void ClearChanges();
+}
+
+/// <summary>
+/// Service that aggregates changes from multiple sources and provides
+/// a unified view of all unsaved changes in the application.
+/// </summary>
+public class ChangeTrackingService
+{
+    private readonly List<IChangeTracker> _trackers = new();
+    private readonly List<ChangeItem> _globalChanges = new();
+    private string _globalCategoryName = "General";
+    private string _globalCategoryIcon = "Cog";
+
+    /// <summary>
+    /// Event raised when the overall change state changes.
+    /// </summary>
+    public event EventHandler? ChangeStateChanged;
+
+    /// <summary>
+    /// Gets whether there are any unsaved changes across all trackers.
+    /// </summary>
+    public bool HasChanges => _globalChanges.Count > 0 || _trackers.Any(t => t.HasChanges);
+
+    /// <summary>
+    /// Registers a change tracker to be aggregated.
+    /// </summary>
+    /// <param name="tracker">The tracker to register.</param>
+    public void RegisterTracker(IChangeTracker tracker)
+    {
+        if (!_trackers.Contains(tracker))
+        {
+            _trackers.Add(tracker);
+        }
+    }
+
+    /// <summary>
+    /// Unregisters a change tracker.
+    /// </summary>
+    /// <param name="tracker">The tracker to unregister.</param>
+    public void UnregisterTracker(IChangeTracker tracker)
+    {
+        _trackers.Remove(tracker);
+    }
+
+    /// <summary>
+    /// Records a global change that isn't tied to a specific tracker.
+    /// </summary>
+    /// <param name="description">Description of the change.</param>
+    /// <param name="changeType">Type of change.</param>
+    public void RecordChange(string description, ChangeType changeType = ChangeType.Modified)
+    {
+        _globalChanges.Add(new ChangeItem
+        {
+            Description = description,
+            ChangeType = changeType
+        });
+        OnChangeStateChanged();
+    }
+
+    /// <summary>
+    /// Records a change with the specified category.
+    /// </summary>
+    /// <param name="categoryName">Name of the category.</param>
+    /// <param name="description">Description of the change.</param>
+    /// <param name="changeType">Type of change.</param>
+    public void RecordChange(string categoryName, string description, ChangeType changeType = ChangeType.Modified)
+    {
+        _globalCategoryName = categoryName;
+        RecordChange(description, changeType);
+    }
+
+    /// <summary>
+    /// Sets the global category name and icon.
+    /// </summary>
+    /// <param name="name">Category name.</param>
+    /// <param name="icon">Icon name.</param>
+    public void SetGlobalCategory(string name, string icon = "Cog")
+    {
+        _globalCategoryName = name;
+        _globalCategoryIcon = icon;
+    }
+
+    /// <summary>
+    /// Clears all global changes.
+    /// </summary>
+    public void ClearGlobalChanges()
+    {
+        _globalChanges.Clear();
+        OnChangeStateChanged();
+    }
+
+    /// <summary>
+    /// Clears all changes from all trackers.
+    /// </summary>
+    public void ClearAllChanges()
+    {
+        _globalChanges.Clear();
+        foreach (var tracker in _trackers)
+        {
+            tracker.ClearChanges();
+        }
+        OnChangeStateChanged();
+    }
+
+    /// <summary>
+    /// Gets all change categories with their changes.
+    /// </summary>
+    /// <returns>Collection of change categories.</returns>
+    public IEnumerable<ChangeCategory> GetAllChangeCategories()
+    {
+        var categories = new List<ChangeCategory>();
+
+        // Add global changes if any
+        if (_globalChanges.Count > 0)
+        {
+            var globalCategory = new ChangeCategory
+            {
+                Name = _globalCategoryName,
+                IconName = _globalCategoryIcon,
+                IsExpanded = true
+            };
+            foreach (var change in _globalChanges)
+            {
+                globalCategory.Changes.Add(change);
+            }
+            categories.Add(globalCategory);
+        }
+
+        // Add changes from registered trackers
+        foreach (var tracker in _trackers.Where(t => t.HasChanges))
+        {
+            var category = new ChangeCategory
+            {
+                Name = tracker.CategoryName,
+                IconName = tracker.CategoryIcon,
+                IsExpanded = true
+            };
+            foreach (var change in tracker.GetChanges())
+            {
+                category.Changes.Add(change);
+            }
+            categories.Add(category);
+        }
+
+        return categories;
+    }
+
+    /// <summary>
+    /// Gets the total count of all changes.
+    /// </summary>
+    public int TotalChangeCount
+    {
+        get
+        {
+            var count = _globalChanges.Count;
+            foreach (var tracker in _trackers.Where(t => t.HasChanges))
+            {
+                count += tracker.GetChanges().Count();
+            }
+            return count;
+        }
+    }
+
+    /// <summary>
+    /// Notifies that change state has changed.
+    /// </summary>
+    public void NotifyChangeStateChanged()
+    {
+        OnChangeStateChanged();
+    }
+
+    private void OnChangeStateChanged()
+    {
+        ChangeStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+}
+
+/// <summary>
+/// Simple change tracker for basic scenarios.
+/// </summary>
+public class SimpleChangeTracker : IChangeTracker
+{
+    private readonly List<ChangeItem> _changes = new();
+
+    public string CategoryName { get; set; } = "Changes";
+    public string CategoryIcon { get; set; } = "Folder";
+    public bool HasChanges => _changes.Count > 0;
+
+    public void AddChange(string description, ChangeType changeType = ChangeType.Modified)
+    {
+        _changes.Add(new ChangeItem
+        {
+            Description = description,
+            ChangeType = changeType
+        });
+    }
+
+    public void AddChange(ChangeItem change)
+    {
+        _changes.Add(change);
+    }
+
+    public IEnumerable<ChangeItem> GetChanges() => _changes;
+
+    public void ClearChanges() => _changes.Clear();
+}

--- a/ArgoBooks/ViewModels/MainWindowViewModel.cs
+++ b/ArgoBooks/ViewModels/MainWindowViewModel.cs
@@ -77,6 +77,12 @@ public partial class MainWindowViewModel : ViewModelBase
     private ConfirmationDialogViewModel? _confirmationDialogViewModel;
 
     /// <summary>
+    /// Gets or sets the UnsavedChangesDialogViewModel for showing unsaved changes dialogs.
+    /// </summary>
+    [ObservableProperty]
+    private UnsavedChangesDialogViewModel? _unsavedChangesDialogViewModel;
+
+    /// <summary>
     /// Whether to show the welcome screen (when no company is open).
     /// </summary>
     [ObservableProperty]

--- a/ArgoBooks/ViewModels/UnsavedChangesDialogViewModel.cs
+++ b/ArgoBooks/ViewModels/UnsavedChangesDialogViewModel.cs
@@ -1,0 +1,289 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ArgoBooks.ViewModels;
+
+/// <summary>
+/// Converter that converts a boolean to an angle for rotation animations.
+/// </summary>
+public class BoolToAngleConverter : IValueConverter
+{
+    public double TrueAngle { get; set; } = 90;
+    public double FalseAngle { get; set; } = 0;
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is true ? TrueAngle : FalseAngle;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}
+
+/// <summary>
+/// Converter that converts a ChangeType enum to a boolean for visibility.
+/// </summary>
+public class ChangeTypeToVisibilityConverter : IValueConverter
+{
+    /// <summary>
+    /// Gets or sets the target change type to match.
+    /// </summary>
+    public ChangeType TargetType { get; set; } = ChangeType.Modified;
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is ChangeType changeType && changeType == TargetType;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}
+
+/// <summary>
+/// Represents a single change item in the unsaved changes list.
+/// </summary>
+public class ChangeItem
+{
+    /// <summary>
+    /// Gets or sets the description of what changed.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type of change (Added, Modified, Deleted).
+    /// </summary>
+    public ChangeType ChangeType { get; set; } = ChangeType.Modified;
+
+    /// <summary>
+    /// Gets the icon name based on the change type.
+    /// </summary>
+    public string IconName => ChangeType switch
+    {
+        ChangeType.Added => "Plus",
+        ChangeType.Deleted => "Trash",
+        _ => "Pencil"
+    };
+
+    /// <summary>
+    /// Gets the color class based on the change type.
+    /// </summary>
+    public string ColorClass => ChangeType switch
+    {
+        ChangeType.Added => "success",
+        ChangeType.Deleted => "danger",
+        _ => "warning"
+    };
+}
+
+/// <summary>
+/// Type of change made to an item.
+/// </summary>
+public enum ChangeType
+{
+    Added,
+    Modified,
+    Deleted
+}
+
+/// <summary>
+/// Represents a category of changes (e.g., Customers, Products).
+/// </summary>
+public partial class ChangeCategory : ObservableObject
+{
+    /// <summary>
+    /// Gets or sets the name of the category.
+    /// </summary>
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the icon name for the category.
+    /// </summary>
+    [ObservableProperty]
+    private string _iconName = "Folder";
+
+    /// <summary>
+    /// Gets or sets whether the category is expanded.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isExpanded = true;
+
+    /// <summary>
+    /// Gets the collection of changes in this category.
+    /// </summary>
+    public ObservableCollection<ChangeItem> Changes { get; } = new();
+
+    /// <summary>
+    /// Gets the count of changes in this category.
+    /// </summary>
+    public int ChangeCount => Changes.Count;
+}
+
+/// <summary>
+/// Result of the unsaved changes dialog.
+/// </summary>
+public enum UnsavedChangesResult
+{
+    None,
+    Save,
+    DontSave,
+    Cancel
+}
+
+/// <summary>
+/// ViewModel for the unsaved changes dialog that displays a list of all pending changes.
+/// </summary>
+public partial class UnsavedChangesDialogViewModel : ViewModelBase
+{
+    private TaskCompletionSource<UnsavedChangesResult>? _completionSource;
+
+    [ObservableProperty]
+    private bool _isOpen;
+
+    [ObservableProperty]
+    private string _title = "Unsaved Changes";
+
+    [ObservableProperty]
+    private string _message = "You have unsaved changes. Would you like to save them before closing?";
+
+    [ObservableProperty]
+    private string _saveButtonText = "Save";
+
+    [ObservableProperty]
+    private string _dontSaveButtonText = "Don't Save";
+
+    [ObservableProperty]
+    private string _cancelButtonText = "Cancel";
+
+    /// <summary>
+    /// Gets the collection of change categories.
+    /// </summary>
+    public ObservableCollection<ChangeCategory> Categories { get; } = new();
+
+    /// <summary>
+    /// Gets whether there are any changes to display.
+    /// </summary>
+    public bool HasChanges => Categories.Count > 0 && Categories.Any(c => c.Changes.Count > 0);
+
+    /// <summary>
+    /// Gets the total number of changes across all categories.
+    /// </summary>
+    public int TotalChangeCount => Categories.Sum(c => c.Changes.Count);
+
+    /// <summary>
+    /// Shows the dialog with the specified changes.
+    /// </summary>
+    /// <param name="categories">The change categories to display.</param>
+    /// <param name="title">Optional custom title.</param>
+    /// <param name="message">Optional custom message.</param>
+    /// <returns>The result indicating which button was clicked.</returns>
+    public Task<UnsavedChangesResult> ShowAsync(
+        IEnumerable<ChangeCategory>? categories = null,
+        string? title = null,
+        string? message = null)
+    {
+        // Set custom text if provided
+        if (title != null) Title = title;
+        if (message != null) Message = message;
+
+        // Clear and populate categories
+        Categories.Clear();
+        if (categories != null)
+        {
+            foreach (var category in categories.Where(c => c.Changes.Count > 0))
+            {
+                Categories.Add(category);
+            }
+        }
+
+        OnPropertyChanged(nameof(HasChanges));
+        OnPropertyChanged(nameof(TotalChangeCount));
+
+        IsOpen = true;
+        _completionSource = new TaskCompletionSource<UnsavedChangesResult>();
+        return _completionSource.Task;
+    }
+
+    /// <summary>
+    /// Shows a simple unsaved changes dialog without a detailed list.
+    /// </summary>
+    /// <param name="title">Optional custom title.</param>
+    /// <param name="message">Optional custom message.</param>
+    /// <returns>The result indicating which button was clicked.</returns>
+    public Task<UnsavedChangesResult> ShowSimpleAsync(
+        string? title = null,
+        string? message = null)
+    {
+        return ShowAsync(null, title, message);
+    }
+
+    [RelayCommand]
+    private void Save()
+    {
+        IsOpen = false;
+        _completionSource?.TrySetResult(UnsavedChangesResult.Save);
+    }
+
+    [RelayCommand]
+    private void DontSave()
+    {
+        IsOpen = false;
+        _completionSource?.TrySetResult(UnsavedChangesResult.DontSave);
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        IsOpen = false;
+        _completionSource?.TrySetResult(UnsavedChangesResult.Cancel);
+    }
+
+    /// <summary>
+    /// Closes the dialog without a result (e.g., when clicking backdrop).
+    /// </summary>
+    public void Close()
+    {
+        IsOpen = false;
+        _completionSource?.TrySetResult(UnsavedChangesResult.None);
+    }
+
+    /// <summary>
+    /// Toggles the expanded state of a category.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleCategory(ChangeCategory category)
+    {
+        category.IsExpanded = !category.IsExpanded;
+    }
+
+    /// <summary>
+    /// Expands all categories.
+    /// </summary>
+    [RelayCommand]
+    private void ExpandAll()
+    {
+        foreach (var category in Categories)
+        {
+            category.IsExpanded = true;
+        }
+    }
+
+    /// <summary>
+    /// Collapses all categories.
+    /// </summary>
+    [RelayCommand]
+    private void CollapseAll()
+    {
+        foreach (var category in Categories)
+        {
+            category.IsExpanded = false;
+        }
+    }
+}

--- a/ArgoBooks/Views/MainWindow.axaml
+++ b/ArgoBooks/Views/MainWindow.axaml
@@ -103,8 +103,12 @@
         <modals:CreateCompanyWizard DataContext="{Binding CreateCompanyViewModel}"
                                     ZIndex="200" />
 
-        <!-- Confirmation Dialog (highest level, can appear over any modal) -->
+        <!-- Confirmation Dialog (high level, can appear over any modal) -->
         <modals:ConfirmationDialog DataContext="{Binding ConfirmationDialogViewModel}"
                                    ZIndex="250" />
+
+        <!-- Unsaved Changes Dialog (highest level, critical for data safety) -->
+        <modals:UnsavedChangesDialog DataContext="{Binding UnsavedChangesDialogViewModel}"
+                                     ZIndex="275" />
     </Panel>
 </Window>


### PR DESCRIPTION
Implement a production-ready unsaved changes dialog similar to the WinForms version CustomMessageBox with Save/Don't Save/Cancel buttons and a scrollable list showing all pending changes.

Features:
- UnsavedChangesDialogViewModel with Save/DontSave/Cancel actions
- ChangeItem and ChangeCategory models for organizing changes
- ChangeTrackingService for aggregating changes from multiple sources
- IChangeTracker interface for components to report their changes
- Expandable/collapsible category sections with change counts
- Visual indicators for Added/Modified/Deleted change types
- Keyboard support (Enter=Save, Escape=Cancel)
- Smooth animations for open/close transitions
- Integration with file menu close action

The dialog displays changes grouped by category (e.g., Customers, Products, Settings) with color-coded icons indicating the type of change (green plus for added, orange pencil for modified, red trash for deleted).