### PR TITLE
Fix modal styling, stock adjustment UI, and welcome screen dragging

### DIFF
--- a/ArgoBooks/Controls/SearchableDropdown.axaml
+++ b/ArgoBooks/Controls/SearchableDropdown.axaml
@@ -14,6 +14,7 @@
         <converters:HighlightBrushMultiConverter x:Key="HighlightBrushMultiConverter" />
         <converters:HighlightBorderBrushMultiConverter x:Key="HighlightBorderBrushMultiConverter" />
         <converters:HighlightBorderThicknessMultiConverter x:Key="HighlightBorderThicknessMultiConverter" />
+        <converters:DisplayMemberMultiConverter x:Key="DisplayMemberMultiConverter" />
     </UserControl.Resources>
 
     <StackPanel Spacing="4">
@@ -187,7 +188,14 @@
                                                     <Binding Path="$parent[controls:SearchableDropdown].HighlightedItem" />
                                                 </MultiBinding>
                                             </Button.BorderThickness>
-                                            <TextBlock Text="{Binding}" />
+                                            <TextBlock>
+                                                <TextBlock.Text>
+                                                    <MultiBinding Converter="{StaticResource DisplayMemberMultiConverter}">
+                                                        <Binding Path="." />
+                                                        <Binding Path="$parent[controls:SearchableDropdown].DisplayMemberPath" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
                                         </Button>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
@@ -228,7 +236,14 @@
                                                     <Binding Path="$parent[controls:SearchableDropdown].HighlightedItem" />
                                                 </MultiBinding>
                                             </Button.BorderThickness>
-                                            <TextBlock Text="{Binding}" />
+                                            <TextBlock>
+                                                <TextBlock.Text>
+                                                    <MultiBinding Converter="{StaticResource DisplayMemberMultiConverter}">
+                                                        <Binding Path="." />
+                                                        <Binding Path="$parent[controls:SearchableDropdown].DisplayMemberPath" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
                                         </Button>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>

--- a/ArgoBooks/Converters/CategoriesConverters.cs
+++ b/ArgoBooks/Converters/CategoriesConverters.cs
@@ -97,7 +97,7 @@ public static class BoolConverters
 
     /// <summary>
     /// Converts bool (hasError) to border brush.
-    /// Error = red (#dc2626), No error = transparent.
+    /// Error = red (#dc2626), No error = default border color.
     /// </summary>
     public static readonly IValueConverter ToErrorBorderBrush =
         new FuncValueConverter<bool, IBrush>(value =>
@@ -112,7 +112,14 @@ public static class BoolConverters
                 }
                 return new SolidColorBrush(Color.Parse("#dc2626"));
             }
-            return Brushes.Transparent;
+            // Return BorderBrush for no error state to preserve the control's default border
+            if (Application.Current?.Resources != null &&
+                Application.Current.Resources.TryGetResource("BorderBrush", Application.Current.ActualThemeVariant, out var borderResource) &&
+                borderResource is IBrush borderBrush)
+            {
+                return borderBrush;
+            }
+            return new SolidColorBrush(Color.Parse("#e5e7eb"));
         });
 
     /// <summary>

--- a/ArgoBooks/Converters/StringEqualsConverter.cs
+++ b/ArgoBooks/Converters/StringEqualsConverter.cs
@@ -259,3 +259,30 @@ public class ThemeBorderBrushConverter : IValueConverter
         throw new NotImplementedException();
     }
 }
+
+/// <summary>
+/// Multi-value converter that returns the display text for an item using the DisplayMemberPath.
+/// Values[0] = the item, Values[1] = the DisplayMemberPath string.
+/// Uses reflection to get the property value specified by DisplayMemberPath.
+/// </summary>
+public class DisplayMemberMultiConverter : IMultiValueConverter
+{
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Count < 2)
+            return values.Count > 0 ? values[0]?.ToString() ?? string.Empty : string.Empty;
+
+        var item = values[0];
+        var displayMemberPath = values[1] as string;
+
+        if (item == null)
+            return string.Empty;
+
+        if (string.IsNullOrEmpty(displayMemberPath))
+            return item.ToString() ?? string.Empty;
+
+        // Use reflection to get the property value
+        var property = item.GetType().GetProperty(displayMemberPath);
+        return property?.GetValue(item)?.ToString() ?? item.ToString() ?? string.Empty;
+    }
+}

--- a/ArgoBooks/Modals/ExpenseModals.axaml
+++ b/ArgoBooks/Modals/ExpenseModals.axaml
@@ -582,7 +582,7 @@
                     <Border Padding="24,16" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="12">
                             <Button Classes="secondary-button" Content="{loc:Loc 'Cancel'}" Command="{Binding CloseItemStatusModalCommand}" />
-                            <Button Classes="warning-button" Content="{Binding ItemStatusSaveButtonText}" Command="{Binding ConfirmItemStatusCommand}" />
+                            <Button Classes="primary-button" Content="{Binding ItemStatusSaveButtonText}" Command="{Binding ConfirmItemStatusCommand}" />
                         </StackPanel>
                     </Border>
                 </StackPanel>

--- a/ArgoBooks/Modals/RevenueModals.axaml
+++ b/ArgoBooks/Modals/RevenueModals.axaml
@@ -593,7 +593,7 @@
                     <Border Padding="24,16" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="12">
                             <Button Classes="secondary-button" Content="{loc:Loc 'Cancel'}" Command="{Binding CloseItemStatusModalCommand}" />
-                            <Button Classes="warning-button" Content="{Binding ItemStatusSaveButtonText}" Command="{Binding ConfirmItemStatusCommand}" />
+                            <Button Classes="primary-button" Content="{Binding ItemStatusSaveButtonText}" Command="{Binding ConfirmItemStatusCommand}" />
                         </StackPanel>
                     </Border>
                 </StackPanel>

--- a/ArgoBooks/Modals/StockAdjustmentsModals.axaml
+++ b/ArgoBooks/Modals/StockAdjustmentsModals.axaml
@@ -80,6 +80,7 @@
                                     <TextBlock Text="{loc:Loc 'Current Stock'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding CurrentStock}"
                                              IsReadOnly="True"
+                                             IsEnabled="False"
                                              Classes="form-input"
                                              Background="{DynamicResource SurfaceAltBrush}" />
                                 </StackPanel>
@@ -99,6 +100,7 @@
                                     <TextBlock Text="{loc:Loc 'New Stock'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding CalculatedNewStock}"
                                              IsReadOnly="True"
+                                             IsEnabled="False"
                                              Classes="form-input"
                                              Background="{DynamicResource SurfaceAltBrush}" />
                                 </StackPanel>

--- a/ArgoBooks/Modals/StockAdjustmentsModals.axaml
+++ b/ArgoBooks/Modals/StockAdjustmentsModals.axaml
@@ -78,11 +78,14 @@
                                 <!-- Current Stock -->
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Current Stock'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding CurrentStock}"
-                                             IsReadOnly="True"
-                                             IsEnabled="False"
-                                             Classes="form-input"
-                                             Background="{DynamicResource SurfaceAltBrush}" />
+                                    <Border Background="{DynamicResource SurfaceAltBrush}"
+                                            CornerRadius="6"
+                                            Padding="12,10"
+                                            MinHeight="40">
+                                        <TextBlock Text="{Binding CurrentStock}"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                                   VerticalAlignment="Center" />
+                                    </Border>
                                 </StackPanel>
 
                                 <!-- Adjustment Quantity -->
@@ -98,11 +101,14 @@
                                 <!-- New Stock Level -->
                                 <StackPanel Grid.Column="4" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'New Stock'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding CalculatedNewStock}"
-                                             IsReadOnly="True"
-                                             IsEnabled="False"
-                                             Classes="form-input"
-                                             Background="{DynamicResource SurfaceAltBrush}" />
+                                    <Border Background="{DynamicResource SurfaceAltBrush}"
+                                            CornerRadius="6"
+                                            Padding="12,10"
+                                            MinHeight="40">
+                                        <TextBlock Text="{Binding CalculatedNewStock}"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                                   VerticalAlignment="Center" />
+                                    </Border>
                                 </StackPanel>
                             </Grid>
 

--- a/ArgoBooks/Modals/StockLevelsModals.axaml
+++ b/ArgoBooks/Modals/StockLevelsModals.axaml
@@ -60,11 +60,14 @@
                                 <!-- Current Stock -->
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Current Stock'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding CurrentStock}"
-                                             IsReadOnly="True"
-                                             IsEnabled="False"
-                                             Classes="form-input"
-                                             Background="{DynamicResource SurfaceAltBrush}" />
+                                    <Border Background="{DynamicResource SurfaceAltBrush}"
+                                            CornerRadius="6"
+                                            Padding="12,10"
+                                            MinHeight="40">
+                                        <TextBlock Text="{Binding CurrentStock}"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                                   VerticalAlignment="Center" />
+                                    </Border>
                                 </StackPanel>
 
                                 <!-- Adjustment Quantity -->
@@ -80,11 +83,14 @@
                                 <!-- New Stock Level -->
                                 <StackPanel Grid.Column="4" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'New Stock'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding CalculatedNewStock}"
-                                             IsReadOnly="True"
-                                             IsEnabled="False"
-                                             Classes="form-input"
-                                             Background="{DynamicResource SurfaceAltBrush}" />
+                                    <Border Background="{DynamicResource SurfaceAltBrush}"
+                                            CornerRadius="6"
+                                            Padding="12,10"
+                                            MinHeight="40">
+                                        <TextBlock Text="{Binding CalculatedNewStock}"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                                   VerticalAlignment="Center" />
+                                    </Border>
                                 </StackPanel>
                             </Grid>
 

--- a/ArgoBooks/Modals/StockLevelsModals.axaml
+++ b/ArgoBooks/Modals/StockLevelsModals.axaml
@@ -15,7 +15,7 @@
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
-                    BorderThickness="1" CornerRadius="12" Width="500"
+                    BorderThickness="1" CornerRadius="12" Width="550"
                     HorizontalAlignment="Center" VerticalAlignment="Center">
                 <Grid RowDefinitions="Auto,*,Auto">
                     <!-- Modal Header -->
@@ -55,12 +55,14 @@
                                 </ComboBox>
                             </StackPanel>
 
-                            <!-- Current Stock (Read-only) -->
-                            <Grid ColumnDefinitions="*,16,*">
+                            <!-- Stock Values Row -->
+                            <Grid ColumnDefinitions="*,16,*,16,*">
+                                <!-- Current Stock -->
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Current Stock'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding CurrentStock}"
                                              IsReadOnly="True"
+                                             IsEnabled="False"
                                              Classes="form-input"
                                              Background="{DynamicResource SurfaceAltBrush}" />
                                 </StackPanel>
@@ -74,16 +76,17 @@
                                              Classes="form-input"
                                              Watermark="{loc:Loc 'Enter quantity'}" />
                                 </StackPanel>
-                            </Grid>
 
-                            <!-- New Stock Level (Calculated, Read-only) -->
-                            <StackPanel Spacing="6">
-                                <TextBlock Text="{loc:Loc 'New Stock Level'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <TextBox Text="{Binding CalculatedNewStock}"
-                                         IsReadOnly="True"
-                                         Classes="form-input"
-                                         Background="{DynamicResource SurfaceAltBrush}" />
-                            </StackPanel>
+                                <!-- New Stock Level -->
+                                <StackPanel Grid.Column="4" Spacing="6">
+                                    <TextBlock Text="{loc:Loc 'New Stock'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <TextBox Text="{Binding CalculatedNewStock}"
+                                             IsReadOnly="True"
+                                             IsEnabled="False"
+                                             Classes="form-input"
+                                             Background="{DynamicResource SurfaceAltBrush}" />
+                                </StackPanel>
+                            </Grid>
 
                             <!-- Reason/Notes -->
                             <StackPanel Spacing="6">
@@ -163,7 +166,7 @@
                                     <TextBlock Text="{loc:Loc SKU}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding AddItemSku, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Auto-generated if empty'}" />
+                                             Watermark="{loc:Loc 'Enter SKU (optional)'}" />
                                 </StackPanel>
 
                                 <StackPanel Grid.Column="2" Spacing="6">

--- a/ArgoBooks/ViewModels/StockLevelsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/StockLevelsModalsViewModel.cs
@@ -301,7 +301,7 @@ public partial class StockLevelsModalsViewModel : ViewModelBase
         if (companyData == null) return;
 
         AvailableProducts.Clear();
-        foreach (var product in companyData.Products.Where(p => p.Type == CategoryType.Purchase))
+        foreach (var product in companyData.Products)
         {
             AvailableProducts.Add(product);
         }
@@ -390,7 +390,7 @@ public partial class StockLevelsModalsViewModel : ViewModelBase
         {
             Id = newId,
             ProductId = SelectedProduct.Id,
-            Sku = string.IsNullOrWhiteSpace(AddItemSku) ? SelectedProduct.Sku : AddItemSku.Trim(),
+            Sku = AddItemSku.Trim(),
             LocationId = SelectedLocation.Id,
             InStock = quantity,
             Reserved = 0,

--- a/ArgoBooks/Views/StockLevelsPage.axaml
+++ b/ArgoBooks/Views/StockLevelsPage.axaml
@@ -127,19 +127,6 @@
                                     </StackPanel>
                                 </Button>
 
-                                <!-- Adjust Stock Button -->
-                                <Button Classes="secondary-button"
-                                        Classes.compact="{Binding ResponsiveHeader.IsCompactMode}"
-                                        Classes.medium="{Binding ResponsiveHeader.IsMediumMode}"
-                                        Command="{Binding OpenBulkAdjustModalCommand}"
-                                        ToolTip.Tip="{loc:Loc 'Adjust Stock'}">
-                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"
-                                                  Width="16" Height="16" />
-                                        <TextBlock Text="{loc:Loc 'Adjust Stock'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
-                                    </StackPanel>
-                                </Button>
-
                                 <!-- Add Item Button -->
                                 <Button Classes="primary-button"
                                         Classes.compact="{Binding ResponsiveHeader.IsCompactMode}"

--- a/ArgoBooks/Views/WelcomeScreen.axaml
+++ b/ArgoBooks/Views/WelcomeScreen.axaml
@@ -18,6 +18,14 @@
         <Border Background="{DynamicResource BackgroundSecondaryBrush}"
                 Opacity="0.5" />
 
+        <!-- Window Drag Region (at top, behind content but interactive) -->
+        <Border x:Name="TitleBarDragRegion"
+                Height="40"
+                VerticalAlignment="Top"
+                Background="Transparent"
+                IsHitTestVisible="True"
+                ZIndex="1" />
+
         <!-- Main Content -->
         <ScrollViewer x:Name="MainScrollViewer"
                       HorizontalScrollBarVisibility="Disabled"

--- a/ArgoBooks/Views/WelcomeScreen.axaml.cs
+++ b/ArgoBooks/Views/WelcomeScreen.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 
 namespace ArgoBooks.Views;
 
@@ -11,6 +12,36 @@ public partial class WelcomeScreen : UserControl
     public WelcomeScreen()
     {
         InitializeComponent();
+
+        // Set up window drag behavior for the title bar region
+        var dragRegion = this.FindControl<Border>("TitleBarDragRegion");
+        if (dragRegion != null)
+        {
+            dragRegion.PointerPressed += OnTitleBarPointerPressed;
+        }
+    }
+
+    private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            // Find the parent window
+            var window = TopLevel.GetTopLevel(this) as Window;
+            if (window == null) return;
+
+            // Double-click to maximize/restore
+            if (e.ClickCount == 2)
+            {
+                window.WindowState = window.WindowState == WindowState.Maximized
+                    ? WindowState.Normal
+                    : WindowState.Maximized;
+            }
+            else
+            {
+                // Single click to start drag
+                window.BeginMoveDrag(e);
+            }
+        }
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)


### PR DESCRIPTION
Summary:
- Fix ComboBox borders in mark as returned/lost modals by updating ToErrorBorderBrush converter
- Change mark buttons from warning (yellow) to primary (accent color)
- Remove 'Adjust Stock' button from stock levels page header
- Fix SearchableDropdown showing type names instead of product names (added DisplayMemberMultiConverter)
- Remove auto-generated SKU fallback when empty
- Fix adjust stock modal layout - all three stock controls now on same row
- Make both stock adjustment modals same width (550px)
- Replace TextBox with Border+TextBlock for read-only stock controls
- Fix window dragging on welcome screen by adding drag region