### PR TITLE
Add PixiEditor ColorPicker and UI improvements

### DIFF
--- a/ArgoBooks/App.axaml
+++ b/ArgoBooks/App.axaml
@@ -1,6 +1,7 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:ArgoBooks"
+             xmlns:colorPickerThemes="clr-namespace:ColorPicker.AvaloniaUI.Templates;assembly=ColorPicker.AvaloniaUI"
              x:Class="ArgoBooks.App"
              RequestedThemeVariant="Default">
     <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
@@ -11,6 +12,7 @@
 
     <Application.Styles>
         <FluentTheme />
+        <colorPickerThemes:SimpleColorPickerTheme />
 
         <!-- Argo Books Styles -->
         <StyleInclude Source="avares://ArgoBooks/Styles/BaseStyles.axaml" />

--- a/ArgoBooks/ArgoBooks.csproj
+++ b/ArgoBooks/ArgoBooks.csproj
@@ -31,6 +31,9 @@
 
         <!-- Charts -->
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" />
+
+        <!-- Color Picker -->
+        <PackageReference Include="PixiEditor.ColorPicker.AvaloniaUI" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ArgoBooks/Controls/ColorPickerInput.axaml
+++ b/ArgoBooks/Controls/ColorPickerInput.axaml
@@ -3,9 +3,51 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:colorPicker="clr-namespace:ColorPicker;assembly=ColorPicker.AvaloniaUI"
              mc:Ignorable="d" d:DesignWidth="200" d:DesignHeight="32"
              x:Class="ArgoBooks.Controls.ColorPickerInput"
              x:Name="Root">
+
+    <UserControl.Styles>
+        <!-- Hide the H and S sliders in the color picker -->
+        <Style Selector="colorPicker|StandardColorPicker colorPicker|ColorSliders">
+            <Setter Property="IsVisible" Value="False" />
+            <Setter Property="Height" Value="0" />
+        </Style>
+        <!-- Hide the HSV/HSL/RGB color display section -->
+        <Style Selector="colorPicker|StandardColorPicker colorPicker|ColorDisplay">
+            <Setter Property="IsVisible" Value="False" />
+            <Setter Property="Height" Value="0" />
+        </Style>
+        <!-- Hide the Hex input row inside the picker -->
+        <Style Selector="colorPicker|StandardColorPicker colorPicker|HexColorTextBox">
+            <Setter Property="IsVisible" Value="False" />
+            <Setter Property="Height" Value="0" />
+        </Style>
+        <!-- Hide any ComboBox (HSV/HSL selector) inside the picker -->
+        <Style Selector="colorPicker|StandardColorPicker ComboBox">
+            <Setter Property="IsVisible" Value="False" />
+            <Setter Property="Height" Value="0" />
+        </Style>
+        <!-- Hide ALL text blocks including the "Hex" label -->
+        <Style Selector="colorPicker|StandardColorPicker TextBlock">
+            <Setter Property="IsVisible" Value="False" />
+            <Setter Property="Height" Value="0" />
+        </Style>
+        <Style Selector="colorPicker|StandardColorPicker Label">
+            <Setter Property="IsVisible" Value="False" />
+            <Setter Property="Height" Value="0" />
+        </Style>
+        <!-- Hide the entire hex row - it's likely in a container -->
+        <Style Selector="colorPicker|StandardColorPicker StackPanel">
+            <Setter Property="IsVisible" Value="False" />
+            <Setter Property="Height" Value="0" />
+        </Style>
+        <!-- Only show the SquarePicker (main color selection area) -->
+        <Style Selector="colorPicker|StandardColorPicker colorPicker|SquarePicker">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+    </UserControl.Styles>
 
     <Grid ColumnDefinitions="Auto,*">
         <!-- Color Swatch Button -->
@@ -43,32 +85,34 @@
                     CornerRadius="8"
                     Padding="12"
                     BoxShadow="0 4 16 0 #22000000">
-                <StackPanel Spacing="12" Width="300">
-                    <!-- Color View (inline color editing surface) -->
-                    <ColorView Color="{Binding #Root.SelectedColor, Mode=TwoWay}"
-                               HorizontalAlignment="Center"
-                               IsColorSpectrumVisible="True"
-                               IsColorPreviewVisible="False"
-                               IsColorPaletteVisible="False"
-                               IsColorComponentsVisible="False" />
+                <StackPanel Spacing="12">
+                    <!-- PixiEditor Standard Color Picker - clip to hide the hex row at bottom -->
+                    <Border ClipToBounds="True" Height="150">
+                        <colorPicker:StandardColorPicker x:Name="ColorPickerControl"
+                                                         Width="220" Height="280"
+                                                         Margin="0,125,0,0"
+                                                         ColorChanged="OnColorPickerColorChanged" />
+                    </Border>
 
-                    <!-- Preview and Hex -->
-                    <Grid ColumnDefinitions="Auto,*" Margin="0,8,0,0">
-                        <Border Grid.Column="0" Width="40" Height="40" CornerRadius="4"
+                    <!-- Preview and Hex Input Row -->
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <Border Grid.Column="0" Width="36" Height="36" CornerRadius="4"
                                 Background="{Binding #Root.ColorBrush}"
                                 BorderBrush="{DynamicResource BorderBrush}"
-                                BorderThickness="1"
-                                Margin="0,0,12,0" />
+                                BorderThickness="1" />
                         <TextBox Grid.Column="1"
                                  Text="{Binding #Root.ColorValue, Mode=TwoWay}"
-                                 VerticalAlignment="Center" />
+                                 VerticalAlignment="Center"
+                                 Margin="8,0"
+                                 FontFamily="Consolas,Menlo,monospace"
+                                 FontSize="13"
+                                 Padding="6,4" />
+                        <Button Grid.Column="2"
+                                Content="Apply"
+                                Classes="primary"
+                                MinWidth="60"
+                                Command="{Binding #Root.ApplyColorCommand}" />
                     </Grid>
-
-                    <!-- Apply Button -->
-                    <Button Content="Apply"
-                            HorizontalAlignment="Stretch"
-                            Classes="primary"
-                            Command="{Binding #Root.ApplyColorCommand}" />
                 </StackPanel>
             </Border>
         </Popup>

--- a/ArgoBooks/Styles/BaseStyles.axaml
+++ b/ArgoBooks/Styles/BaseStyles.axaml
@@ -146,16 +146,15 @@
         <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
         <Setter Property="MinHeight" Value="32" />
     </Style>
-    <Style Selector="NumericUpDown /template/ ButtonSpinner">
-        <Setter Property="MinWidth" Value="0" />
+    <Style Selector="NumericUpDown /template/ ButtonSpinner /template/ RepeatButton#PART_IncreaseButton">
+        <Setter Property="MinWidth" Value="16" />
+        <Setter Property="Width" Value="16" />
+        <Setter Property="Padding" Value="0" />
     </Style>
-    <Style Selector="NumericUpDown /template/ ButtonSpinner /template/ Border#BorderElement">
-        <Setter Property="MinWidth" Value="0" />
-    </Style>
-    <Style Selector="NumericUpDown /template/ ButtonSpinner /template/ RepeatButton">
-        <Setter Property="MinWidth" Value="20" />
-        <Setter Property="Width" Value="20" />
-        <Setter Property="Padding" Value="2" />
+    <Style Selector="NumericUpDown /template/ ButtonSpinner /template/ RepeatButton#PART_DecreaseButton">
+        <Setter Property="MinWidth" Value="16" />
+        <Setter Property="Width" Value="16" />
+        <Setter Property="Padding" Value="0" />
     </Style>
     <Style Selector="NumericUpDown /template/ TextBox">
         <Setter Property="MinWidth" Value="40" />

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -1675,7 +1675,7 @@
             <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
         </Style>
 
-        <!-- NumericUpDown Styling -->
+        <!-- NumericUpDown Styling - hide spinner buttons, just show text input -->
         <Style Selector="NumericUpDown">
             <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
             <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
@@ -1685,21 +1685,10 @@
             <Setter Property="MinHeight" Value="32" />
             <Setter Property="Padding" Value="8,4" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="ShowButtonSpinner" Value="False" />
         </Style>
         <Style Selector="NumericUpDown:focus /template/ Border#PART_BorderElement">
             <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
-        </Style>
-        <Style Selector="NumericUpDown /template/ ButtonSpinner">
-            <Setter Property="Height" Value="30" />
-        </Style>
-        <Style Selector="NumericUpDown /template/ RepeatButton">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
-            <Setter Property="Width" Value="18" />
-            <Setter Property="MinWidth" Value="18" />
-        </Style>
-        <Style Selector="NumericUpDown /template/ RepeatButton:pointerover">
-            <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
         </Style>
     </UserControl.Styles>
 </UserControl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,9 @@
         <!-- Charts -->
         <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc3.3" />
 
+        <!-- Color Picker -->
+        <PackageVersion Include="PixiEditor.ColorPicker.AvaloniaUI" Version="1.0.7" />
+
         <!-- Graphics (for report rendering) -->
         <PackageVersion Include="SkiaSharp" Version="3.116.1" />
 


### PR DESCRIPTION
- Replace Avalonia ColorView with PixiEditor StandardColorPicker
- Hide NumericUpDown spinner buttons with ShowButtonSpinner="False"
- Fix elements not rendering on first template selection
- Fix image element opacity to apply to entire element including background
- Fix table row heights using HeaderRowHeight and DataRowHeight properties
- Add null check in AddElementControl for canvas readiness