### PR TITLE
Only show sidebar tooltips when collapsed

### DIFF
--- a/ArgoBooks/Controls/SidebarItem.axaml
+++ b/ArgoBooks/Controls/SidebarItem.axaml
@@ -13,7 +13,7 @@
             Classes.collapsed="{Binding IsCollapsed, RelativeSource={RelativeSource AncestorType=controls:SidebarItem}}"
             Command="{Binding Command, RelativeSource={RelativeSource AncestorType=controls:SidebarItem}}"
             CommandParameter="{Binding CommandParameter, RelativeSource={RelativeSource AncestorType=controls:SidebarItem}}"
-            ToolTip.Tip="{Binding TooltipText, RelativeSource={RelativeSource AncestorType=controls:SidebarItem}}"
+            ToolTip.Tip="{Binding EffectiveTooltipText, RelativeSource={RelativeSource AncestorType=controls:SidebarItem}}"
             HorizontalAlignment="Stretch">
         <Grid ColumnDefinitions="Auto,*,Auto">
             <!-- Icon -->

--- a/ArgoBooks/Controls/SidebarItem.axaml.cs
+++ b/ArgoBooks/Controls/SidebarItem.axaml.cs
@@ -45,6 +45,11 @@ public partial class SidebarItem : UserControl
     public static readonly StyledProperty<string?> PageNameProperty =
         AvaloniaProperty.Register<SidebarItem, string?>(nameof(PageName));
 
+    public static readonly DirectProperty<SidebarItem, string?> EffectiveTooltipTextProperty =
+        AvaloniaProperty.RegisterDirect<SidebarItem, string?>(
+            nameof(EffectiveTooltipText),
+            o => o.EffectiveTooltipText);
+
     #endregion
 
     #region Properties
@@ -148,6 +153,11 @@ public partial class SidebarItem : UserControl
         set => SetValue(PageNameProperty, value);
     }
 
+    /// <summary>
+    /// Gets the effective tooltip text (only shown when sidebar is collapsed).
+    /// </summary>
+    public string? EffectiveTooltipText => IsCollapsed ? TooltipText : null;
+
     #endregion
 
     public SidebarItem()
@@ -182,6 +192,12 @@ public partial class SidebarItem : UserControl
             {
                 // Invalid path data - ignore
             }
+        }
+
+        // Update EffectiveTooltipText when IsCollapsed or TooltipText changes
+        if (change.Property == IsCollapsedProperty || change.Property == TooltipTextProperty)
+        {
+            RaisePropertyChanged(EffectiveTooltipTextProperty, null, EffectiveTooltipText);
         }
     }
 }


### PR DESCRIPTION
Add EffectiveTooltipText computed property that returns the tooltip text only when IsCollapsed is true, and null otherwise. This ensures tooltips only appear when the sidebar is collapsed and text labels are hidden.