### PR TITLE
Fix license key persistence using stable machine identifiers

### DIFF
--- a/ArgoBooks.Core/Platform/BasePlatformService.cs
+++ b/ArgoBooks.Core/Platform/BasePlatformService.cs
@@ -79,6 +79,14 @@ public abstract class BasePlatformService : IPlatformService
         return Path.Combine(paths);
     }
 
+    /// <inheritdoc />
+    public virtual string GetMachineId()
+    {
+        // Fallback implementation using machine name
+        // Platform-specific implementations should override this with more stable identifiers
+        return Environment.MachineName;
+    }
+
     /// <summary>
     /// Gets the application name used in paths.
     /// </summary>

--- a/ArgoBooks.Core/Platform/IPlatformService.cs
+++ b/ArgoBooks.Core/Platform/IPlatformService.cs
@@ -84,6 +84,20 @@ public interface IPlatformService
     /// <param name="paths">Path segments to combine.</param>
     /// <returns>Combined path.</returns>
     string CombinePaths(params string[] paths);
+
+    /// <summary>
+    /// Gets a stable, unique identifier for this machine.
+    /// Used for machine-binding features like license encryption.
+    /// </summary>
+    /// <remarks>
+    /// Platform implementations:
+    /// - Windows: Uses MachineGuid from registry
+    /// - Linux: Uses /etc/machine-id
+    /// - macOS: Uses IOPlatformUUID
+    /// - Browser: Uses a stored random ID
+    /// </remarks>
+    /// <returns>A stable machine identifier string.</returns>
+    string GetMachineId();
 }
 
 /// <summary>

--- a/ArgoBooks.Core/Platform/LinuxPlatformService.cs
+++ b/ArgoBooks.Core/Platform/LinuxPlatformService.cs
@@ -75,4 +75,46 @@ public class LinuxPlatformService : BasePlatformService
 
     /// <inheritdoc />
     public override bool SupportsAutoUpdate => true; // AppImage/Flatpak can auto-update
+
+    /// <inheritdoc />
+    public override string GetMachineId()
+    {
+        // Try /etc/machine-id first (systemd standard)
+        try
+        {
+            const string machineIdPath = "/etc/machine-id";
+            if (File.Exists(machineIdPath))
+            {
+                var machineId = File.ReadAllText(machineIdPath).Trim();
+                if (!string.IsNullOrEmpty(machineId))
+                {
+                    return machineId;
+                }
+            }
+        }
+        catch
+        {
+            // File read failed
+        }
+
+        // Try /var/lib/dbus/machine-id (older systems)
+        try
+        {
+            const string dbusMachineIdPath = "/var/lib/dbus/machine-id";
+            if (File.Exists(dbusMachineIdPath))
+            {
+                var machineId = File.ReadAllText(dbusMachineIdPath).Trim();
+                if (!string.IsNullOrEmpty(machineId))
+                {
+                    return machineId;
+                }
+            }
+        }
+        catch
+        {
+            // File read failed
+        }
+
+        return base.GetMachineId();
+    }
 }

--- a/ArgoBooks.Core/Platform/MacPlatformService.cs
+++ b/ArgoBooks.Core/Platform/MacPlatformService.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace ArgoBooks.Core.Platform;
 
 /// <summary>
@@ -50,4 +52,53 @@ public class MacPlatformService : BasePlatformService
 
     /// <inheritdoc />
     public override bool SupportsAutoUpdate => true;
+
+    /// <inheritdoc />
+    public override string GetMachineId()
+    {
+        try
+        {
+            // Use ioreg to get the hardware UUID (IOPlatformUUID)
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo
+            {
+                FileName = "/usr/sbin/ioreg",
+                Arguments = "-rd1 -c IOPlatformExpertDevice",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            };
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(5000); // 5 second timeout
+
+            // Parse the IOPlatformUUID from the output
+            // Format: "IOPlatformUUID" = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+            const string uuidKey = "\"IOPlatformUUID\"";
+            var keyIndex = output.IndexOf(uuidKey, StringComparison.Ordinal);
+            if (keyIndex >= 0)
+            {
+                var startQuote = output.IndexOf('"', keyIndex + uuidKey.Length + 1);
+                if (startQuote >= 0)
+                {
+                    var endQuote = output.IndexOf('"', startQuote + 1);
+                    if (endQuote > startQuote)
+                    {
+                        var uuid = output.Substring(startQuote + 1, endQuote - startQuote - 1);
+                        if (!string.IsNullOrEmpty(uuid))
+                        {
+                            return uuid;
+                        }
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Process execution failed
+        }
+
+        return base.GetMachineId();
+    }
 }

--- a/ArgoBooks.Core/Platform/WindowsPlatformService.cs
+++ b/ArgoBooks.Core/Platform/WindowsPlatformService.cs
@@ -1,3 +1,5 @@
+using Microsoft.Win32;
+
 namespace ArgoBooks.Core.Platform;
 
 /// <summary>
@@ -46,5 +48,26 @@ public class WindowsPlatformService : BasePlatformService
         }
 
         return normalized;
+    }
+
+    /// <inheritdoc />
+    public override string GetMachineId()
+    {
+        try
+        {
+            // Use Windows Cryptography MachineGuid - stable across reboots and network changes
+            using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Cryptography");
+            var machineGuid = key?.GetValue("MachineGuid") as string;
+            if (!string.IsNullOrEmpty(machineGuid))
+            {
+                return machineGuid;
+            }
+        }
+        catch
+        {
+            // Registry access failed, fall back to base implementation
+        }
+
+        return base.GetMachineId();
     }
 }

--- a/ArgoBooks.Tests/Services/LicenseServiceTests.cs
+++ b/ArgoBooks.Tests/Services/LicenseServiceTests.cs
@@ -1,4 +1,5 @@
 using ArgoBooks.Core.Models;
+using ArgoBooks.Core.Platform;
 using ArgoBooks.Core.Services;
 using Xunit;
 
@@ -11,13 +12,15 @@ public class LicenseServiceTests
 {
     private readonly MockEncryptionService _encryptionService;
     private readonly MockGlobalSettingsService _settingsService;
+    private readonly MockPlatformService _platformService;
     private readonly LicenseService _licenseService;
 
     public LicenseServiceTests()
     {
         _encryptionService = new MockEncryptionService();
         _settingsService = new MockGlobalSettingsService();
-        _licenseService = new LicenseService(_encryptionService, _settingsService);
+        _platformService = new MockPlatformService();
+        _licenseService = new LicenseService(_encryptionService, _settingsService, _platformService);
     }
 
     #region Constructor Tests
@@ -26,14 +29,21 @@ public class LicenseServiceTests
     public void Constructor_NullEncryptionService_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new LicenseService(null!, _settingsService));
+            new LicenseService(null!, _settingsService, _platformService));
     }
 
     [Fact]
     public void Constructor_NullSettingsService_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new LicenseService(_encryptionService, null!));
+            new LicenseService(_encryptionService, null!, _platformService));
+    }
+
+    [Fact]
+    public void Constructor_NullPlatformService_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new LicenseService(_encryptionService, _settingsService, null!));
     }
 
     #endregion
@@ -347,6 +357,30 @@ public class LicenseServiceTests
         {
             _settings.License = new LicenseSettings();
         }
+    }
+
+    private class MockPlatformService : IPlatformService
+    {
+        public PlatformType Platform => PlatformType.Windows;
+        public bool SupportsFileSystem => true;
+        public bool SupportsNativeDialogs => true;
+        public bool SupportsBiometrics => false;
+        public bool SupportsAutoUpdate => true;
+        public int MaxRecentCompanies => 10;
+
+        public string GetAppDataPath() => "/mock/appdata";
+        public string GetTempPath() => "/mock/temp";
+        public string GetDefaultDocumentsPath() => "/mock/documents";
+        public string GetLogsPath() => "/mock/logs";
+        public string GetCachePath() => "/mock/cache";
+        public string NormalizePath(string path) => path;
+        public string CombinePaths(params string[] paths) => string.Join("/", paths);
+        public void EnsureDirectoryExists(string path) { }
+
+        /// <summary>
+        /// Returns a stable mock machine ID for testing.
+        /// </summary>
+        public string GetMachineId() => "MOCK-MACHINE-ID-12345";
     }
 
     #endregion


### PR DESCRIPTION
The license key was forgotten after restarting the PC because the encryption key was based on MAC addresses from network adapters. These can change when VPN software, Docker, or USB adapters modify the network configuration.