### PR TITLE
Fix compilation errors and remove unused code

### DIFF
--- a/ArgoBooks/Converters/CategoriesConverters.cs
+++ b/ArgoBooks/Converters/CategoriesConverters.cs
@@ -49,6 +49,12 @@ public class StringToBrushConverter : IValueConverter
 public static class BoolConverters
 {
     /// <summary>
+    /// Converts bool to one of two strings based on the parameter.
+    /// Parameter format: "TrueValue;FalseValue"
+    /// </summary>
+    public static new readonly IValueConverter ToString = new BoolToStringConverter();
+
+    /// <summary>
     /// Converts bool to "Expenses" (true) or "Revenue" (false).
     /// </summary>
     public static readonly IValueConverter ToExpensesOrRevenue =
@@ -59,24 +65,6 @@ public static class BoolConverters
     /// </summary>
     public static readonly IValueConverter ToExpensesOrRevenueProducts =
         new FuncValueConverter<bool, string>(value => value ? "Expenses" : "Revenue");
-
-    /// <summary>
-    /// Converts bool (isChild) to background color for child rows.
-    /// </summary>
-    public static readonly IValueConverter ToChildRowBackground =
-        new FuncValueConverter<bool, IBrush?>(value =>
-        {
-            if (!value) return null;
-
-            if (Application.Current?.Resources != null &&
-                Application.Current.Resources.TryGetResource("SurfaceAltBrush", Application.Current.ActualThemeVariant, out var resource) &&
-                resource is IBrush brush)
-            {
-                return brush;
-            }
-
-            return new SolidColorBrush(Color.Parse("#F9FAFB"));
-        });
 
     /// <summary>
     /// Converts bool (isChild) to left margin indent for child rows.
@@ -107,29 +95,10 @@ public static class BoolConverters
 public static class IntConverters
 {
     /// <summary>
-    /// Returns true if the integer is greater than zero.
-    /// </summary>
-    public static readonly IValueConverter IsGreaterThanZero =
-        new FuncValueConverter<int, bool>(value => value > 0);
-
-    /// <summary>
     /// Returns true if the integer is zero.
     /// </summary>
     public static readonly IValueConverter IsZero =
         new FuncValueConverter<int, bool>(value => value == 0);
-
-    /// <summary>
-    /// Returns true if the integer is greater than one (for pagination visibility).
-    /// </summary>
-    public static readonly IValueConverter IsGreaterThanOne =
-        new FuncValueConverter<int, bool>(value => value > 1);
-
-    /// <summary>
-    /// Checks if the value equals the current page (for pagination active state).
-    /// This is a placeholder - actual comparison happens differently.
-    /// </summary>
-    public static readonly IValueConverter EqualsCurrentPage =
-        new FuncValueConverter<int, bool>(value => false);
 }
 
 /// <summary>
@@ -372,5 +341,29 @@ public class PageActiveForegroundConverter : IMultiValueConverter
             return brush;
         }
         return new SolidColorBrush(Color.Parse("#374151"));
+    }
+}
+
+/// <summary>
+/// Converter that converts a bool to one of two strings based on the parameter.
+/// Parameter format: "TrueValue;FalseValue"
+/// </summary>
+public class BoolToStringConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not bool boolValue || parameter is not string paramString)
+            return string.Empty;
+
+        var parts = paramString.Split(';');
+        if (parts.Length != 2)
+            return string.Empty;
+
+        return boolValue ? parts[0] : parts[1];
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/ArgoBooks/Modals/CategoryModals.axaml
+++ b/ArgoBooks/Modals/CategoryModals.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
+             xmlns:converters="using:ArgoBooks.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ArgoBooks.Modals.CategoryModals"
              x:DataType="vm:CategoryModalsViewModel">
@@ -20,7 +21,7 @@
                     <Border Grid.Row="0" Padding="24,20" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
                         <Grid ColumnDefinitions="*,Auto">
                             <StackPanel Grid.Column="0">
-                                <TextBlock Text="{Binding IsAddingSubCategory, Converter={x:Static BoolConverters.ToString}, ConverterParameter='Add Sub-Category;Add Category'}"
+                                <TextBlock Text="{Binding IsAddingSubCategory, Converter={x:Static converters:BoolConverters.ToString}, ConverterParameter='Add Sub-Category;Add Category'}"
                                            FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                                 <TextBlock Text="{Binding AddingSubCategoryParentName, StringFormat='Under: {0}'}"
                                            FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}"

--- a/ArgoBooks/Modals/CreateCompanyWizard.axaml
+++ b/ArgoBooks/Modals/CreateCompanyWizard.axaml
@@ -13,8 +13,7 @@
 
     <Panel IsVisible="{Binding IsOpen}">
         <!-- Modal Backdrop with fade animation -->
-        <Border Background="#80000000"
-                PointerPressed="Backdrop_PointerPressed">
+        <Border Background="#80000000">
             <Border.Transitions>
                 <Transitions>
                     <DoubleTransition Property="Opacity" Duration="0:0:0.2" />

--- a/ArgoBooks/Modals/CreateCompanyWizard.axaml.cs
+++ b/ArgoBooks/Modals/CreateCompanyWizard.axaml.cs
@@ -58,14 +58,6 @@ public partial class CreateCompanyWizard : UserControl
         }
     }
 
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is CreateCompanyViewModel vm)
-        {
-            vm.CloseCommand.Execute(null);
-        }
-    }
-
     private void Wizard_KeyDown(object? sender, KeyEventArgs e)
     {
         if (DataContext is not CreateCompanyViewModel vm) return;

--- a/ArgoBooks/Modals/ExportAsModal.axaml
+++ b/ArgoBooks/Modals/ExportAsModal.axaml
@@ -13,8 +13,7 @@
 
     <Panel IsVisible="{Binding IsOpen}">
         <!-- Modal Backdrop -->
-        <Border Background="#80000000"
-                PointerPressed="Backdrop_PointerPressed">
+        <Border Background="#80000000">
             <Border.Transitions>
                 <Transitions>
                     <DoubleTransition Property="Opacity" Duration="0:0:0.2" />

--- a/ArgoBooks/Modals/ExportAsModal.axaml.cs
+++ b/ArgoBooks/Modals/ExportAsModal.axaml.cs
@@ -37,14 +37,6 @@ public partial class ExportAsModal : UserControl
         }
     }
 
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is ExportAsModalViewModel vm)
-        {
-            vm.CloseCommand.Execute(null);
-        }
-    }
-
     private void Modal_KeyDown(object? sender, KeyEventArgs e)
     {
         if (e.Key == Key.Escape && DataContext is ExportAsModalViewModel vm)

--- a/ArgoBooks/Modals/ImportModal.axaml
+++ b/ArgoBooks/Modals/ImportModal.axaml
@@ -13,8 +13,7 @@
 
     <Panel IsVisible="{Binding IsOpen}">
         <!-- Modal Backdrop -->
-        <Border Background="#80000000"
-                PointerPressed="Backdrop_PointerPressed">
+        <Border Background="#80000000">
             <Border.Transitions>
                 <Transitions>
                     <DoubleTransition Property="Opacity" Duration="0:0:0.2" />

--- a/ArgoBooks/Modals/ImportModal.axaml.cs
+++ b/ArgoBooks/Modals/ImportModal.axaml.cs
@@ -37,14 +37,6 @@ public partial class ImportModal : UserControl
         }
     }
 
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is ImportModalViewModel vm)
-        {
-            vm.CloseCommand.Execute(null);
-        }
-    }
-
     private void Modal_KeyDown(object? sender, KeyEventArgs e)
     {
         if (e.Key == Key.Escape && DataContext is ImportModalViewModel vm)

--- a/ArgoBooks/Modals/ProfileModal.axaml
+++ b/ArgoBooks/Modals/ProfileModal.axaml
@@ -13,8 +13,7 @@
 
     <Panel IsVisible="{Binding IsOpen}">
         <!-- Modal Backdrop with fade animation -->
-        <Border Background="#80000000"
-                PointerPressed="Backdrop_PointerPressed">
+        <Border Background="#80000000">
             <Border.Transitions>
                 <Transitions>
                     <DoubleTransition Property="Opacity" Duration="0:0:0.2" />

--- a/ArgoBooks/Modals/ProfileModal.axaml.cs
+++ b/ArgoBooks/Modals/ProfileModal.axaml.cs
@@ -51,17 +51,6 @@ public partial class ProfileModal : UserControl
     }
 
     /// <summary>
-    /// Closes the modal when clicking on the backdrop.
-    /// </summary>
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is ProfileModalViewModel vm)
-        {
-            vm.CloseCommand.Execute(null);
-        }
-    }
-
-    /// <summary>
     /// Handles keyboard input for the modal.
     /// </summary>
     private void Modal_KeyDown(object? sender, KeyEventArgs e)

--- a/ArgoBooks/Modals/SettingsModal.axaml
+++ b/ArgoBooks/Modals/SettingsModal.axaml
@@ -14,8 +14,7 @@
 
     <Panel IsVisible="{Binding IsOpen}">
         <!-- Modal Backdrop -->
-        <Border Background="#80000000"
-                PointerPressed="Backdrop_PointerPressed">
+        <Border Background="#80000000">
             <Border.Transitions>
                 <Transitions>
                     <DoubleTransition Property="Opacity" Duration="0:0:0.2" />
@@ -625,7 +624,7 @@
 
         <!-- Add Password Modal -->
         <Panel IsVisible="{Binding IsAddPasswordModalOpen}">
-            <Border Background="#80000000" PointerPressed="PasswordBackdrop_PointerPressed" />
+            <Border Background="#80000000" />
             <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
                     BorderThickness="1"
@@ -694,7 +693,7 @@
 
         <!-- Change Password Modal -->
         <Panel IsVisible="{Binding IsChangePasswordModalOpen}">
-            <Border Background="#80000000" PointerPressed="PasswordBackdrop_PointerPressed" />
+            <Border Background="#80000000" />
             <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
                     BorderThickness="1"
@@ -781,7 +780,7 @@
 
         <!-- Remove Password Modal -->
         <Panel IsVisible="{Binding IsRemovePasswordModalOpen}">
-            <Border Background="#80000000" PointerPressed="PasswordBackdrop_PointerPressed" />
+            <Border Background="#80000000" />
             <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
                     BorderThickness="1"

--- a/ArgoBooks/Modals/SettingsModal.axaml.cs
+++ b/ArgoBooks/Modals/SettingsModal.axaml.cs
@@ -85,22 +85,6 @@ public partial class SettingsModal : UserControl
         }, DispatcherPriority.Background);
     }
 
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is SettingsModalViewModel vm)
-        {
-            vm.CloseCommand.Execute(null);
-        }
-    }
-
-    private void PasswordBackdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is SettingsModalViewModel vm)
-        {
-            vm.ClosePasswordModalCommand.Execute(null);
-        }
-    }
-
     private void Modal_KeyDown(object? sender, KeyEventArgs e)
     {
         if (e.Key == Key.Escape && DataContext is SettingsModalViewModel vm)

--- a/ArgoBooks/Modals/SwitchAccountModal.axaml
+++ b/ArgoBooks/Modals/SwitchAccountModal.axaml
@@ -13,8 +13,7 @@
 
     <Panel IsVisible="{Binding IsOpen}">
         <!-- Modal Backdrop -->
-        <Border Background="#80000000"
-                PointerPressed="Backdrop_PointerPressed">
+        <Border Background="#80000000">
             <Border.Transitions>
                 <Transitions>
                     <DoubleTransition Property="Opacity" Duration="0:0:0.2" />

--- a/ArgoBooks/Modals/SwitchAccountModal.axaml.cs
+++ b/ArgoBooks/Modals/SwitchAccountModal.axaml.cs
@@ -51,17 +51,6 @@ public partial class SwitchAccountModal : UserControl
     }
 
     /// <summary>
-    /// Closes the modal when clicking on the backdrop.
-    /// </summary>
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is SwitchAccountModalViewModel vm)
-        {
-            vm.CloseCommand.Execute(null);
-        }
-    }
-
-    /// <summary>
     /// Handles keyboard input for the modal.
     /// </summary>
     private void Modal_KeyDown(object? sender, KeyEventArgs e)

--- a/ArgoBooks/Modals/UpgradeModal.axaml
+++ b/ArgoBooks/Modals/UpgradeModal.axaml
@@ -15,8 +15,7 @@
         <!-- Upgrade Modal -->
         <Panel IsVisible="{Binding IsOpen}">
             <!-- Backdrop with fade animation -->
-            <Border Background="#80000000"
-                    PointerPressed="Backdrop_PointerPressed">
+            <Border Background="#80000000">
                 <Border.Transitions>
                     <Transitions>
                         <DoubleTransition Property="Opacity" Duration="0:0:0.2" />
@@ -271,8 +270,7 @@
 
         <!-- Enter Key Modal -->
         <Panel IsVisible="{Binding IsEnterKeyModalOpen}">
-            <Border Background="#80000000"
-                    PointerPressed="EnterKeyBackdrop_PointerPressed" />
+            <Border Background="#80000000" />
 
             <Border x:Name="EnterKeyModalBorder"
                     Background="{DynamicResource SurfaceBrush}"

--- a/ArgoBooks/Modals/UpgradeModal.axaml.cs
+++ b/ArgoBooks/Modals/UpgradeModal.axaml.cs
@@ -225,22 +225,6 @@ public partial class UpgradeModal : UserControl
         });
     }
 
-    private void Backdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is UpgradeModalViewModel vm)
-        {
-            vm.CloseCommand.Execute(null);
-        }
-    }
-
-    private void EnterKeyBackdrop_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (DataContext is UpgradeModalViewModel vm)
-        {
-            vm.CloseEnterKeyCommand.Execute(null);
-        }
-    }
-
     private bool _isFormatting;
 
     private void LicenseKeyTextBox_TextChanged(object? sender, TextChangedEventArgs e)

--- a/ArgoBooks/Services/ModalService.cs
+++ b/ArgoBooks/Services/ModalService.cs
@@ -24,7 +24,6 @@ public class ModalService : IModalService
         if (_overlay != null)
         {
             _overlay.Closed -= OnOverlayClosed;
-            _overlay.Closing -= OnOverlayClosing;
         }
 
         _overlay = overlay;
@@ -32,7 +31,6 @@ public class ModalService : IModalService
         if (_overlay != null)
         {
             _overlay.Closed += OnOverlayClosed;
-            _overlay.Closing += OnOverlayClosing;
         }
     }
 
@@ -207,11 +205,6 @@ public class ModalService : IModalService
         // If modal was closed externally (backdrop click, escape), set result
         _resultTcs?.TrySetResult(ModalResult.Cancel);
         _valueResultTcs?.TrySetResult(null);
-    }
-
-    private void OnOverlayClosing(object? sender, ModalClosingEventArgs e)
-    {
-        // Can be used to prevent closing in certain cases
     }
 
     private static ModalSize ParseSize(string size)

--- a/ArgoBooks/ViewModels/DepartmentModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/DepartmentModalsViewModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.ObjectModel;
-using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -90,7 +89,6 @@ public partial class DepartmentModalsViewModel : ObservableObject
             Id = newId,
             Name = ModalDepartmentName.Trim(),
             Description = string.IsNullOrWhiteSpace(ModalDescription) ? null : ModalDescription.Trim(),
-            Status = EntityStatus.Active,
             CreatedAt = DateTime.UtcNow
         };
 

--- a/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
-using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models;
+using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -147,7 +147,6 @@ public partial class SupplierModalsViewModel : ObservableObject
                 Country = string.IsNullOrWhiteSpace(ModalCountry) ? string.Empty : ModalCountry.Trim()
             },
             Notes = string.IsNullOrWhiteSpace(ModalNotes) ? string.Empty : ModalNotes.Trim(),
-            Status = EntityStatus.Active,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         };
@@ -182,7 +181,7 @@ public partial class SupplierModalsViewModel : ObservableObject
         ModalSupplierName = supplier.Name;
         ModalEmail = supplier.Email;
         ModalPhone = supplier.Phone;
-        ModalWebsite = supplier.Website;
+        ModalWebsite = supplier.Website ?? string.Empty;
         ModalStreetAddress = supplier.Address.Street;
         ModalCity = supplier.Address.City;
         ModalStateProvince = supplier.Address.State;


### PR DESCRIPTION
Compilation fixes:
- Add missing ArgoBooks.Core.Models.Common using for Address type
- Remove invalid Status property from Supplier and Department creation
- Fix nullable string assignment for supplier.Website
- Add BoolToStringConverter for parameterized bool-to-string conversion
- Add converters namespace to CategoryModals.axaml

Code cleanup:
- Remove unused converters: ToChildRowBackground, IsGreaterThanZero, IsGreaterThanOne, EqualsCurrentPage
- Remove empty OnOverlayClosing() method from ModalService

UX improvement:
- Remove backdrop click-to-close from all modals (Settings, Export, Import, Profile, CreateCompany, SwitchAccount, UpgradeModal)
- Users must now use close button or Escape key to close modals