### PR TITLE
Show sample company message in dashboard subtitle instead of notifica…

### DIFF
--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -1166,10 +1166,7 @@ public class App : Application
             if (success)
             {
                 await LoadRecentCompaniesAsync();
-                _appShellViewModel.AddNotification(
-                    "Welcome!".Translate(),
-                    "You're exploring TechFlow Solutions - a sample company. Feel free to experiment!".Translate(),
-                    NotificationType.Info);
+                // Note: Sample company welcome message is shown in DashboardPageViewModel.WelcomeSubtitle
             }
             else
             {

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -382,6 +382,17 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
 
     #endregion
 
+    #region Welcome Subtitle
+
+    /// <summary>
+    /// Gets the welcome subtitle text, which changes based on whether this is a sample company.
+    /// </summary>
+    public string WelcomeSubtitle => _companyManager?.IsSampleCompany == true
+        ? "You're exploring TechFlow Solutions - a sample company. Feel free to experiment!".Translate()
+        : "Welcome back! Here is an overview of your business.".Translate();
+
+    #endregion
+
     #region Statistics Properties
 
     [ObservableProperty]
@@ -584,6 +595,9 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
         _companyManager = companyManager;
         LoadDashboardData();
 
+        // Notify welcome subtitle since it depends on company manager
+        OnPropertyChanged(nameof(WelcomeSubtitle));
+
         // Subscribe to data change events
         _companyManager.CompanyDataChanged += OnCompanyDataChanged;
 
@@ -616,6 +630,9 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
 
         // Notify computed chart title properties to refresh
         OnPropertyChanged(nameof(SalesVsExpensesChartTitle));
+
+        // Refresh welcome subtitle for translation
+        OnPropertyChanged(nameof(WelcomeSubtitle));
 
         // Force ComboBox to re-render items with new translations
         // by refreshing the collection (items don't change, but triggers re-render)

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -85,7 +85,7 @@
                                FontSize="24"
                                FontWeight="Bold"
                                Foreground="{DynamicResource TextPrimaryBrush}" />
-                    <TextBlock Text="{loc:Loc 'Welcome back! Here is an overview of your business.'}"
+                    <TextBlock Text="{Binding WelcomeSubtitle}"
                                FontSize="14"
                                Foreground="{DynamicResource TextSecondaryBrush}" />
                 </StackPanel>


### PR DESCRIPTION
…tion

Changed the sample company welcome message to display in the dashboard subtitle text instead of showing a separate notification popup. This provides a more integrated and less intrusive way to indicate when the user is viewing the sample company.