### PR TITLE
Fix zoom-to-cursor in report page

### DIFF
--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -213,9 +213,8 @@ public partial class SkiaReportDesignCanvas : UserControl
             _canvasImage.PointerReleased += OnCanvasPointerReleased;
         }
 
-        // Wire up pointer wheel for zoom-to-cursor
-        // Use AddHandler with handledEventsToo to intercept events that ScrollViewer handles
-        _scrollViewer?.AddHandler(PointerWheelChangedEvent, OnPointerWheelChanged, Avalonia.Interactivity.RoutingStrategies.Bubble, handledEventsToo: true);
+        // Wire up pointer wheel for zoom-to-cursor (only fires when not already handled by parent)
+        _scrollViewer?.AddHandler(PointerWheelChangedEvent, OnPointerWheelChanged, Avalonia.Interactivity.RoutingStrategies.Bubble);
 
         // Wire up keyboard events
         KeyDown += OnKeyDown;
@@ -646,10 +645,6 @@ public partial class SkiaReportDesignCanvas : UserControl
         var canvasX = (mousePosInContent.X - margin) / oldZoom;
         var canvasY = (mousePosInContent.Y - margin) / oldZoom;
 
-        Console.WriteLine($"[Zoom] MouseInViewport: ({mousePosInViewport.X:F1}, {mousePosInViewport.Y:F1}), CenteringOffset: ({centeringOffsetX:F1}, {centeringOffsetY:F1})");
-        Console.WriteLine($"[Zoom] MouseInContent: ({mousePosInContent.X:F1}, {mousePosInContent.Y:F1}), CanvasCoord: ({canvasX:F1}, {canvasY:F1})");
-        Console.WriteLine($"[Zoom] OldZoom: {oldZoom:F2} -> NewZoom: {newZoom:F2}");
-
         // Apply the new zoom level
         ZoomLevel = newZoom;
 
@@ -681,7 +676,6 @@ public partial class SkiaReportDesignCanvas : UserControl
             // If content will be centered after zoom, no scroll adjustment needed
             if (newExtentWidth <= newViewportWidth && newExtentHeight <= newViewportHeight)
             {
-                Console.WriteLine("[Zoom] Content fits in viewport, no scroll adjustment needed");
                 return;
             }
 
@@ -696,8 +690,6 @@ public partial class SkiaReportDesignCanvas : UserControl
 
             newScrollX = Math.Clamp(newScrollX, 0, maxScrollX);
             newScrollY = Math.Clamp(newScrollY, 0, maxScrollY);
-
-            Console.WriteLine($"[Zoom] NewScroll: ({newScrollX:F1}, {newScrollY:F1}), MaxScroll: ({maxScrollX:F1}, {maxScrollY:F1})");
 
             _scrollViewer.Offset = new Vector(newScrollX, newScrollY);
         }, DispatcherPriority.Render);

--- a/ArgoBooks/Views/ReportsPage.axaml.cs
+++ b/ArgoBooks/Views/ReportsPage.axaml.cs
@@ -379,11 +379,11 @@ public partial class ReportsPage : UserControl
         if (_designCanvas != null && DataContext is ReportsPageViewModel vm)
         {
             var scrollViewer = _designCanvas.FindControl<ScrollViewer>("CanvasScrollViewer");
-            var zoomContainer = _designCanvas.FindControl<Border>("ZoomContainer");
+            var zoomTransformControl = _designCanvas.FindControl<LayoutTransformControl>("ZoomTransformControl");
 
-            if (scrollViewer != null && zoomContainer != null)
+            if (scrollViewer != null && zoomTransformControl != null)
             {
-                CanvasZoomAtPoint(e.Delta.Y > 0, e.GetPosition(scrollViewer), e.GetPosition(zoomContainer), scrollViewer, vm);
+                CanvasZoomAtPoint(e.Delta.Y > 0, e.GetPosition(scrollViewer), e.GetPosition(zoomTransformControl), scrollViewer, vm);
             }
             else
             {


### PR DESCRIPTION
Two issues were causing zoom to always center on the top-left:

1. ReportsPage.OnCanvasPointerWheelChanged was getting mouse position relative to ZoomContainer (Border inside LayoutTransformControl) instead of ZoomTransformControl itself. This gave coordinates in the wrong coordinate space for the zoom calculation.

2. SkiaReportDesignCanvas had its own wheel handler with handledEventsToo:true, causing both handlers to fire and conflict when setting the scroll offset.

Changes:
- Use ZoomTransformControl instead of ZoomContainer in ReportsPage
- Remove handledEventsToo so canvas handler only fires standalone
- Remove debug Console.WriteLine statements from zoom code