### PR TITLE
Add date range options and improve sample company experience

### DIFF
--- a/ArgoBooks.Core/Models/Reports/ReportConfiguration.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportConfiguration.cs
@@ -359,6 +359,7 @@ public static class DatePresetNames
     public const string Yesterday = "Yesterday";
     public const string Last7Days = "Last 7 days";
     public const string Last30Days = "Last 30 days";
+    public const string Last100Days = "Last 100 days";
     public const string ThisWeek = "This week";
     public const string LastWeek = "Last week";
     public const string ThisMonth = "This month";
@@ -396,6 +397,7 @@ public static class DatePresetNames
             "yesterday" => (today.AddDays(-1), today.AddSeconds(-1)),
             "last 7 days" => (today.AddDays(-6), today.AddDays(1).AddSeconds(-1)),
             "last 30 days" => (today.AddDays(-29), today.AddDays(1).AddSeconds(-1)),
+            "last 100 days" => (today.AddDays(-99), today.AddDays(1).AddSeconds(-1)),
             "this week" => (today.AddDays(-(int)today.DayOfWeek), today.AddDays(7 - (int)today.DayOfWeek).AddSeconds(-1)),
             "last week" => (today.AddDays(-(int)today.DayOfWeek - 7), today.AddDays(-(int)today.DayOfWeek).AddSeconds(-1)),
             "this month" => (new DateTime(now.Year, now.Month, 1), new DateTime(now.Year, now.Month, 1).AddMonths(1).AddSeconds(-1)),
@@ -506,6 +508,8 @@ public static class DatePresetNames
     [
         "This Month",
         "Last Month",
+        "Last 30 Days",
+        "Last 100 Days",
         "This Quarter",
         "Last Quarter",
         "This Year",

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -543,6 +543,15 @@ public class CompanyManager : IDisposable
     }
 
     /// <summary>
+    /// Notifies listeners that company data has been updated without marking as modified.
+    /// Used for in-memory transformations like sample data time-shifting.
+    /// </summary>
+    public void NotifyDataChanged()
+    {
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
     /// Opens the containing folder for the current company file.
     /// </summary>
     public void ShowInFolder()

--- a/ArgoBooks/Controls/MessageBox.axaml
+++ b/ArgoBooks/Controls/MessageBox.axaml
@@ -18,7 +18,8 @@
             <!-- Header with Icon and Title -->
             <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="16" Margin="0,0,0,16">
                 <!-- Icon -->
-                <Border Width="48" Height="48"
+                <Border x:Name="IconBorder"
+                        Width="48" Height="48"
                         CornerRadius="{StaticResource RadiusMd}"
                         VerticalAlignment="Top"
                         IsVisible="{Binding ShowIcon, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}">
@@ -39,44 +40,29 @@
                             <Setter Property="Background" Value="{DynamicResource PrimaryIconBgBrush}" />
                         </Style>
                     </Border.Styles>
-                    <Border.Classes>
-                        <MultiBinding Converter="{x:Static controls:MessageBox.MessageTypeClassConverter}">
-                            <Binding Path="MessageType" RelativeSource="{RelativeSource AncestorType=controls:MessageBox}" />
-                        </MultiBinding>
-                    </Border.Classes>
-                    <PathIcon Width="24" Height="24">
+                    <PathIcon x:Name="IconPath" Width="24" Height="24">
                         <PathIcon.Styles>
-                            <!-- Info icon -->
                             <Style Selector="PathIcon.info">
                                 <Setter Property="Data" Value="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
                                 <Setter Property="Foreground" Value="{DynamicResource PrimaryBrush}" />
                             </Style>
-                            <!-- Success icon -->
                             <Style Selector="PathIcon.success">
                                 <Setter Property="Data" Value="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
                                 <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
                             </Style>
-                            <!-- Warning icon -->
                             <Style Selector="PathIcon.warning">
                                 <Setter Property="Data" Value="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
                                 <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
                             </Style>
-                            <!-- Error icon -->
                             <Style Selector="PathIcon.error">
                                 <Setter Property="Data" Value="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
                                 <Setter Property="Foreground" Value="{DynamicResource DangerBrush}" />
                             </Style>
-                            <!-- Question icon -->
                             <Style Selector="PathIcon.question">
                                 <Setter Property="Data" Value="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z" />
                                 <Setter Property="Foreground" Value="{DynamicResource PrimaryBrush}" />
                             </Style>
                         </PathIcon.Styles>
-                        <PathIcon.Classes>
-                            <MultiBinding Converter="{x:Static controls:MessageBox.MessageTypeClassConverter}">
-                                <Binding Path="MessageType" RelativeSource="{RelativeSource AncestorType=controls:MessageBox}" />
-                            </MultiBinding>
-                        </PathIcon.Classes>
                     </PathIcon>
                 </Border>
 
@@ -122,7 +108,8 @@
                         MinWidth="80" />
 
                 <!-- Primary/OK/Yes Button -->
-                <controls:ArgoButton Text="{Binding PrimaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
+                <controls:ArgoButton x:Name="PrimaryButton"
+                                     Text="{Binding PrimaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
                                      Command="{Binding PrimaryCommand, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
                                      IsVisible="{Binding PrimaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                                      MinWidth="80">
@@ -143,11 +130,6 @@
                             <Setter Property="Variant" Value="Primary" />
                         </Style>
                     </controls:ArgoButton.Styles>
-                    <controls:ArgoButton.Classes>
-                        <MultiBinding Converter="{x:Static controls:MessageBox.MessageTypeClassConverter}">
-                            <Binding Path="MessageType" RelativeSource="{RelativeSource AncestorType=controls:MessageBox}" />
-                        </MultiBinding>
-                    </controls:ArgoButton.Classes>
                 </controls:ArgoButton>
             </StackPanel>
         </Grid>

--- a/ArgoBooks/Controls/MessageBox.axaml.cs
+++ b/ArgoBooks/Controls/MessageBox.axaml.cs
@@ -303,6 +303,7 @@ public partial class MessageBox : UserControl
     {
         InitializeComponent();
         UpdateButtonConfiguration();
+        UpdateMessageTypeClasses();
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -312,6 +313,45 @@ public partial class MessageBox : UserControl
         if (change.Property == ButtonsProperty)
         {
             UpdateButtonConfiguration();
+        }
+        else if (change.Property == MessageTypeProperty)
+        {
+            UpdateMessageTypeClasses();
+        }
+    }
+
+    private void UpdateMessageTypeClasses()
+    {
+        var className = MessageType switch
+        {
+            MessageBoxType.Info => "info",
+            MessageBoxType.Success => "success",
+            MessageBoxType.Warning => "warning",
+            MessageBoxType.Error => "error",
+            MessageBoxType.Question => "question",
+            _ => "info"
+        };
+
+        var iconBorder = this.FindControl<Border>("IconBorder");
+        var iconPath = this.FindControl<PathIcon>("IconPath");
+        var primaryButton = this.FindControl<ArgoButton>("PrimaryButton");
+
+        if (iconBorder != null)
+        {
+            iconBorder.Classes.Clear();
+            iconBorder.Classes.Add(className);
+        }
+
+        if (iconPath != null)
+        {
+            iconPath.Classes.Clear();
+            iconPath.Classes.Add(className);
+        }
+
+        if (primaryButton != null)
+        {
+            primaryButton.Classes.Clear();
+            primaryButton.Classes.Add(className);
         }
     }
 

--- a/ArgoBooks/Services/ChartSettingsService.cs
+++ b/ArgoBooks/Services/ChartSettingsService.cs
@@ -65,6 +65,24 @@ public partial class ChartSettingsService : ObservableObject
         ? $"{StartDate:MMM d, yyyy} - {EndDate:MMM d, yyyy}"
         : string.Empty;
 
+    /// <summary>
+    /// Gets the label for comparison period based on selected date range.
+    /// </summary>
+    public string ComparisonPeriodLabel => SelectedDateRange switch
+    {
+        "This Month" => "from last month",
+        "Last Month" => "from prior month",
+        "Last 30 Days" => "from prior 30 days",
+        "Last 100 Days" => "from prior 100 days",
+        "This Quarter" => "from last quarter",
+        "Last Quarter" => "from prior quarter",
+        "This Year" => "from last year",
+        "Last Year" => "from prior year",
+        "All Time" => "",
+        "Custom Range" => "from prior period",
+        _ => "from last period"
+    };
+
     private ChartSettingsService()
     {
         // Try to get the global settings service from the app
@@ -160,6 +178,7 @@ public partial class ChartSettingsService : ObservableObject
     partial void OnSelectedDateRangeChanged(string value)
     {
         OnPropertyChanged(nameof(AppliedDateRangeText));
+        OnPropertyChanged(nameof(ComparisonPeriodLabel));
 
         if (value != "Custom Range")
         {
@@ -204,6 +223,16 @@ public partial class ChartSettingsService : ObservableObject
                 var lastMonth = now.AddMonths(-1);
                 StartDate = new DateTime(lastMonth.Year, lastMonth.Month, 1);
                 EndDate = new DateTime(lastMonth.Year, lastMonth.Month, DateTime.DaysInMonth(lastMonth.Year, lastMonth.Month));
+                break;
+
+            case "Last 30 Days":
+                StartDate = now.AddDays(-29).Date;
+                EndDate = now;
+                break;
+
+            case "Last 100 Days":
+                StartDate = now.AddDays(-99).Date;
+                EndDate = now;
                 break;
 
             case "This Quarter":

--- a/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
@@ -277,20 +277,9 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
     public bool IsCustomDateRange => SelectedDateRange == "Custom Range";
 
     /// <summary>
-    /// Gets the label for comparison period based on selected date range.
+    /// Gets the label for comparison period based on selected date range (delegates to shared service).
     /// </summary>
-    public string ComparisonPeriodLabel => SelectedDateRange switch
-    {
-        "This Month" => "from last month",
-        "Last Month" => "from prior month",
-        "This Quarter" => "from last quarter",
-        "Last Quarter" => "from prior quarter",
-        "This Year" => "from last year",
-        "Last Year" => "from prior year",
-        "All Time" => "",
-        "Custom Range" => "from prior period",
-        _ => "from last period"
-    };
+    public string ComparisonPeriodLabel => ChartSettingsShared.ComparisonPeriodLabel;
 
     /// <summary>
     /// Opens the custom date range modal.

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -213,20 +213,9 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
     public bool IsCustomDateRange => SelectedDateRange == "Custom Range";
 
     /// <summary>
-    /// Gets the label for comparison period based on selected date range.
+    /// Gets the label for comparison period based on selected date range (delegates to shared service).
     /// </summary>
-    public string ComparisonPeriodLabel => SelectedDateRange switch
-    {
-        "This Month" => "from last month",
-        "Last Month" => "from prior month",
-        "This Quarter" => "from last quarter",
-        "Last Quarter" => "from prior quarter",
-        "This Year" => "from last year",
-        "Last Year" => "from prior year",
-        "All Time" => "",
-        "Custom Range" => "from prior period",
-        _ => "from last period"
-    };
+    public string ComparisonPeriodLabel => ChartSettings.ComparisonPeriodLabel;
 
     /// <summary>
     /// Opens the custom date range modal.


### PR DESCRIPTION
- Add 'Last 30 Days' and 'Last 100 Days' date range options
- Consolidate ComparisonPeriodLabel into unified implementation
- Time-shift sample data to keep dates current when opened
- Add bounds checking to prevent DateTime overflow during shifting
- Exclude future-scheduled dates from max date calculation
- Fix MessageBox crash and sample company asterisk issue
- Improve sample company UX: clear dirty flag, show info message
- Add OK/Cancel buttons to sample company save dialog with Save As prompt