### PR TITLE
Protect sample company from being modified

### DIFF
--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -50,6 +50,13 @@ public class CompanyManager : IDisposable
     public bool IsEncrypted => !string.IsNullOrEmpty(_currentPassword);
 
     /// <summary>
+    /// Gets whether the currently open company is the sample company.
+    /// The sample company should not be modified directly; use Save As instead.
+    /// </summary>
+    public bool IsSampleCompany => _currentFilePath != null &&
+        string.Equals(_currentFilePath, SampleCompanyService.GetSampleCompanyPath(), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Verifies if the provided password matches the current company's password.
     /// </summary>
     /// <param name="password">The password to verify.</param>

--- a/ArgoBooks/Views/MainWindow.axaml.cs
+++ b/ArgoBooks/Views/MainWindow.axaml.cs
@@ -173,7 +173,16 @@ public partial class MainWindow : Window
                         // Save and close
                         if (App.CompanyManager != null)
                         {
-                            await App.CompanyManager.SaveCompanyAsync();
+                            // Sample company cannot be saved directly - redirect to Save As
+                            if (App.CompanyManager.IsSampleCompany)
+                            {
+                                var saved = await App.SaveCompanyAsFromWindowAsync();
+                                if (!saved) return; // User cancelled Save As, don't close
+                            }
+                            else
+                            {
+                                await App.CompanyManager.SaveCompanyAsync();
+                            }
                         }
                         _isClosingConfirmed = true;
                         Close();


### PR DESCRIPTION
- Add IsSampleCompany property to CompanyManager to detect when the sample company is open
- Redirect Save to Save As when working with sample company, preventing direct modification of the original sample file
- Exclude sample company from recently opened lists in GlobalSettingsService
- Handle sample company in all save scenarios: header save button, file menu, close company dialog, window closing, and auto-save before lock