### PR TITLE
Add settings icon to quick actions container with configurable visibility

### DIFF
--- a/ArgoBooks.Core/Models/GlobalSettings.cs
+++ b/ArgoBooks.Core/Models/GlobalSettings.cs
@@ -42,10 +42,32 @@ public class UiSettings
 
 public class QuickActionsSettings
 {
+    // Primary actions (shown by default)
+    public bool ShowNewInvoice { get; set; } = true;
     public bool ShowNewExpense { get; set; } = true;
-    public bool ShowNewSale { get; set; } = true;
-    public bool ShowCreateInvoice { get; set; } = true;
-    public bool ShowNewRental { get; set; } = true;
+    public bool ShowNewRevenue { get; set; } = true;
+    public bool ShowScanReceipt { get; set; } = true;
+
+    // Contact actions
+    public bool ShowNewCustomer { get; set; } = false;
+    public bool ShowNewSupplier { get; set; } = false;
+
+    // Product & Inventory actions
+    public bool ShowNewProduct { get; set; } = false;
+    public bool ShowRecordPayment { get; set; } = false;
+
+    // Rental actions
+    public bool ShowNewRentalItem { get; set; } = false;
+    public bool ShowNewRentalRecord { get; set; } = true;
+
+    // Organization actions
+    public bool ShowNewCategory { get; set; } = false;
+    public bool ShowNewDepartment { get; set; } = false;
+    public bool ShowNewLocation { get; set; } = false;
+
+    // Order & Stock actions
+    public bool ShowNewPurchaseOrder { get; set; } = false;
+    public bool ShowNewStockAdjustment { get; set; } = false;
 }
 
 public class ChartSettings

--- a/ArgoBooks.Core/Models/GlobalSettings.cs
+++ b/ArgoBooks.Core/Models/GlobalSettings.cs
@@ -37,6 +37,15 @@ public class UiSettings
     public string AccentColor { get; set; } = "Blue";
     public string Language { get; set; } = "English";
     public ChartSettings Chart { get; set; } = new();
+    public QuickActionsSettings QuickActions { get; set; } = new();
+}
+
+public class QuickActionsSettings
+{
+    public bool ShowNewExpense { get; set; } = true;
+    public bool ShowNewSale { get; set; } = true;
+    public bool ShowCreateInvoice { get; set; } = true;
+    public bool ShowNewRental { get; set; } = true;
 }
 
 public class ChartSettings

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -149,6 +149,11 @@ public class App : Application
     public static PredictionInfoModalViewModel? PredictionInfoModalViewModel => _appShellViewModel?.PredictionInfoModalViewModel;
 
     /// <summary>
+    /// Gets the quick actions settings modal view model for shared access.
+    /// </summary>
+    public static QuickActionsSettingsModalViewModel? QuickActionsSettingsModalViewModel => _appShellViewModel?.QuickActionsSettingsModalViewModel;
+
+    /// <summary>
     /// Adds a notification to the notification panel.
     /// </summary>
     /// <param name="title">The notification title.</param>

--- a/ArgoBooks/Modals/QuickActionsSettingsModal.axaml
+++ b/ArgoBooks/Modals/QuickActionsSettingsModal.axaml
@@ -1,0 +1,216 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:ArgoBooks.ViewModels"
+             xmlns:loc="using:ArgoBooks.Localization"
+             mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="400"
+             x:Class="ArgoBooks.Modals.QuickActionsSettingsModal"
+             x:DataType="vm:QuickActionsSettingsModalViewModel">
+
+    <Design.DataContext>
+        <vm:QuickActionsSettingsModalViewModel />
+    </Design.DataContext>
+
+    <Panel IsVisible="{Binding IsOpen}">
+        <!-- Modal Backdrop with fade animation -->
+        <Border Background="#80000000">
+            <Border.Transitions>
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.2" />
+                </Transitions>
+            </Border.Transitions>
+        </Border>
+
+        <!-- Modal Container with scale animation -->
+        <Border x:Name="ModalBorder"
+                Background="{DynamicResource SurfaceBrush}"
+                BorderBrush="{DynamicResource BorderBrush}"
+                BorderThickness="1"
+                CornerRadius="8"
+                Width="420"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                BoxShadow="0 4 20 0 #26000000"
+                Focusable="True"
+                KeyDown="Modal_KeyDown"
+                Opacity="0"
+                RenderTransformOrigin="0.5,0.5">
+            <Border.RenderTransform>
+                <ScaleTransform ScaleX="0.95" ScaleY="0.95" />
+            </Border.RenderTransform>
+            <Border.Transitions>
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.15" Easing="CubicEaseOut" />
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.15" Easing="CubicEaseOut" />
+                </Transitions>
+            </Border.Transitions>
+
+            <Grid RowDefinitions="Auto,*,Auto">
+                <!-- Modal Header -->
+                <Border Grid.Row="0"
+                        Padding="20,16"
+                        BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="0,0,0,1">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Grid.Column="0"
+                                   Text="{loc:Loc 'Quick Actions Settings'}"
+                                   FontSize="16"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                        <Button Grid.Column="1"
+                                Classes="icon-button"
+                                Command="{Binding CloseCommand}">
+                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                      Width="16" Height="16" />
+                        </Button>
+                    </Grid>
+                </Border>
+
+                <!-- Modal Body -->
+                <StackPanel Grid.Row="1" Margin="20,24" Spacing="16">
+                    <TextBlock Text="{loc:Loc 'Choose which quick actions to display on the dashboard:'}"
+                               FontSize="13"
+                               Foreground="{DynamicResource TextSecondaryBrush}"
+                               TextWrapping="Wrap" />
+
+                    <!-- Quick Action Toggles -->
+                    <StackPanel Spacing="12" Margin="0,8,0,0">
+                        <!-- New Expense -->
+                        <Border Background="{DynamicResource SurfaceAltBrush}"
+                                CornerRadius="8"
+                                Padding="16,12">
+                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                <Border Grid.Column="0"
+                                        Width="36" Height="36"
+                                        CornerRadius="8"
+                                        Background="{DynamicResource DangerIconBgBrush}"
+                                        Margin="0,0,12,0">
+                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                              Width="18" Height="18"
+                                              Foreground="{DynamicResource DangerBrush}" />
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                                    <TextBlock Text="{loc:Loc 'New Expense'}"
+                                               FontSize="14"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    <TextBlock Text="{loc:Loc 'Record an expense'}"
+                                               FontSize="12"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                </StackPanel>
+                                <ToggleSwitch Grid.Column="2"
+                                              IsChecked="{Binding ShowNewExpense}"
+                                              VerticalAlignment="Center" />
+                            </Grid>
+                        </Border>
+
+                        <!-- New Sale -->
+                        <Border Background="{DynamicResource SurfaceAltBrush}"
+                                CornerRadius="8"
+                                Padding="16,12">
+                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                <Border Grid.Column="0"
+                                        Width="36" Height="36"
+                                        CornerRadius="8"
+                                        Background="{DynamicResource SuccessIconBgBrush}"
+                                        Margin="0,0,12,0">
+                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.91s4.18 1.39 4.18 3.91c-.01 1.83-1.38 2.83-3.12 3.16z"
+                                              Width="18" Height="18"
+                                              Foreground="{DynamicResource SuccessBrush}" />
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                                    <TextBlock Text="{loc:Loc 'New Sale'}"
+                                               FontSize="14"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    <TextBlock Text="{loc:Loc 'Record revenue'}"
+                                               FontSize="12"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                </StackPanel>
+                                <ToggleSwitch Grid.Column="2"
+                                              IsChecked="{Binding ShowNewSale}"
+                                              VerticalAlignment="Center" />
+                            </Grid>
+                        </Border>
+
+                        <!-- Create Invoice -->
+                        <Border Background="{DynamicResource SurfaceAltBrush}"
+                                CornerRadius="8"
+                                Padding="16,12">
+                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                <Border Grid.Column="0"
+                                        Width="36" Height="36"
+                                        CornerRadius="8"
+                                        Background="{DynamicResource WarningIconBgBrush}"
+                                        Margin="0,0,12,0">
+                                    <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                              Width="18" Height="18"
+                                              Foreground="{DynamicResource WarningBrush}" />
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                                    <TextBlock Text="{loc:Loc 'Create Invoice'}"
+                                               FontSize="14"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    <TextBlock Text="{loc:Loc 'Bill a customer'}"
+                                               FontSize="12"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                </StackPanel>
+                                <ToggleSwitch Grid.Column="2"
+                                              IsChecked="{Binding ShowCreateInvoice}"
+                                              VerticalAlignment="Center" />
+                            </Grid>
+                        </Border>
+
+                        <!-- New Rental -->
+                        <Border Background="{DynamicResource SurfaceAltBrush}"
+                                CornerRadius="8"
+                                Padding="16,12">
+                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                <Border Grid.Column="0"
+                                        Width="36" Height="36"
+                                        CornerRadius="8"
+                                        Background="{DynamicResource InfoIconBgBrush}"
+                                        Margin="0,0,12,0">
+                                    <PathIcon Data="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"
+                                              Width="18" Height="18"
+                                              Foreground="{DynamicResource InfoBrush}" />
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                                    <TextBlock Text="{loc:Loc 'New Rental'}"
+                                               FontSize="14"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    <TextBlock Text="{loc:Loc 'Start a rental'}"
+                                               FontSize="12"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                </StackPanel>
+                                <ToggleSwitch Grid.Column="2"
+                                              IsChecked="{Binding ShowNewRental}"
+                                              VerticalAlignment="Center" />
+                            </Grid>
+                        </Border>
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- Modal Footer -->
+                <Border Grid.Row="2"
+                        Padding="20,16"
+                        BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="0,1,0,0">
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Right"
+                                Spacing="12">
+                        <Button Classes="secondary-button"
+                                Content="{loc:Loc Cancel}"
+                                Command="{Binding CloseCommand}" />
+                        <Button Classes="primary-button"
+                                Content="{loc:Loc 'Save Changes'}"
+                                Command="{Binding SaveCommand}" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+    </Panel>
+</UserControl>

--- a/ArgoBooks/Modals/QuickActionsSettingsModal.axaml
+++ b/ArgoBooks/Modals/QuickActionsSettingsModal.axaml
@@ -402,16 +402,25 @@
                         Padding="24,16"
                         BorderBrush="{DynamicResource BorderBrush}"
                         BorderThickness="0,1,0,0">
-                    <StackPanel Orientation="Horizontal"
-                                HorizontalAlignment="Right"
-                                Spacing="12">
-                        <Button Classes="secondary-button"
-                                Content="{loc:Loc Cancel}"
-                                Command="{Binding CloseCommand}" />
-                        <Button Classes="primary-button"
-                                Content="{loc:Loc 'Save Changes'}"
-                                Command="{Binding SaveCommand}" />
-                    </StackPanel>
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <!-- Reset All Button (Left) -->
+                        <Button Grid.Column="0"
+                                Classes="secondary-button"
+                                Content="{loc:Loc 'Reset All'}"
+                                Command="{Binding ResetAllCommand}" />
+
+                        <!-- Cancel and Save Buttons (Right) -->
+                        <StackPanel Grid.Column="2"
+                                    Orientation="Horizontal"
+                                    Spacing="12">
+                            <Button Classes="secondary-button"
+                                    Content="{loc:Loc Cancel}"
+                                    Command="{Binding CloseCommand}" />
+                            <Button Classes="primary-button"
+                                    Content="{loc:Loc 'Save Changes'}"
+                                    Command="{Binding SaveCommand}" />
+                        </StackPanel>
+                    </Grid>
                 </Border>
             </Grid>
         </Border>

--- a/ArgoBooks/Modals/QuickActionsSettingsModal.axaml
+++ b/ArgoBooks/Modals/QuickActionsSettingsModal.axaml
@@ -4,13 +4,34 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
-             mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="400"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="600"
              x:Class="ArgoBooks.Modals.QuickActionsSettingsModal"
              x:DataType="vm:QuickActionsSettingsModalViewModel">
 
     <Design.DataContext>
         <vm:QuickActionsSettingsModalViewModel />
     </Design.DataContext>
+
+    <UserControl.Styles>
+        <!-- Animated Toggle Item Style -->
+        <Style Selector="Border.toggle-item">
+            <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="12,10" />
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="RenderTransform" Value="translateX(0)" />
+            <Setter Property="Transitions">
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.2" Easing="CubicEaseOut" />
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.2" Easing="CubicEaseOut" />
+                    <BrushTransition Property="Background" Duration="0:0:0.15" />
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="Border.toggle-item:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+        </Style>
+    </UserControl.Styles>
 
     <Panel IsVisible="{Binding IsOpen}">
         <!-- Modal Backdrop with fade animation -->
@@ -27,11 +48,12 @@
                 Background="{DynamicResource SurfaceBrush}"
                 BorderBrush="{DynamicResource BorderBrush}"
                 BorderThickness="1"
-                CornerRadius="8"
-                Width="420"
+                CornerRadius="12"
+                Width="500"
+                MaxHeight="700"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
-                BoxShadow="0 4 20 0 #26000000"
+                BoxShadow="0 8 32 0 #40000000"
                 Focusable="True"
                 KeyDown="Modal_KeyDown"
                 Opacity="0"
@@ -49,17 +71,22 @@
             <Grid RowDefinitions="Auto,*,Auto">
                 <!-- Modal Header -->
                 <Border Grid.Row="0"
-                        Padding="20,16"
+                        Padding="24,20"
                         BorderBrush="{DynamicResource BorderBrush}"
                         BorderThickness="0,0,0,1">
                     <Grid ColumnDefinitions="*,Auto">
-                        <TextBlock Grid.Column="0"
-                                   Text="{loc:Loc 'Quick Actions Settings'}"
-                                   FontSize="16"
-                                   FontWeight="SemiBold"
-                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                        <StackPanel Grid.Column="0" Spacing="4">
+                            <TextBlock Text="{loc:Loc 'Quick Actions Settings'}"
+                                       FontSize="18"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextPrimaryBrush}" />
+                            <TextBlock Text="{loc:Loc 'Choose which quick actions to display on the dashboard'}"
+                                       FontSize="13"
+                                       Foreground="{DynamicResource TextSecondaryBrush}" />
+                        </StackPanel>
                         <Button Grid.Column="1"
                                 Classes="icon-button"
+                                VerticalAlignment="Top"
                                 Command="{Binding CloseCommand}">
                             <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
                                       Width="16" Height="16" />
@@ -67,136 +94,312 @@
                     </Grid>
                 </Border>
 
-                <!-- Modal Body -->
-                <StackPanel Grid.Row="1" Margin="20,24" Spacing="16">
-                    <TextBlock Text="{loc:Loc 'Choose which quick actions to display on the dashboard:'}"
-                               FontSize="13"
-                               Foreground="{DynamicResource TextSecondaryBrush}"
-                               TextWrapping="Wrap" />
+                <!-- Modal Body - Scrollable -->
+                <ScrollViewer Grid.Row="1"
+                              VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel Margin="24,20" Spacing="20">
 
-                    <!-- Quick Action Toggles -->
-                    <StackPanel Spacing="12" Margin="0,8,0,0">
-                        <!-- New Expense -->
-                        <Border Background="{DynamicResource SurfaceAltBrush}"
-                                CornerRadius="8"
-                                Padding="16,12">
-                            <Grid ColumnDefinitions="Auto,*,Auto">
-                                <Border Grid.Column="0"
-                                        Width="36" Height="36"
-                                        CornerRadius="8"
-                                        Background="{DynamicResource DangerIconBgBrush}"
-                                        Margin="0,0,12,0">
-                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                                              Width="18" Height="18"
-                                              Foreground="{DynamicResource DangerBrush}" />
-                                </Border>
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                                    <TextBlock Text="{loc:Loc 'New Expense'}"
-                                               FontSize="14"
-                                               FontWeight="Medium"
-                                               Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    <TextBlock Text="{loc:Loc 'Record an expense'}"
-                                               FontSize="12"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                </StackPanel>
-                                <ToggleSwitch Grid.Column="2"
-                                              IsChecked="{Binding ShowNewExpense}"
-                                              VerticalAlignment="Center" />
-                            </Grid>
-                        </Border>
+                        <!-- Primary Actions -->
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{loc:Loc 'Primary Actions'}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Margin="0,0,0,4" />
 
-                        <!-- New Sale -->
-                        <Border Background="{DynamicResource SurfaceAltBrush}"
-                                CornerRadius="8"
-                                Padding="16,12">
-                            <Grid ColumnDefinitions="Auto,*,Auto">
-                                <Border Grid.Column="0"
-                                        Width="36" Height="36"
-                                        CornerRadius="8"
-                                        Background="{DynamicResource SuccessIconBgBrush}"
-                                        Margin="0,0,12,0">
-                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.91s4.18 1.39 4.18 3.91c-.01 1.83-1.38 2.83-3.12 3.16z"
-                                              Width="18" Height="18"
-                                              Foreground="{DynamicResource SuccessBrush}" />
-                                </Border>
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                                    <TextBlock Text="{loc:Loc 'New Sale'}"
-                                               FontSize="14"
-                                               FontWeight="Medium"
-                                               Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    <TextBlock Text="{loc:Loc 'Record revenue'}"
-                                               FontSize="12"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                </StackPanel>
-                                <ToggleSwitch Grid.Column="2"
-                                              IsChecked="{Binding ShowNewSale}"
-                                              VerticalAlignment="Center" />
-                            </Grid>
-                        </Border>
+                            <!-- New Invoice -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource WarningIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Invoice'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Create a new invoice'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewInvoice}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
 
-                        <!-- Create Invoice -->
-                        <Border Background="{DynamicResource SurfaceAltBrush}"
-                                CornerRadius="8"
-                                Padding="16,12">
-                            <Grid ColumnDefinitions="Auto,*,Auto">
-                                <Border Grid.Column="0"
-                                        Width="36" Height="36"
-                                        CornerRadius="8"
-                                        Background="{DynamicResource WarningIconBgBrush}"
-                                        Margin="0,0,12,0">
-                                    <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
-                                              Width="18" Height="18"
-                                              Foreground="{DynamicResource WarningBrush}" />
-                                </Border>
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                                    <TextBlock Text="{loc:Loc 'Create Invoice'}"
-                                               FontSize="14"
-                                               FontWeight="Medium"
-                                               Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    <TextBlock Text="{loc:Loc 'Bill a customer'}"
-                                               FontSize="12"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                </StackPanel>
-                                <ToggleSwitch Grid.Column="2"
-                                              IsChecked="{Binding ShowCreateInvoice}"
-                                              VerticalAlignment="Center" />
-                            </Grid>
-                        </Border>
+                            <!-- New Expense -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource DangerIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource DangerBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Expense'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Record an expense'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewExpense}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
 
-                        <!-- New Rental -->
-                        <Border Background="{DynamicResource SurfaceAltBrush}"
-                                CornerRadius="8"
-                                Padding="16,12">
-                            <Grid ColumnDefinitions="Auto,*,Auto">
-                                <Border Grid.Column="0"
-                                        Width="36" Height="36"
-                                        CornerRadius="8"
-                                        Background="{DynamicResource InfoIconBgBrush}"
-                                        Margin="0,0,12,0">
-                                    <PathIcon Data="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"
-                                              Width="18" Height="18"
-                                              Foreground="{DynamicResource InfoBrush}" />
-                                </Border>
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                                    <TextBlock Text="{loc:Loc 'New Rental'}"
-                                               FontSize="14"
-                                               FontWeight="Medium"
-                                               Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    <TextBlock Text="{loc:Loc 'Start a rental'}"
-                                               FontSize="12"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                </StackPanel>
-                                <ToggleSwitch Grid.Column="2"
-                                              IsChecked="{Binding ShowNewRental}"
-                                              VerticalAlignment="Center" />
-                            </Grid>
-                        </Border>
+                            <!-- New Revenue -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource SuccessIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Revenue'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Record a sale'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewRevenue}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
+                            <!-- Scan Receipt -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource InfoIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'Scan Receipt'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Import with AI'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowScanReceipt}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+
+                        <!-- Contacts -->
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{loc:Loc 'Contacts'}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Margin="0,0,0,4" />
+
+                            <!-- New Customer -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource PrimaryIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Customer'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Add a customer'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewCustomer}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
+                            <!-- New Supplier -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource PrimaryIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Supplier'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Add a supplier'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewSupplier}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+
+                        <!-- Products & Payments -->
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{loc:Loc 'Products &amp; Payments'}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Margin="0,0,0,4" />
+
+                            <!-- New Product -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource SuccessIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Product'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Add a product'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewProduct}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
+                            <!-- Record Payment -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource SuccessIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'Record Payment'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Log a payment'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowRecordPayment}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+
+                        <!-- Rentals -->
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{loc:Loc 'Rentals'}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Margin="0,0,0,4" />
+
+                            <!-- New Rental Item -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource InfoIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zM7 4V3h10v1H7zm0 14V6h10v12H7zm0 3v-1h10v1H7z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Rental Item'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Add rental inventory'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewRentalItem}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
+                            <!-- New Rental Record -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource InfoIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Rental Record'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Start a rental'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewRentalRecord}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+
+                        <!-- Organization -->
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{loc:Loc 'Organization'}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Margin="0,0,0,4" />
+
+                            <!-- New Category -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource WarningIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M12 2l-5.5 9h11L12 2zm0 3.84L13.93 9h-3.87L12 5.84z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Category'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Add a category'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewCategory}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
+                            <!-- New Department -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource WarningIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Department'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Add a department'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewDepartment}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
+                            <!-- New Location -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource WarningIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Location'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Add a location'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewLocation}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+
+                        <!-- Orders & Stock -->
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{loc:Loc 'Orders &amp; Stock'}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Margin="0,0,0,4" />
+
+                            <!-- New Purchase Order -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource PrimaryIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6-2c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm6 16H6V8h2v2c0 .55.45 1 1 1s1-.45 1-1V8h4v2c0 .55.45 1 1 1s1-.45 1-1V8h2v12z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Purchase Order'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Create an order'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewPurchaseOrder}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+
+                            <!-- New Stock Adjustment -->
+                            <Border Classes="toggle-item">
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
+                                            Background="{DynamicResource PrimaryIconBgBrush}" Margin="0,0,12,0">
+                                        <PathIcon Data="M19 3H14.82C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
+                                                  Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
+                                        <TextBlock Text="{loc:Loc 'New Stock Adjustment'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="{loc:Loc 'Adjust inventory'}" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    </StackPanel>
+                                    <ToggleSwitch Grid.Column="2" IsChecked="{Binding ShowNewStockAdjustment}" VerticalAlignment="Center" />
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+
                     </StackPanel>
-                </StackPanel>
+                </ScrollViewer>
 
                 <!-- Modal Footer -->
                 <Border Grid.Row="2"
-                        Padding="20,16"
+                        Padding="24,16"
                         BorderBrush="{DynamicResource BorderBrush}"
                         BorderThickness="0,1,0,0">
                     <StackPanel Orientation="Horizontal"

--- a/ArgoBooks/Modals/QuickActionsSettingsModal.axaml.cs
+++ b/ArgoBooks/Modals/QuickActionsSettingsModal.axaml.cs
@@ -1,0 +1,71 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using ArgoBooks.ViewModels;
+
+namespace ArgoBooks.Modals;
+
+/// <summary>
+/// Modal dialog for configuring quick action visibility on the dashboard.
+/// </summary>
+public partial class QuickActionsSettingsModal : UserControl
+{
+    public QuickActionsSettingsModal()
+    {
+        InitializeComponent();
+
+        // Animate and focus the modal when it opens
+        DataContextChanged += (_, _) =>
+        {
+            if (DataContext is QuickActionsSettingsModalViewModel vm)
+            {
+                vm.PropertyChanged += (_, e) =>
+                {
+                    if (e.PropertyName == nameof(QuickActionsSettingsModalViewModel.IsOpen))
+                    {
+                        if (vm.IsOpen)
+                        {
+                            Dispatcher.UIThread.Post(() =>
+                            {
+                                if (ModalBorder != null)
+                                {
+                                    ModalBorder.Opacity = 1;
+                                    ModalBorder.RenderTransform = new ScaleTransform(1, 1);
+                                }
+                                ModalBorder?.Focus();
+                            }, DispatcherPriority.Render);
+                        }
+                        else
+                        {
+                            Dispatcher.UIThread.Post(() =>
+                            {
+                                if (ModalBorder != null)
+                                {
+                                    ModalBorder.Opacity = 0;
+                                    ModalBorder.RenderTransform = new ScaleTransform(0.95, 0.95);
+                                }
+                            }, DispatcherPriority.Background);
+                        }
+                    }
+                };
+            }
+        };
+    }
+
+    /// <summary>
+    /// Handles keyboard input for the modal.
+    /// </summary>
+    private void Modal_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (DataContext is not QuickActionsSettingsModalViewModel vm) return;
+
+        switch (e.Key)
+        {
+            case Key.Escape:
+                vm.CloseCommand.Execute(null);
+                e.Handled = true;
+                break;
+        }
+    }
+}

--- a/ArgoBooks/ViewModels/AppShellViewModel.cs
+++ b/ArgoBooks/ViewModels/AppShellViewModel.cs
@@ -223,6 +223,11 @@ public partial class AppShellViewModel : ViewModelBase
     /// </summary>
     public UnsavedChangesDialogViewModel UnsavedChangesDialogViewModel { get; }
 
+    /// <summary>
+    /// Gets the quick actions settings modal view model.
+    /// </summary>
+    public QuickActionsSettingsModalViewModel QuickActionsSettingsModalViewModel { get; }
+
     #endregion
 
     #region Navigation Properties
@@ -376,6 +381,9 @@ public partial class AppShellViewModel : ViewModelBase
 
         // Create unsaved changes dialog
         UnsavedChangesDialogViewModel = new UnsavedChangesDialogViewModel();
+
+        // Create quick actions settings modal
+        QuickActionsSettingsModalViewModel = new QuickActionsSettingsModalViewModel();
 
         // Register navigation guard for unsaved changes check
         if (_navigationService is NavigationService navService)

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -1230,7 +1230,7 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
     private void ScanReceipt()
     {
         App.NavigationService?.NavigateTo("Receipts");
-        App.ReceiptsModalsViewModel?.OpenScanModal();
+        // Note: Scan modal requires a file path, so just navigate to receipts page
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -584,6 +584,9 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
         _companyManager = companyManager;
         LoadDashboardData();
 
+        // Load quick action visibility settings
+        LoadQuickActionsSettings();
+
         // Notify welcome subtitle since it depends on company manager
         OnPropertyChanged(nameof(WelcomeSubtitle));
 
@@ -592,6 +595,17 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
 
         // Subscribe to language changes to refresh translated chart titles
         LanguageService.Instance.LanguageChanged += OnLanguageChanged;
+
+        // Subscribe to quick actions settings changes
+        if (App.QuickActionsSettingsModalViewModel != null)
+        {
+            App.QuickActionsSettingsModalViewModel.SettingsSaved += OnQuickActionsSettingsSaved;
+        }
+    }
+
+    private void OnQuickActionsSettingsSaved(object? sender, EventArgs e)
+    {
+        LoadQuickActionsSettings();
     }
 
     /// <summary>
@@ -610,6 +624,12 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
 
         // Unsubscribe from language changes
         LanguageService.Instance.LanguageChanged -= OnLanguageChanged;
+
+        // Unsubscribe from quick actions settings changes
+        if (App.QuickActionsSettingsModalViewModel != null)
+        {
+            App.QuickActionsSettingsModalViewModel.SettingsSaved -= OnQuickActionsSettingsSaved;
+        }
     }
 
     private void OnLanguageChanged(object? sender, LanguageChangedEventArgs e)
@@ -1052,6 +1072,55 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
     /// Gets the chart loader service for external use (e.g., report generation).
     /// </summary>
     public ChartLoaderService ChartLoaderService { get; } = new();
+
+    #endregion
+
+    #region Quick Actions Visibility
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewExpense = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewSale = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showCreateInvoice = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewRental = true;
+
+    /// <summary>
+    /// Gets whether at least one quick action is visible.
+    /// </summary>
+    public bool HasVisibleQuickActions => ShowNewExpense || ShowNewSale || ShowCreateInvoice || ShowNewRental;
+
+    /// <summary>
+    /// Loads quick action visibility settings from global settings.
+    /// </summary>
+    public void LoadQuickActionsSettings()
+    {
+        var globalSettings = App.SettingsService?.GlobalSettings;
+        if (globalSettings != null)
+        {
+            ShowNewExpense = globalSettings.Ui.QuickActions.ShowNewExpense;
+            ShowNewSale = globalSettings.Ui.QuickActions.ShowNewSale;
+            ShowCreateInvoice = globalSettings.Ui.QuickActions.ShowCreateInvoice;
+            ShowNewRental = globalSettings.Ui.QuickActions.ShowNewRental;
+        }
+    }
+
+    /// <summary>
+    /// Opens the quick actions settings modal.
+    /// </summary>
+    [RelayCommand]
+    private void OpenQuickActionsSettings()
+    {
+        App.QuickActionsSettingsModalViewModel?.OpenCommand.Execute(null);
+    }
 
     #endregion
 

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -1077,26 +1077,81 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
 
     #region Quick Actions Visibility
 
+    // Primary actions
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewInvoice = true;
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
     private bool _showNewExpense = true;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
-    private bool _showNewSale = true;
+    private bool _showNewRevenue = true;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
-    private bool _showCreateInvoice = true;
+    private bool _showScanReceipt = true;
+
+    // Contact actions
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewCustomer;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
-    private bool _showNewRental = true;
+    private bool _showNewSupplier;
+
+    // Product & Inventory actions
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewProduct;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showRecordPayment;
+
+    // Rental actions
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewRentalItem;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewRentalRecord = true;
+
+    // Organization actions
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewCategory;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewDepartment;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewLocation;
+
+    // Order & Stock actions
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewPurchaseOrder;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasVisibleQuickActions))]
+    private bool _showNewStockAdjustment;
 
     /// <summary>
     /// Gets whether at least one quick action is visible.
     /// </summary>
-    public bool HasVisibleQuickActions => ShowNewExpense || ShowNewSale || ShowCreateInvoice || ShowNewRental;
+    public bool HasVisibleQuickActions =>
+        ShowNewInvoice || ShowNewExpense || ShowNewRevenue || ShowScanReceipt ||
+        ShowNewCustomer || ShowNewSupplier || ShowNewProduct || ShowRecordPayment ||
+        ShowNewRentalItem || ShowNewRentalRecord ||
+        ShowNewCategory || ShowNewDepartment || ShowNewLocation ||
+        ShowNewPurchaseOrder || ShowNewStockAdjustment;
 
     /// <summary>
     /// Loads quick action visibility settings from global settings.
@@ -1106,10 +1161,34 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
         var globalSettings = App.SettingsService?.GlobalSettings;
         if (globalSettings != null)
         {
-            ShowNewExpense = globalSettings.Ui.QuickActions.ShowNewExpense;
-            ShowNewSale = globalSettings.Ui.QuickActions.ShowNewSale;
-            ShowCreateInvoice = globalSettings.Ui.QuickActions.ShowCreateInvoice;
-            ShowNewRental = globalSettings.Ui.QuickActions.ShowNewRental;
+            var qa = globalSettings.Ui.QuickActions;
+
+            // Primary actions
+            ShowNewInvoice = qa.ShowNewInvoice;
+            ShowNewExpense = qa.ShowNewExpense;
+            ShowNewRevenue = qa.ShowNewRevenue;
+            ShowScanReceipt = qa.ShowScanReceipt;
+
+            // Contact actions
+            ShowNewCustomer = qa.ShowNewCustomer;
+            ShowNewSupplier = qa.ShowNewSupplier;
+
+            // Product & Inventory actions
+            ShowNewProduct = qa.ShowNewProduct;
+            ShowRecordPayment = qa.ShowRecordPayment;
+
+            // Rental actions
+            ShowNewRentalItem = qa.ShowNewRentalItem;
+            ShowNewRentalRecord = qa.ShowNewRentalRecord;
+
+            // Organization actions
+            ShowNewCategory = qa.ShowNewCategory;
+            ShowNewDepartment = qa.ShowNewDepartment;
+            ShowNewLocation = qa.ShowNewLocation;
+
+            // Order & Stock actions
+            ShowNewPurchaseOrder = qa.ShowNewPurchaseOrder;
+            ShowNewStockAdjustment = qa.ShowNewStockAdjustment;
         }
     }
 
@@ -1127,10 +1206,16 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
     #region Quick Actions
 
     [RelayCommand]
+    private void NewInvoice()
+    {
+        App.NavigationService?.NavigateTo("Invoices");
+        App.InvoiceModalsViewModel?.OpenCreateModal();
+    }
+
+    [RelayCommand]
     private void AddExpense()
     {
         App.NavigationService?.NavigateTo("Expenses");
-        // Open the add expense modal after navigation
         App.ExpenseModalsViewModel?.OpenAddModal();
     }
 
@@ -1138,24 +1223,91 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
     private void RecordSale()
     {
         App.NavigationService?.NavigateTo("Revenue");
-        // Open the add revenue modal after navigation
         App.RevenueModalsViewModel?.OpenAddModal();
     }
 
     [RelayCommand]
-    private void CreateInvoice()
+    private void ScanReceipt()
     {
-        App.NavigationService?.NavigateTo("Invoices");
-        // Open the create invoice modal after navigation
-        App.InvoiceModalsViewModel?.OpenCreateModal();
+        App.NavigationService?.NavigateTo("Receipts");
+        App.ReceiptModalsViewModel?.OpenScanModal();
+    }
+
+    [RelayCommand]
+    private void NewCustomer()
+    {
+        App.NavigationService?.NavigateTo("Customers");
+        App.CustomerModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void NewSupplier()
+    {
+        App.NavigationService?.NavigateTo("Suppliers");
+        App.SupplierModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void NewProduct()
+    {
+        App.NavigationService?.NavigateTo("Products");
+        App.ProductModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void RecordPayment()
+    {
+        App.NavigationService?.NavigateTo("Payments");
+        App.PaymentModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void NewRentalItem()
+    {
+        App.NavigationService?.NavigateTo("RentalInventory");
+        App.RentalInventoryModalsViewModel?.OpenAddModal();
     }
 
     [RelayCommand]
     private void NewRental()
     {
         App.NavigationService?.NavigateTo("RentalRecords");
-        // Open the add rental modal after navigation
         App.RentalRecordsModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void NewCategory()
+    {
+        App.NavigationService?.NavigateTo("Categories");
+        App.CategoryModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void NewDepartment()
+    {
+        App.NavigationService?.NavigateTo("Departments");
+        App.DepartmentModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void NewLocation()
+    {
+        App.NavigationService?.NavigateTo("Locations");
+        App.LocationModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void NewPurchaseOrder()
+    {
+        App.NavigationService?.NavigateTo("PurchaseOrders");
+        App.PurchaseOrderModalsViewModel?.OpenAddModal();
+    }
+
+    [RelayCommand]
+    private void NewStockAdjustment()
+    {
+        App.NavigationService?.NavigateTo("Adjustments");
+        App.AdjustmentModalsViewModel?.OpenAddModal();
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -1230,7 +1230,7 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
     private void ScanReceipt()
     {
         App.NavigationService?.NavigateTo("Receipts");
-        App.ReceiptModalsViewModel?.OpenScanModal();
+        App.ReceiptsModalsViewModel?.OpenScanModal();
     }
 
     [RelayCommand]
@@ -1293,21 +1293,21 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
     private void NewLocation()
     {
         App.NavigationService?.NavigateTo("Locations");
-        App.LocationModalsViewModel?.OpenAddModal();
+        App.LocationsModalsViewModel?.OpenAddModal();
     }
 
     [RelayCommand]
     private void NewPurchaseOrder()
     {
         App.NavigationService?.NavigateTo("PurchaseOrders");
-        App.PurchaseOrderModalsViewModel?.OpenAddModal();
+        App.PurchaseOrdersModalsViewModel?.OpenAddModal();
     }
 
     [RelayCommand]
     private void NewStockAdjustment()
     {
         App.NavigationService?.NavigateTo("Adjustments");
-        App.AdjustmentModalsViewModel?.OpenAddModal();
+        App.StockAdjustmentsModalsViewModel?.OpenAddModal();
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/QuickActionsSettingsModalViewModel.cs
+++ b/ArgoBooks/ViewModels/QuickActionsSettingsModalViewModel.cs
@@ -126,6 +126,40 @@ public partial class QuickActionsSettingsModalViewModel : ViewModelBase
         IsOpen = false;
     }
 
+    /// <summary>
+    /// Resets all quick actions to their default values.
+    /// </summary>
+    [RelayCommand]
+    private void ResetAll()
+    {
+        // Primary actions (shown by default)
+        ShowNewInvoice = true;
+        ShowNewExpense = true;
+        ShowNewRevenue = true;
+        ShowScanReceipt = true;
+
+        // Contact actions (hidden by default)
+        ShowNewCustomer = false;
+        ShowNewSupplier = false;
+
+        // Product & Inventory actions (hidden by default)
+        ShowNewProduct = false;
+        ShowRecordPayment = false;
+
+        // Rental actions
+        ShowNewRentalItem = false;
+        ShowNewRentalRecord = true;
+
+        // Organization actions (hidden by default)
+        ShowNewCategory = false;
+        ShowNewDepartment = false;
+        ShowNewLocation = false;
+
+        // Order & Stock actions (hidden by default)
+        ShowNewPurchaseOrder = false;
+        ShowNewStockAdjustment = false;
+    }
+
     #endregion
 
     #region Settings Persistence

--- a/ArgoBooks/ViewModels/QuickActionsSettingsModalViewModel.cs
+++ b/ArgoBooks/ViewModels/QuickActionsSettingsModalViewModel.cs
@@ -12,19 +12,72 @@ public partial class QuickActionsSettingsModalViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isOpen;
 
-    #region Quick Action Visibility
+    #region Quick Action Visibility - Primary Actions
+
+    [ObservableProperty]
+    private bool _showNewInvoice = true;
 
     [ObservableProperty]
     private bool _showNewExpense = true;
 
     [ObservableProperty]
-    private bool _showNewSale = true;
+    private bool _showNewRevenue = true;
 
     [ObservableProperty]
-    private bool _showCreateInvoice = true;
+    private bool _showScanReceipt = true;
+
+    #endregion
+
+    #region Quick Action Visibility - Contact Actions
 
     [ObservableProperty]
-    private bool _showNewRental = true;
+    private bool _showNewCustomer;
+
+    [ObservableProperty]
+    private bool _showNewSupplier;
+
+    #endregion
+
+    #region Quick Action Visibility - Product & Inventory Actions
+
+    [ObservableProperty]
+    private bool _showNewProduct;
+
+    [ObservableProperty]
+    private bool _showRecordPayment;
+
+    #endregion
+
+    #region Quick Action Visibility - Rental Actions
+
+    [ObservableProperty]
+    private bool _showNewRentalItem;
+
+    [ObservableProperty]
+    private bool _showNewRentalRecord = true;
+
+    #endregion
+
+    #region Quick Action Visibility - Organization Actions
+
+    [ObservableProperty]
+    private bool _showNewCategory;
+
+    [ObservableProperty]
+    private bool _showNewDepartment;
+
+    [ObservableProperty]
+    private bool _showNewLocation;
+
+    #endregion
+
+    #region Quick Action Visibility - Order & Stock Actions
+
+    [ObservableProperty]
+    private bool _showNewPurchaseOrder;
+
+    [ObservableProperty]
+    private bool _showNewStockAdjustment;
 
     #endregion
 
@@ -82,10 +135,34 @@ public partial class QuickActionsSettingsModalViewModel : ViewModelBase
         var globalSettings = App.SettingsService?.GlobalSettings;
         if (globalSettings != null)
         {
-            ShowNewExpense = globalSettings.Ui.QuickActions.ShowNewExpense;
-            ShowNewSale = globalSettings.Ui.QuickActions.ShowNewSale;
-            ShowCreateInvoice = globalSettings.Ui.QuickActions.ShowCreateInvoice;
-            ShowNewRental = globalSettings.Ui.QuickActions.ShowNewRental;
+            var qa = globalSettings.Ui.QuickActions;
+
+            // Primary actions
+            ShowNewInvoice = qa.ShowNewInvoice;
+            ShowNewExpense = qa.ShowNewExpense;
+            ShowNewRevenue = qa.ShowNewRevenue;
+            ShowScanReceipt = qa.ShowScanReceipt;
+
+            // Contact actions
+            ShowNewCustomer = qa.ShowNewCustomer;
+            ShowNewSupplier = qa.ShowNewSupplier;
+
+            // Product & Inventory actions
+            ShowNewProduct = qa.ShowNewProduct;
+            ShowRecordPayment = qa.ShowRecordPayment;
+
+            // Rental actions
+            ShowNewRentalItem = qa.ShowNewRentalItem;
+            ShowNewRentalRecord = qa.ShowNewRentalRecord;
+
+            // Organization actions
+            ShowNewCategory = qa.ShowNewCategory;
+            ShowNewDepartment = qa.ShowNewDepartment;
+            ShowNewLocation = qa.ShowNewLocation;
+
+            // Order & Stock actions
+            ShowNewPurchaseOrder = qa.ShowNewPurchaseOrder;
+            ShowNewStockAdjustment = qa.ShowNewStockAdjustment;
         }
     }
 
@@ -94,10 +171,34 @@ public partial class QuickActionsSettingsModalViewModel : ViewModelBase
         var globalSettings = App.SettingsService?.GlobalSettings;
         if (globalSettings != null)
         {
-            globalSettings.Ui.QuickActions.ShowNewExpense = ShowNewExpense;
-            globalSettings.Ui.QuickActions.ShowNewSale = ShowNewSale;
-            globalSettings.Ui.QuickActions.ShowCreateInvoice = ShowCreateInvoice;
-            globalSettings.Ui.QuickActions.ShowNewRental = ShowNewRental;
+            var qa = globalSettings.Ui.QuickActions;
+
+            // Primary actions
+            qa.ShowNewInvoice = ShowNewInvoice;
+            qa.ShowNewExpense = ShowNewExpense;
+            qa.ShowNewRevenue = ShowNewRevenue;
+            qa.ShowScanReceipt = ShowScanReceipt;
+
+            // Contact actions
+            qa.ShowNewCustomer = ShowNewCustomer;
+            qa.ShowNewSupplier = ShowNewSupplier;
+
+            // Product & Inventory actions
+            qa.ShowNewProduct = ShowNewProduct;
+            qa.ShowRecordPayment = ShowRecordPayment;
+
+            // Rental actions
+            qa.ShowNewRentalItem = ShowNewRentalItem;
+            qa.ShowNewRentalRecord = ShowNewRentalRecord;
+
+            // Organization actions
+            qa.ShowNewCategory = ShowNewCategory;
+            qa.ShowNewDepartment = ShowNewDepartment;
+            qa.ShowNewLocation = ShowNewLocation;
+
+            // Order & Stock actions
+            qa.ShowNewPurchaseOrder = ShowNewPurchaseOrder;
+            qa.ShowNewStockAdjustment = ShowNewStockAdjustment;
 
             await App.SettingsService!.SaveGlobalSettingsAsync();
         }

--- a/ArgoBooks/ViewModels/QuickActionsSettingsModalViewModel.cs
+++ b/ArgoBooks/ViewModels/QuickActionsSettingsModalViewModel.cs
@@ -1,0 +1,107 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ArgoBooks.ViewModels;
+
+/// <summary>
+/// ViewModel for the quick actions settings modal.
+/// Allows users to configure which quick actions are visible on the dashboard.
+/// </summary>
+public partial class QuickActionsSettingsModalViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    private bool _isOpen;
+
+    #region Quick Action Visibility
+
+    [ObservableProperty]
+    private bool _showNewExpense = true;
+
+    [ObservableProperty]
+    private bool _showNewSale = true;
+
+    [ObservableProperty]
+    private bool _showCreateInvoice = true;
+
+    [ObservableProperty]
+    private bool _showNewRental = true;
+
+    #endregion
+
+    /// <summary>
+    /// Event raised when settings are saved.
+    /// </summary>
+    public event EventHandler? SettingsSaved;
+
+    /// <summary>
+    /// Default constructor.
+    /// </summary>
+    public QuickActionsSettingsModalViewModel()
+    {
+        LoadSettings();
+    }
+
+    #region Commands
+
+    /// <summary>
+    /// Opens the quick actions settings modal.
+    /// </summary>
+    [RelayCommand]
+    private void Open()
+    {
+        LoadSettings();
+        IsOpen = true;
+    }
+
+    /// <summary>
+    /// Closes the quick actions settings modal without saving.
+    /// </summary>
+    [RelayCommand]
+    private void Close()
+    {
+        IsOpen = false;
+    }
+
+    /// <summary>
+    /// Saves the quick actions settings and closes the modal.
+    /// </summary>
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        await SaveSettingsAsync();
+        SettingsSaved?.Invoke(this, EventArgs.Empty);
+        IsOpen = false;
+    }
+
+    #endregion
+
+    #region Settings Persistence
+
+    private void LoadSettings()
+    {
+        var globalSettings = App.SettingsService?.GlobalSettings;
+        if (globalSettings != null)
+        {
+            ShowNewExpense = globalSettings.Ui.QuickActions.ShowNewExpense;
+            ShowNewSale = globalSettings.Ui.QuickActions.ShowNewSale;
+            ShowCreateInvoice = globalSettings.Ui.QuickActions.ShowCreateInvoice;
+            ShowNewRental = globalSettings.Ui.QuickActions.ShowNewRental;
+        }
+    }
+
+    private async Task SaveSettingsAsync()
+    {
+        var globalSettings = App.SettingsService?.GlobalSettings;
+        if (globalSettings != null)
+        {
+            globalSettings.Ui.QuickActions.ShowNewExpense = ShowNewExpense;
+            globalSettings.Ui.QuickActions.ShowNewSale = ShowNewSale;
+            globalSettings.Ui.QuickActions.ShowCreateInvoice = ShowCreateInvoice;
+            globalSettings.Ui.QuickActions.ShowNewRental = ShowNewRental;
+
+            await App.SettingsService!.SaveGlobalSettingsAsync();
+        }
+    }
+
+    #endregion
+}

--- a/ArgoBooks/Views/AppShell.axaml
+++ b/ArgoBooks/Views/AppShell.axaml
@@ -166,5 +166,8 @@
 
         <!-- Unsaved Changes Dialog -->
         <modals:UnsavedChangesDialog DataContext="{Binding UnsavedChangesDialogViewModel}" />
+
+        <!-- Quick Actions Settings Modal -->
+        <modals:QuickActionsSettingsModal DataContext="{Binding QuickActionsSettingsModalViewModel}" />
     </Panel>
 </UserControl>

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -170,8 +170,14 @@
                     </Grid>
 
                     <!-- Responsive WrapPanel for Quick Actions -->
-                    <WrapPanel HorizontalAlignment="Center" Orientation="Horizontal">
-                        <!-- New Invoice -->
+                    <ItemsControl>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.Items>
+                            <!-- New Invoice -->
                         <Button Classes="quick-action-compact" Margin="6" Width="160"
                                 Command="{Binding NewInvoiceCommand}"
                                 IsVisible="{Binding ShowNewInvoice}">
@@ -380,7 +386,8 @@
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
-                    </WrapPanel>
+                        </ItemsControl.Items>
+                    </ItemsControl>
                 </StackPanel>
             </Border>
 

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -126,12 +126,23 @@
             </controls:StatCardsRow>
 
             <!-- Quick Actions Section -->
-            <Border Classes="card" Padding="20">
+            <Border Classes="card" Padding="20" IsVisible="{Binding HasVisibleQuickActions}">
                 <StackPanel Spacing="16">
-                    <TextBlock Text="{loc:Loc 'Quick Actions'}"
-                               FontSize="16"
-                               FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Grid.Column="0"
+                                   Text="{loc:Loc 'Quick Actions'}"
+                                   FontSize="16"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                        <Button Grid.Column="1"
+                                Classes="icon-button"
+                                ToolTip.Tip="{loc:Loc 'Configure Quick Actions'}"
+                                Command="{Binding OpenQuickActionsSettingsCommand}">
+                            <PathIcon Data="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+                                      Width="16" Height="16"
+                                      Foreground="{DynamicResource TextSecondaryBrush}" />
+                        </Button>
+                    </Grid>
 
                     <Grid ColumnDefinitions="*,*,*,*">
                         <!-- New Expense -->
@@ -139,7 +150,8 @@
                                 Classes="quick-action"
                                 Margin="0,0,6,0"
                                 Command="{Binding AddExpenseCommand}"
-                                HorizontalAlignment="Stretch">
+                                HorizontalAlignment="Stretch"
+                                IsVisible="{Binding ShowNewExpense}">
                             <Grid ColumnDefinitions="Auto,*">
                                 <Border Grid.Column="0"
                                         Width="4"
@@ -168,7 +180,8 @@
                                 Classes="quick-action"
                                 Margin="6,0,6,0"
                                 Command="{Binding RecordSaleCommand}"
-                                HorizontalAlignment="Stretch">
+                                HorizontalAlignment="Stretch"
+                                IsVisible="{Binding ShowNewSale}">
                             <Grid ColumnDefinitions="Auto,*">
                                 <Border Grid.Column="0"
                                         Width="4"
@@ -197,7 +210,8 @@
                                 Classes="quick-action"
                                 Margin="6,0,6,0"
                                 Command="{Binding CreateInvoiceCommand}"
-                                HorizontalAlignment="Stretch">
+                                HorizontalAlignment="Stretch"
+                                IsVisible="{Binding ShowCreateInvoice}">
                             <Grid ColumnDefinitions="Auto,*">
                                 <Border Grid.Column="0"
                                         Width="4"
@@ -226,7 +240,8 @@
                                 Classes="quick-action"
                                 Margin="6,0,0,0"
                                 Command="{Binding NewRentalCommand}"
-                                HorizontalAlignment="Stretch">
+                                HorizontalAlignment="Stretch"
+                                IsVisible="{Binding ShowNewRental}">
                             <Grid ColumnDefinitions="Auto,*">
                                 <Border Grid.Column="0"
                                         Width="4"

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -33,6 +33,31 @@
             <Setter Property="Background" Value="{DynamicResource SurfaceActiveBrush}" />
         </Style>
 
+        <!-- Compact Quick Action Button Style for responsive layout -->
+        <Style Selector="Button.quick-action-compact">
+            <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="12,10" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Transitions">
+                <Transitions>
+                    <BrushTransition Property="Background" Duration="0:0:0.15" />
+                    <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.15" Easing="CubicEaseOut" />
+                </Transitions>
+            </Setter>
+        </Style>
+        <Style Selector="Button.quick-action-compact:pointerover">
+            <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+            <Setter Property="RenderTransform" Value="scale(1.02)" />
+        </Style>
+        <Style Selector="Button.quick-action-compact:pressed">
+            <Setter Property="Background" Value="{DynamicResource SurfaceActiveBrush}" />
+            <Setter Property="RenderTransform" Value="scale(0.98)" />
+        </Style>
+
         <!-- Card Style -->
         <Style Selector="Border.card">
             <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
@@ -144,127 +169,218 @@
                         </Button>
                     </Grid>
 
-                    <Grid ColumnDefinitions="*,*,*,*">
+                    <!-- Responsive WrapPanel for Quick Actions -->
+                    <WrapPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                        <!-- New Invoice -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewInvoiceCommand}"
+                                IsVisible="{Binding ShowNewInvoice}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource WarningIconBgBrush}">
+                                    <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                              Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Invoice'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
                         <!-- New Expense -->
-                        <Button Grid.Column="0"
-                                Classes="quick-action"
-                                Margin="0,0,6,0"
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
                                 Command="{Binding AddExpenseCommand}"
-                                HorizontalAlignment="Stretch"
                                 IsVisible="{Binding ShowNewExpense}">
-                            <Grid ColumnDefinitions="Auto,*">
-                                <Border Grid.Column="0"
-                                        Width="4"
-                                        CornerRadius="2"
-                                        Background="{DynamicResource DangerBrush}"
-                                        Margin="0,0,14,0" />
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="4">
-                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                                                  Width="18" Height="18"
-                                                  Foreground="{DynamicResource DangerBrush}" />
-                                        <TextBlock Text="{loc:Loc 'New Expense'}"
-                                                   FontSize="14"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    </StackPanel>
-                                    <TextBlock Text="{loc:Loc 'Record an expense'}"
-                                               FontSize="12"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                </StackPanel>
-                            </Grid>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource DangerIconBgBrush}">
+                                    <PathIcon Data="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                                              Width="16" Height="16" Foreground="{DynamicResource DangerBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Expense'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
                         </Button>
 
-                        <!-- Record Sale -->
-                        <Button Grid.Column="1"
-                                Classes="quick-action"
-                                Margin="6,0,6,0"
+                        <!-- New Revenue -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
                                 Command="{Binding RecordSaleCommand}"
-                                HorizontalAlignment="Stretch"
-                                IsVisible="{Binding ShowNewSale}">
-                            <Grid ColumnDefinitions="Auto,*">
-                                <Border Grid.Column="0"
-                                        Width="4"
-                                        CornerRadius="2"
-                                        Background="{DynamicResource SuccessBrush}"
-                                        Margin="0,0,14,0" />
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="4">
-                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.91s4.18 1.39 4.18 3.91c-.01 1.83-1.38 2.83-3.12 3.16z"
-                                                  Width="18" Height="18"
-                                                  Foreground="{DynamicResource SuccessBrush}" />
-                                        <TextBlock Text="{loc:Loc 'New Sale'}"
-                                                   FontSize="14"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    </StackPanel>
-                                    <TextBlock Text="{loc:Loc 'Record revenue'}"
-                                               FontSize="12"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                </StackPanel>
-                            </Grid>
+                                IsVisible="{Binding ShowNewRevenue}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource SuccessIconBgBrush}">
+                                    <PathIcon Data="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                                              Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Revenue'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
                         </Button>
 
-                        <!-- Create Invoice -->
-                        <Button Grid.Column="2"
-                                Classes="quick-action"
-                                Margin="6,0,6,0"
-                                Command="{Binding CreateInvoiceCommand}"
-                                HorizontalAlignment="Stretch"
-                                IsVisible="{Binding ShowCreateInvoice}">
-                            <Grid ColumnDefinitions="Auto,*">
-                                <Border Grid.Column="0"
-                                        Width="4"
-                                        CornerRadius="2"
-                                        Background="{DynamicResource WarningBrush}"
-                                        Margin="0,0,14,0" />
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="4">
-                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
-                                                  Width="18" Height="18"
-                                                  Foreground="{DynamicResource WarningBrush}" />
-                                        <TextBlock Text="{loc:Loc 'Create Invoice'}"
-                                                   FontSize="14"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    </StackPanel>
-                                    <TextBlock Text="{loc:Loc 'Bill a customer'}"
-                                               FontSize="12"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                </StackPanel>
-                            </Grid>
+                        <!-- Scan Receipt -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding ScanReceiptCommand}"
+                                IsVisible="{Binding ShowScanReceipt}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource InfoIconBgBrush}">
+                                    <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                              Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'Scan Receipt'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
                         </Button>
 
-                        <!-- New Rental -->
-                        <Button Grid.Column="3"
-                                Classes="quick-action"
-                                Margin="6,0,0,0"
+                        <!-- New Customer -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewCustomerCommand}"
+                                IsVisible="{Binding ShowNewCustomer}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource PrimaryIconBgBrush}">
+                                    <PathIcon Data="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                                              Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Customer'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- New Supplier -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewSupplierCommand}"
+                                IsVisible="{Binding ShowNewSupplier}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource PrimaryIconBgBrush}">
+                                    <PathIcon Data="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4z"
+                                              Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Supplier'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- New Product -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewProductCommand}"
+                                IsVisible="{Binding ShowNewProduct}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource SuccessIconBgBrush}">
+                                    <PathIcon Data="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+                                              Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Product'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- Record Payment -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding RecordPaymentCommand}"
+                                IsVisible="{Binding ShowRecordPayment}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource SuccessIconBgBrush}">
+                                    <PathIcon Data="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
+                                              Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'Record Payment'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- New Rental Item -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewRentalItemCommand}"
+                                IsVisible="{Binding ShowNewRentalItem}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource InfoIconBgBrush}">
+                                    <PathIcon Data="M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zM7 4V3h10v1H7zm0 14V6h10v12H7zm0 3v-1h10v1H7z"
+                                              Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Rental Item'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- New Rental Record -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
                                 Command="{Binding NewRentalCommand}"
-                                HorizontalAlignment="Stretch"
-                                IsVisible="{Binding ShowNewRental}">
-                            <Grid ColumnDefinitions="Auto,*">
-                                <Border Grid.Column="0"
-                                        Width="4"
-                                        CornerRadius="2"
-                                        Background="{DynamicResource InfoBrush}"
-                                        Margin="0,0,14,0" />
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="4">
-                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"
-                                                  Width="18" Height="18"
-                                                  Foreground="{DynamicResource InfoBrush}" />
-                                        <TextBlock Text="{loc:Loc 'New Rental'}"
-                                                   FontSize="14"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    </StackPanel>
-                                    <TextBlock Text="{loc:Loc 'Start a rental'}"
-                                               FontSize="12"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                </StackPanel>
-                            </Grid>
+                                IsVisible="{Binding ShowNewRentalRecord}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource InfoIconBgBrush}">
+                                    <PathIcon Data="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z"
+                                              Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Rental'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
                         </Button>
-                    </Grid>
+
+                        <!-- New Category -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewCategoryCommand}"
+                                IsVisible="{Binding ShowNewCategory}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource WarningIconBgBrush}">
+                                    <PathIcon Data="M12 2l-5.5 9h11L12 2zm0 3.84L13.93 9h-3.87L12 5.84z"
+                                              Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Category'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- New Department -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewDepartmentCommand}"
+                                IsVisible="{Binding ShowNewDepartment}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource WarningIconBgBrush}">
+                                    <PathIcon Data="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                                              Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Department'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- New Location -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewLocationCommand}"
+                                IsVisible="{Binding ShowNewLocation}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource WarningIconBgBrush}">
+                                    <PathIcon Data="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+                                              Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'New Location'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- New Purchase Order -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewPurchaseOrderCommand}"
+                                IsVisible="{Binding ShowNewPurchaseOrder}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource PrimaryIconBgBrush}">
+                                    <PathIcon Data="M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6-2c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm6 16H6V8h2v2c0 .55.45 1 1 1s1-.45 1-1V8h4v2c0 .55.45 1 1 1s1-.45 1-1V8h2v12z"
+                                              Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'Purchase Order'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+
+                        <!-- New Stock Adjustment -->
+                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                                Command="{Binding NewStockAdjustmentCommand}"
+                                IsVisible="{Binding ShowNewStockAdjustment}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource PrimaryIconBgBrush}">
+                                    <PathIcon Data="M19 3H14.82C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
+                                              Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                </Border>
+                                <TextBlock Text="{loc:Loc 'Stock Adjustment'}" FontSize="13" FontWeight="Medium"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                    </WrapPanel>
                 </StackPanel>
             </Border>
 


### PR DESCRIPTION
Summary:
- Add a gear/settings icon to the top right of the quick actions container on the dashboard
- Click the icon to open a modal that allows configuring which quick actions are visible
- Support for all 15 quick actions with animated toggle buttons grouped by category
- Quick actions auto-center and wrap responsively with proper per-row centering using ItemsRepeater with UniformGridLayout
- Add "Reset All" button to restore default visibility settings