### PR TITLE
Fix product linking when importing xlsx spreadsheets

### DIFF
--- a/ArgoBooks.Core/Services/SpreadsheetImportService.cs
+++ b/ArgoBooks.Core/Services/SpreadsheetImportService.cs
@@ -1041,6 +1041,23 @@ public class SpreadsheetImportService
             purchase.TotalUSD = purchase.Total;
             purchase.TaxAmountUSD = purchase.TaxAmount;
 
+            // Link product by looking up by name and creating a LineItem
+            if (!string.IsNullOrEmpty(description))
+            {
+                var product = data.Products.FirstOrDefault(p =>
+                    string.Equals(p.Name, description, StringComparison.OrdinalIgnoreCase));
+
+                var lineItem = new LineItem
+                {
+                    ProductId = product?.Id,
+                    Description = description,
+                    Quantity = 1,
+                    UnitPrice = purchase.Amount,
+                    TaxRate = purchase.Amount > 0 ? purchase.TaxAmount / purchase.Amount : 0
+                };
+                purchase.LineItems = [lineItem];
+            }
+
             if (existing == null)
                 data.Purchases.Add(purchase);
         }
@@ -1194,6 +1211,23 @@ public class SpreadsheetImportService
 
             if (string.IsNullOrEmpty(sale.PaymentStatus))
                 sale.PaymentStatus = "Paid";
+
+            // Link product by looking up by name and creating a LineItem
+            if (!string.IsNullOrEmpty(description))
+            {
+                var product = data.Products.FirstOrDefault(p =>
+                    string.Equals(p.Name, description, StringComparison.OrdinalIgnoreCase));
+
+                var lineItem = new LineItem
+                {
+                    ProductId = product?.Id,
+                    Description = description,
+                    Quantity = 1,
+                    UnitPrice = sale.Amount,
+                    TaxRate = sale.Amount > 0 ? sale.TaxAmount / sale.Amount : 0
+                };
+                sale.LineItems = [lineItem];
+            }
 
             if (existing == null)
                 data.Sales.Add(sale);


### PR DESCRIPTION
When importing purchases and sales from xlsx files, create LineItems with ProductId references by looking up products by name. This ensures that when users edit imported expenses, the SearchTextBox for product selection is properly populated.

Previously, only the product name was stored in the Description field without creating LineItems, causing the product dropdown to appear empty when editing imported transactions.