### PR TITLE
Add centralized Icons.cs for consistent SVG icon paths

### DIFF
--- a/ArgoBooks/Controls/ChartContextMenu.axaml
+++ b/ArgoBooks/Controls/ChartContextMenu.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="200" d:DesignHeight="200"
              x:Class="ArgoBooks.Controls.ChartContextMenu"
              x:DataType="controls:ChartContextMenu">
@@ -52,7 +53,7 @@
                     <Button Classes="context-menu-item"
                             Command="{Binding ExportToExcelCommand, RelativeSource={RelativeSource AncestorType=controls:ChartContextMenu}}">
                         <StackPanel Orientation="Horizontal" Spacing="10">
-                            <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                            <PathIcon Data="{x:Static local:Icons.Reports}"
                                       Width="16" Height="16"
                                       Foreground="{DynamicResource TextSecondaryBrush}" />
                             <TextBlock Text="{loc:Loc 'Export to Excel'}"
@@ -74,7 +75,7 @@
                     <Button Classes="context-menu-item"
                             Command="{Binding ResetChartZoomCommand, RelativeSource={RelativeSource AncestorType=controls:ChartContextMenu}}">
                         <StackPanel Orientation="Horizontal" Spacing="10">
-                            <PathIcon Data="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+                            <PathIcon Data="{x:Static local:Icons.Undo}"
                                       Width="16" Height="16"
                                       Foreground="{DynamicResource TextSecondaryBrush}" />
                             <TextBlock Text="{loc:Loc 'Reset Zoom'}"

--- a/ArgoBooks/Controls/ChartTypeSelector.axaml
+++ b/ArgoBooks/Controls/ChartTypeSelector.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="200" d:DesignHeight="40"
              x:Class="ArgoBooks.Controls.ChartTypeSelector"
              x:CompileBindings="False">
@@ -10,7 +11,7 @@
     <StackPanel Orientation="Horizontal"
                 Spacing="8"
                 VerticalAlignment="Center">
-        <PathIcon Data="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z"
+        <PathIcon Data="{x:Static local:Icons.Analytics}"
                   Width="16" Height="16"
                   Foreground="{DynamicResource TextSecondaryBrush}" />
         <ComboBox ItemsSource="{Binding ChartTypeOptions}"

--- a/ArgoBooks/Controls/Header.axaml
+++ b/ArgoBooks/Controls/Header.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="60"
              x:Class="ArgoBooks.Controls.Header"
              x:DataType="vm:HeaderViewModel">
@@ -32,7 +33,7 @@
                 <Grid ColumnDefinitions="Auto,*,Auto">
                     <!-- Search Icon -->
                     <PathIcon Grid.Column="0"
-                              Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                              Data="{x:Static local:Icons.Search}"
                               Width="16" Height="16"
                               Foreground="{DynamicResource TextTertiaryBrush}"
                               Margin="15,0,10,0"
@@ -71,7 +72,7 @@
                 <Button Classes="header-icon"
                         Command="{Binding OpenFileMenuCommand}"
                         ToolTip.Tip="{loc:Loc File}">
-                    <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                    <PathIcon Data="{x:Static local:Icons.Reports}"
                               Width="18" Height="18" />
                 </Button>
 
@@ -85,7 +86,7 @@
                     <Button Classes="header-icon"
                             Command="{Binding SaveCommand}"
                             ToolTip.Tip="{loc:Loc Save}">
-                        <PathIcon Data="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"
+                        <PathIcon Data="{x:Static local:Icons.Save}"
                                   Width="18" Height="18" />
                     </Button>
 
@@ -153,7 +154,7 @@
                         Command="{Binding OpenNotificationsCommand}"
                         ToolTip.Tip="{loc:Loc Notifications}">
                     <Panel>
-                        <PathIcon Data="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
+                        <PathIcon Data="{x:Static local:Icons.Notification}"
                                   Width="20" Height="20" />
                         <!-- Notification Badge -->
                         <Border Background="{DynamicResource DangerBrush}"
@@ -178,7 +179,7 @@
                 <Button Classes="header-icon"
                         Command="{Binding OpenHelpCommand}"
                         ToolTip.Tip="{loc:Loc Help}">
-                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                    <PathIcon Data="{x:Static local:Icons.Help}"
                               Width="20" Height="20" />
                 </Button>
 
@@ -186,7 +187,7 @@
                 <Button Classes="header-icon"
                         Command="{Binding OpenMyPlanCommand}"
                         ToolTip.Tip="{loc:Loc 'My Plan'}">
-                    <PathIcon Data="M12 1l3.09 6.26L22 8.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 1z"
+                    <PathIcon Data="{x:Static local:Icons.Star}"
                               Width="20" Height="20" />
                 </Button>
 
@@ -194,7 +195,7 @@
                 <Button Classes="header-icon"
                         Command="{Binding OpenSettingsCommand}"
                         ToolTip.Tip="{loc:Loc Settings}">
-                    <PathIcon Data="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+                    <PathIcon Data="{x:Static local:Icons.Settings}"
                               Width="20" Height="20" />
                 </Button>
 

--- a/ArgoBooks/Controls/PaginationFooter.axaml
+++ b/ArgoBooks/Controls/PaginationFooter.axaml
@@ -5,6 +5,7 @@
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="50"
              x:Class="ArgoBooks.Controls.PaginationFooter"
              x:DataType="controls:PaginationFooter"
@@ -53,7 +54,7 @@
                 <Button Classes="pagination-button"
                         Command="{Binding #Root.GoToPreviousPageCommand}"
                         IsEnabled="{Binding #Root.CanGoToPreviousPage}">
-                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                               Width="16" Height="16" />
                 </Button>
 
@@ -85,7 +86,7 @@
                 <Button Classes="pagination-button"
                         Command="{Binding #Root.GoToNextPageCommand}"
                         IsEnabled="{Binding #Root.CanGoToNextPage}">
-                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                               Width="16" Height="16" />
                 </Button>
             </StackPanel>

--- a/ArgoBooks/Controls/SearchableDropdown.axaml
+++ b/ArgoBooks/Controls/SearchableDropdown.axaml
@@ -5,6 +5,7 @@
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:converters="using:ArgoBooks.Converters"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="300"
              x:Class="ArgoBooks.Controls.SearchableDropdown"
              x:DataType="controls:SearchableDropdown"
@@ -130,7 +131,7 @@
                             IsVisible="{Binding $parent[controls:SearchableDropdown].ShowAddNew}"
                             Command="{Binding $parent[controls:SearchableDropdown].AddNewCommand}">
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                            <PathIcon Data="{x:Static local:Icons.Add}"
                                       Width="16" Height="16"
                                       Foreground="{DynamicResource PrimaryBrush}" />
                             <TextBlock Text="{Binding $parent[controls:SearchableDropdown].AddNewText}"

--- a/ArgoBooks/Controls/ToggleArrow.axaml
+++ b/ArgoBooks/Controls/ToggleArrow.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="24" d:DesignHeight="24"
              x:Class="ArgoBooks.Controls.ToggleArrow"
              x:DataType="controls:ToggleArrow"
@@ -10,7 +11,7 @@
 
     <!-- Left-pointing chevron arrow (Material Design chevron_left) -->
     <PathIcon x:Name="ArrowIcon"
-              Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+              Data="{x:Static local:Icons.ChevronLeft}"
               Width="{Binding IconSize, ElementName=Root}"
               Height="{Binding IconSize, ElementName=Root}"
               Foreground="{Binding Foreground, ElementName=Root}" />

--- a/ArgoBooks/Controls/UndoRedoButtonGroup.axaml
+++ b/ArgoBooks/Controls/UndoRedoButtonGroup.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="200" d:DesignHeight="50"
              x:Class="ArgoBooks.Controls.UndoRedoButtonGroup"
              x:CompileBindings="False">
@@ -29,7 +30,7 @@
                         ToolTip.Tip="{Binding UndoTooltip}"
                         Command="{Binding UndoCommand}"
                         IsEnabled="{Binding CanUndo}">
-                    <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                    <PathIcon Data="{x:Static local:Icons.Returns}"
                               Width="15" Height="15" />
                 </Button>
 
@@ -107,7 +108,7 @@
                                             Tag="{Binding Index}">
                                         <Grid ColumnDefinitions="Auto,*">
                                             <PathIcon Grid.Column="0"
-                                                      Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                                      Data="{x:Static local:Icons.Returns}"
                                                       Width="12" Height="12"
                                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                                       Margin="0,0,8,0" />

--- a/ArgoBooks/Icons.cs
+++ b/ArgoBooks/Icons.cs
@@ -164,6 +164,37 @@ public static class Icons
 
     #endregion
 
+    #region Common Actions
+
+    /// <summary>Plus/add icon.</summary>
+    public const string Add = "M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z";
+
+    /// <summary>Edit/pencil icon.</summary>
+    public const string Edit = "M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z";
+
+    /// <summary>Trash/delete icon.</summary>
+    public const string Delete = "M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z";
+
+    /// <summary>Close/X icon.</summary>
+    public const string Close = "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z";
+
+    /// <summary>Checkmark icon.</summary>
+    public const string Check = "M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z";
+
+    /// <summary>Download icon.</summary>
+    public const string Download = "M19 12v7H5v-7H3v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zm-6 .67l2.59-2.58L17 11.5l-5 5-5-5 1.41-1.41L11 12.67V3h2v9.67z";
+
+    /// <summary>Save/floppy disk icon.</summary>
+    public const string Save = "M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z";
+
+    /// <summary>Refresh/sync icon.</summary>
+    public const string Refresh = "M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z";
+
+    /// <summary>Search/magnifying glass icon.</summary>
+    public const string Search = "M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z";
+
+    #endregion
+
     #region UI Elements
 
     /// <summary>Chevron left icon for collapse/back.</summary>
@@ -172,11 +203,100 @@ public static class Icons
     /// <summary>Chevron right icon for expand/forward.</summary>
     public const string ChevronRight = "M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z";
 
+    /// <summary>Chevron right (alternate) for navigation.</summary>
+    public const string ChevronRightNav = "M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z";
+
     /// <summary>Chevron down icon for dropdown expanded.</summary>
     public const string ChevronDown = "M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z";
 
     /// <summary>Chevron up icon for dropdown collapsed.</summary>
     public const string ChevronUp = "M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6 1.41 1.41z";
+
+    /// <summary>Folder icon.</summary>
+    public const string Folder = "M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z";
+
+    /// <summary>Star icon.</summary>
+    public const string Star = "M12 1l3.09 6.26L22 8.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 1z";
+
+    /// <summary>Bell/notification icon.</summary>
+    public const string Notification = "M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z";
+
+    /// <summary>Clock/time icon.</summary>
+    public const string Clock = "M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z";
+
+    /// <summary>Lock icon.</summary>
+    public const string Lock = "M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z";
+
+    /// <summary>Fingerprint icon.</summary>
+    public const string Fingerprint = "M17.81 4.47c-.08 0-.16-.02-.23-.06C15.66 3.42 14 3 12.01 3c-1.98 0-3.86.47-5.57 1.41-.24.13-.54.04-.68-.2-.13-.24-.04-.55.2-.68C7.82 2.52 9.86 2 12.01 2c2.13 0 3.99.47 6.03 1.52.25.13.34.43.21.67-.09.18-.26.28-.44.28zM3.5 9.72a.499.499 0 0 1-.41-.79c.99-1.4 2.25-2.5 3.75-3.27C9.98 4.04 14 4.03 17.15 5.65c1.5.77 2.76 1.86 3.75 3.25a.5.5 0 0 1-.12.7.5.5 0 0 1-.7-.12 9.388 9.388 0 0 0-3.39-2.94c-2.87-1.47-6.54-1.47-9.4.01-1.36.7-2.5 1.7-3.4 2.96-.08.14-.23.21-.39.21zm6.25 12.07a.47.47 0 0 1-.35-.15c-.87-.87-1.34-1.43-2.01-2.64-.69-1.23-1.05-2.73-1.05-4.34 0-2.97 2.54-5.39 5.66-5.39s5.66 2.42 5.66 5.39c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-2.42-2.09-4.39-4.66-4.39-2.57 0-4.66 1.97-4.66 4.39 0 1.44.32 2.77.93 3.85.64 1.15 1.08 1.64 1.85 2.42.19.2.19.51 0 .71-.11.1-.24.15-.37.15zm7.17-1.85c-1.19 0-2.24-.3-3.1-.89-1.49-1.01-2.38-2.65-2.38-4.39 0-.28.22-.5.5-.5s.5.22.5.5c0 1.41.72 2.74 1.94 3.56.71.48 1.54.71 2.54.71.24 0 .64-.03 1.04-.1.27-.05.53.13.58.41.05.27-.13.53-.41.58-.57.11-1.07.12-1.21.12zM14.91 22c-.04 0-.09-.01-.13-.02-1.59-.44-2.63-1.03-3.72-2.1a7.297 7.297 0 0 1-2.17-5.22c0-1.62 1.38-2.94 3.08-2.94 1.7 0 3.08 1.32 3.08 2.94 0 1.07.93 1.94 2.08 1.94s2.08-.87 2.08-1.94c0-3.77-3.25-6.83-7.25-6.83-2.84 0-5.44 1.58-6.61 4.03-.39.81-.59 1.76-.59 2.8 0 .78.07 2.01.67 3.61.1.26-.03.55-.29.64-.26.1-.55-.04-.64-.29a11.14 11.14 0 0 1-.73-3.96c0-1.2.23-2.29.68-3.24 1.33-2.79 4.28-4.6 7.51-4.6 4.55 0 8.25 3.51 8.25 7.83 0 1.62-1.38 2.94-3.08 2.94s-3.08-1.32-3.08-2.94c0-1.07-.93-1.94-2.08-1.94s-2.08.87-2.08 1.94c0 1.71.66 3.31 1.87 4.51.95.94 1.86 1.46 3.27 1.85.27.07.42.35.35.61-.05.23-.26.38-.47.38z";
+
+    /// <summary>Logout/sign out icon.</summary>
+    public const string Logout = "M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z";
+
+    /// <summary>Fullscreen exit icon.</summary>
+    public const string FullscreenExit = "M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z";
+
+    /// <summary>Fullscreen enter icon.</summary>
+    public const string FullscreenEnter = "M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z";
+
+    #endregion
+
+    #region Help & Support
+
+    /// <summary>Gift/present icon.</summary>
+    public const string Gift = "M20 6h-2.18c.11-.31.18-.65.18-1 0-1.66-1.34-3-3-3-1.05 0-1.96.54-2.5 1.35l-.5.67-.5-.68C10.96 2.54 10.05 2 9 2 7.34 2 6 3.34 6 5c0 .35.07.69.18 1H4c-1.11 0-1.99.89-1.99 2L2 19c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V8c0-1.11-.89-2-2-2zm-5-2c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zM9 4c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm11 15H4v-2h16v2zm0-5H4V8h5.08L7 10.83 8.62 12 11 8.76l1-1.36 1 1.36L15.38 12 17 10.83 14.92 8H20v6z";
+
+    /// <summary>Book/documentation icon.</summary>
+    public const string Book = "M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z";
+
+    /// <summary>Phone/contact icon.</summary>
+    public const string Phone = "M20 15.5c-1.25 0-2.45-.2-3.57-.57-.35-.11-.74-.03-1.02.24l-2.2 2.2c-2.83-1.44-5.15-3.75-6.59-6.59l2.2-2.21c.28-.26.36-.65.25-1C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.5c0-.55-.45-1-1-1zM19 12h2c0-4.97-4.03-9-9-9v2c3.87 0 7 3.13 7 7zm-4 0h2c0-2.76-2.24-5-5-5v2c1.66 0 3 1.34 3 3z";
+
+    #endregion
+
+    #region Charts & Reports
+
+    /// <summary>Bar chart icon.</summary>
+    public const string BarChart = "M3 13.125C3 12.504 3.504 12 4.125 12H6.375C6.996 12 7.5 12.504 7.5 13.125V19.875C7.5 20.496 6.996 21 6.375 21H4.125C3.504 21 3 20.496 3 19.875V13.125ZM9.75 8.625C9.75 8.004 10.254 7.5 10.875 7.5H13.125C13.746 7.5 14.25 8.004 14.25 8.625V19.875C14.25 20.496 13.746 21 13.125 21H10.875C10.254 21 9.75 20.496 9.75 19.875V8.625ZM16.5 4.125C16.5 3.504 17.004 3 17.625 3H19.875C20.496 3 21 3.504 21 4.125V19.875C21 20.496 20.496 21 19.875 21H17.625C17.004 21 16.5 20.496 16.5 19.875V4.125Z";
+
+    /// <summary>Pie chart icon.</summary>
+    public const string PieChart = "M11 2v20c-5.07-.5-9-4.79-9-10s3.93-9.5 9-10zm2.03 0v8.99H22c-.47-4.74-4.24-8.52-8.97-8.99zm0 11.01V22c4.74-.47 8.5-4.25 8.97-8.99h-8.97z";
+
+    /// <summary>Trend up icon.</summary>
+    public const string TrendUp = "M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z";
+
+    /// <summary>Split/compare icon.</summary>
+    public const string SplitCompare = "M9.5 3H4C2.9 3 2 3.9 2 5v14c0 1.1.9 2 2 2h5.5V3zm5 0v18H20c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-5.5z";
+
+    /// <summary>Growth chart icon.</summary>
+    public const string GrowthChart = "M7.5 21H2V9h5.5v12zm7.25-18h-5.5v18h5.5V3zM22 11h-5.5v10H22V11z";
+
+    /// <summary>Globe/international icon.</summary>
+    public const string Globe = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z";
+
+    /// <summary>Dollar/currency icon.</summary>
+    public const string Dollar = "M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z";
+
+    /// <summary>Info circle icon.</summary>
+    public const string Info = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z";
+
+    /// <summary>Heart/favorite icon.</summary>
+    public const string Heart = "M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z";
+
+    /// <summary>Bookmark/rental icon.</summary>
+    public const string Bookmark = "M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z";
+
+    /// <summary>Chat/message icon.</summary>
+    public const string Chat = "M12 3C6.5 3 2 6.58 2 11c0 2.13 1.02 4.05 2.67 5.45v4.05l3.58-2.03c1.2.39 2.48.53 3.75.53 5.5 0 10-3.58 10-8s-4.5-8-10-8z";
+
+    /// <summary>Circle check icon.</summary>
+    public const string CircleCheck = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z";
+
+    /// <summary>Return/undo icon (alternate).</summary>
+    public const string Undo = "M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z";
+
+    /// <summary>Product card icon.</summary>
+    public const string ProductCard = "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zm-7-7l-4 5h8z";
 
     #endregion
 }

--- a/ArgoBooks/Icons.cs
+++ b/ArgoBooks/Icons.cs
@@ -1,0 +1,182 @@
+namespace ArgoBooks;
+
+/// <summary>
+/// Centralized repository of all SVG path data for icons used throughout the application.
+/// All icons are Material Design icon paths.
+/// </summary>
+public static class Icons
+{
+    #region Navigation - Main
+
+    /// <summary>Home icon for Dashboard.</summary>
+    public const string Dashboard = "M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z";
+
+    /// <summary>Line chart icon for Analytics.</summary>
+    public const string Analytics = "M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z";
+
+    /// <summary>Lightbulb icon for Insights.</summary>
+    public const string Insights = "M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6C7.8 12.16 7 10.63 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z";
+
+    /// <summary>Document icon for Reports.</summary>
+    public const string Reports = "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z";
+
+    #endregion
+
+    #region Navigation - Transactions
+
+    /// <summary>Down arrow icon for Expenses.</summary>
+    public const string Expenses = "M20 12l-1-1L13 16V4h-2v12l-5-5L4 12l8 8 8-8z";
+
+    /// <summary>Up arrow icon for Revenue.</summary>
+    public const string Revenue = "M4 12l1 1L11 8V20h2V8l5 5L20 12l-8-8-8 8z";
+
+    /// <summary>Invoice/document icon for Invoices.</summary>
+    public const string Invoices = "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z";
+
+    /// <summary>Credit card icon for Payments.</summary>
+    public const string Payments = "M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z";
+
+    /// <summary>Receipt icon for Receipts.</summary>
+    public const string Receipts = "M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z";
+
+    /// <summary>Shopping bag icon for Purchase Orders.</summary>
+    public const string PurchaseOrders = "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z";
+
+    /// <summary>Undo/refresh icon for Returns.</summary>
+    public const string Returns = "M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z";
+
+    /// <summary>Warning triangle icon for Lost/Damaged.</summary>
+    public const string LostDamaged = "M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z";
+
+    #endregion
+
+    #region Navigation - Rentals
+
+    /// <summary>List/inventory icon for Rental Inventory.</summary>
+    public const string RentalInventory = "M21 3H3C1.9 3 1 3.9 1 5v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14zM5 15h14v2H5zm0-4h14v2H5zm0-4h14v2H5z";
+
+    /// <summary>Clipboard with check icon for Rental Records.</summary>
+    public const string RentalRecords = "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z";
+
+    #endregion
+
+    #region Navigation - Management
+
+    /// <summary>People/users icon for Customers.</summary>
+    public const string Customers = "M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z";
+
+    /// <summary>Cube/box icon for Products/Services.</summary>
+    public const string Products = "M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.16.12-.36.18-.57.18-.21 0-.41-.06-.57-.18l-7.9-4.44A.991.991 0 0 1 3 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.16-.12.36-.18.57-.18.21 0 .41.06.57.18l7.9 4.44c.32.17.53.5.53.88v9zM12 4.15L6.04 7.5 12 10.85l5.96-3.35L12 4.15z";
+
+    /// <summary>Tag/label icon for Categories.</summary>
+    public const string Categories = "M17.63 5.84C17.27 5.33 16.67 5 16 5L5 5.01C3.9 5.01 3 5.9 3 7v10c0 1.1.9 1.99 2 1.99L16 19c.67 0 1.27-.33 1.63-.84L22 12l-4.37-6.16z";
+
+    /// <summary>Truck icon for Suppliers.</summary>
+    public const string Suppliers = "M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm13.5-9l1.96 2.5H17V9.5h2.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z";
+
+    #endregion
+
+    #region Navigation - Inventory
+
+    /// <summary>Chart/levels icon for Stock Levels.</summary>
+    public const string StockLevels = "M22 18V3H2v15H0v2h24v-2h-2zm-2-1H4V5h16v12zM6 15h2v-5H6v5zm4 0h2V8h-2v7zm4 0h2v-3h-2v3z";
+
+    /// <summary>Sliders icon for Stock Adjustments.</summary>
+    public const string Adjustments = "M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z";
+
+    /// <summary>Map marker icon for Locations.</summary>
+    public const string Locations = "M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z";
+
+    /// <summary>Exchange/swap arrows icon for Transfers.</summary>
+    public const string Transfers = "M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z";
+
+    #endregion
+
+    #region Navigation - Team
+
+    /// <summary>Person icon for Employees.</summary>
+    public const string Employees = "M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z";
+
+    /// <summary>Building icon for Departments.</summary>
+    public const string Departments = "M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z";
+
+    /// <summary>Calculator/plus icon for Accountants.</summary>
+    public const string Accountants = "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-6 14h-2v-4H7v-2h4V7h2v4h4v2h-4v4z";
+
+    #endregion
+
+    #region Quick Actions
+
+    /// <summary>Document with check icon for Scan Receipt.</summary>
+    public const string ScanReceipt = "M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z";
+
+    /// <summary>Person with plus icon for New Customer.</summary>
+    public const string NewCustomer = "M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z";
+
+    /// <summary>Box with plus icon for New Product.</summary>
+    public const string NewProduct = "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z";
+
+    /// <summary>Shopping bag with circle icon for New Purchase Order.</summary>
+    public const string NewPurchaseOrder = "M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6-2c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm6 16H6V8h2v2c0 .55.45 1 1 1s1-.45 1-1V8h4v2c0 .55.45 1 1 1s1-.45 1-1V8h2v12z";
+
+    /// <summary>Clipboard with check icon for New Stock Adjustment.</summary>
+    public const string NewStockAdjustment = "M19 3H14.82C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z";
+
+    /// <summary>Clipboard with checkmark icon for New Accountant.</summary>
+    public const string NewAccountant = "M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-2 14l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z";
+
+    /// <summary>Return arrow icon for New Return.</summary>
+    public const string NewReturn = "M19 8l-4 4h3c0 3.31-2.69 6-6 6-1.01 0-1.97-.25-2.8-.7l-1.46 1.46C8.97 19.54 10.43 20 12 20c4.42 0 8-3.58 8-8h3l-4-4zM6 12c0-3.31 2.69-6 6-6 1.01 0 1.97.25 2.8.7l1.46-1.46C15.03 4.46 13.57 4 12 4c-4.42 0-8 3.58-8 8H1l4 4 4-4H6z";
+
+    /// <summary>Phone/device icon for New Rental Item.</summary>
+    public const string NewRentalItem = "M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zM7 4V3h10v1H7zm0 14V6h10v12H7zm0 3v-1h10v1H7z";
+
+    #endregion
+
+    #region Tools & Settings
+
+    /// <summary>Gear/cog icon for Settings.</summary>
+    public const string Settings = "M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z";
+
+    /// <summary>Building icon for Edit Company.</summary>
+    public const string EditCompany = "M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z";
+
+    /// <summary>Person circle icon for View Profile.</summary>
+    public const string ViewProfile = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z";
+
+    /// <summary>People switch icon for Switch Account.</summary>
+    public const string SwitchAccount = "M16.67 13.13C18.04 14.06 19 15.32 19 17v3h4v-3c0-2.18-3.57-3.47-6.33-3.87zM15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4c-.47 0-.91.1-1.33.24C14.5 5.27 15 6.58 15 8s-.5 2.73-1.33 3.76c.42.14.86.24 1.33.24zM9 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0-6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zM9 13c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4z";
+
+    /// <summary>Refresh/update icon for Check for Updates.</summary>
+    public const string CheckForUpdates = "M21 10.12h-6.78l2.74-2.82c-2.73-2.7-7.15-2.8-9.88-.1-2.73 2.71-2.73 7.08 0 9.79 2.73 2.71 7.15 2.71 9.88 0C18.32 15.65 19 14.08 19 12.1h2c0 1.98-.88 4.55-2.64 6.29-3.51 3.48-9.21 3.48-12.72 0-3.5-3.47-3.53-9.11-.02-12.58 3.51-3.47 9.14-3.47 12.65 0L21 3v7.12zM12.5 8v4.25l3.5 2.08-.72 1.21L11 13V8h1.5z";
+
+    /// <summary>Download icon for Export Data.</summary>
+    public const string ExportData = "M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z";
+
+    /// <summary>Upload icon for Import Data.</summary>
+    public const string ImportData = "M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z";
+
+    /// <summary>Question mark circle icon for Help.</summary>
+    public const string Help = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z";
+
+    /// <summary>Keyboard icon for Keyboard Shortcuts.</summary>
+    public const string KeyboardShortcuts = "M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z";
+
+    #endregion
+
+    #region UI Elements
+
+    /// <summary>Chevron left icon for collapse/back.</summary>
+    public const string ChevronLeft = "M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z";
+
+    /// <summary>Chevron right icon for expand/forward.</summary>
+    public const string ChevronRight = "M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z";
+
+    /// <summary>Chevron down icon for dropdown expanded.</summary>
+    public const string ChevronDown = "M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z";
+
+    /// <summary>Chevron up icon for dropdown collapsed.</summary>
+    public const string ChevronUp = "M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6 1.41 1.41z";
+
+    #endregion
+}

--- a/ArgoBooks/Icons.cs
+++ b/ArgoBooks/Icons.cs
@@ -178,6 +178,9 @@ public static class Icons
     /// <summary>Close/X icon.</summary>
     public const string Close = "M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z";
 
+    /// <summary>Close circle icon.</summary>
+    public const string CloseCircle = "M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z";
+
     /// <summary>Checkmark icon.</summary>
     public const string Check = "M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z";
 
@@ -212,8 +215,11 @@ public static class Icons
     /// <summary>Chevron up icon for dropdown collapsed.</summary>
     public const string ChevronUp = "M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6 1.41 1.41z";
 
-    /// <summary>Folder icon.</summary>
+    /// <summary>Folder icon (outlined).</summary>
     public const string Folder = "M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z";
+
+    /// <summary>Folder icon (filled).</summary>
+    public const string FolderFilled = "M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z";
 
     /// <summary>Star icon.</summary>
     public const string Star = "M12 1l3.09 6.26L22 8.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 1z";

--- a/ArgoBooks/Modals/CategoryModals.axaml
+++ b/ArgoBooks/Modals/CategoryModals.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ArgoBooks.Modals.CategoryModals"
@@ -28,7 +29,7 @@
                                            IsVisible="{Binding IsAddingSubCategory}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -97,7 +98,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="{loc:Loc 'Edit Category'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -169,7 +170,7 @@
                                 <TextBlock Text="{Binding MovingCategoryName}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseMoveModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>

--- a/ArgoBooks/Modals/CheckForUpdateModal.axaml
+++ b/ArgoBooks/Modals/CheckForUpdateModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="350"
              x:Class="ArgoBooks.Modals.CheckForUpdateModal"
              x:DataType="vm:CheckForUpdateModalViewModel">
@@ -39,7 +40,7 @@
                         <Button Grid.Column="1"
                                 Classes="icon-button"
                                 Command="{Binding CloseCommand}">
-                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            <PathIcon Data="{x:Static local:Icons.Close}"
                                       Width="20" Height="20" />
                         </Button>
                     </Grid>
@@ -87,7 +88,7 @@
                                         Orientation="Horizontal"
                                         HorizontalAlignment="Center"
                                         Spacing="12">
-                                <PathIcon Data="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                                <PathIcon Data="{x:Static local:Icons.Refresh}"
                                           Width="20" Height="20"
                                           Foreground="{DynamicResource PrimaryBrush}"
                                           Classes="spinning"
@@ -110,7 +111,7 @@
                                         CornerRadius="20"
                                         Background="#10B981"
                                         HorizontalAlignment="Center">
-                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                    <PathIcon Data="{x:Static local:Icons.Check}"
                                               Width="20" Height="20"
                                               Foreground="White" />
                                 </Border>
@@ -133,7 +134,7 @@
                                         CornerRadius="20"
                                         Background="{DynamicResource PrimaryBrush}"
                                         HorizontalAlignment="Center">
-                                    <PathIcon Data="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                                    <PathIcon Data="{x:Static local:Icons.Refresh}"
                                               Width="20" Height="20"
                                               Foreground="White" />
                                 </Border>
@@ -163,7 +164,7 @@
                                         CornerRadius="20"
                                         Background="#DC2626"
                                         HorizontalAlignment="Center">
-                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                    <PathIcon Data="{x:Static local:Icons.Info}"
                                               Width="20" Height="20"
                                               Foreground="White" />
                                 </Border>

--- a/ArgoBooks/Modals/CustomerModals.axaml
+++ b/ArgoBooks/Modals/CustomerModals.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:helpers="using:ArgoBooks.Helpers"
@@ -44,7 +45,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/DepartmentModals.axaml
+++ b/ArgoBooks/Modals/DepartmentModals.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              xmlns:controls="using:ArgoBooks.Controls"
              x:Class="ArgoBooks.Modals.DepartmentModals"
              x:DataType="vm:DepartmentModalsViewModel">
@@ -18,7 +19,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="{loc:Loc 'Add Department'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -58,7 +59,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="{loc:Loc 'Edit Department'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>

--- a/ArgoBooks/Modals/EditCompanyModal.axaml
+++ b/ArgoBooks/Modals/EditCompanyModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="clr-namespace:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="500"
              x:Class="ArgoBooks.Modals.EditCompanyModal"
              x:DataType="vm:EditCompanyModalViewModel">
@@ -39,7 +40,7 @@
                         <Button Grid.Column="1"
                                 Classes="icon-button"
                                 Command="{Binding CloseCommand}">
-                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            <PathIcon Data="{x:Static local:Icons.Close}"
                                       Width="20" Height="20" />
                         </Button>
                     </Grid>
@@ -122,7 +123,7 @@
                                     <Button Classes="secondary-button"
                                             Command="{Binding BrowseLogoCommand}">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <PathIcon Data="M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z"
+                                            <PathIcon Data="{x:Static local:Icons.ImportData}"
                                                       Width="16" Height="16" />
                                             <TextBlock Text="{loc:Loc 'Upload Logo'}" />
                                         </StackPanel>

--- a/ArgoBooks/Modals/ExpenseModals.axaml
+++ b/ArgoBooks/Modals/ExpenseModals.axaml
@@ -6,6 +6,7 @@
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:modals="using:ArgoBooks.Modals"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="800"
              x:Class="ArgoBooks.Modals.ExpenseModals"
@@ -42,7 +43,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseAddEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -92,7 +93,7 @@
                                             Classes="secondary-button"
                                             Command="{Binding AddLineItemCommand}">
                                         <StackPanel Orientation="Horizontal" Spacing="6">
-                                            <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                            <PathIcon Data="{x:Static icons:Icons.Add}"
                                                       Width="14" Height="14" />
                                             <TextBlock Text="{loc:Loc 'Add Item'}" />
                                         </StackPanel>
@@ -183,7 +184,7 @@
                                                             Command="{Binding $parent[ItemsControl].((vm:ExpenseModalsViewModel)DataContext).RemoveLineItemCommand}"
                                                             CommandParameter="{Binding}"
                                                             ToolTip.Tip="{loc:Loc 'Remove item'}">
-                                                        <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                        <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                   Width="14" Height="14" />
                                                     </Button>
                                                 </Grid>
@@ -394,7 +395,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -540,7 +541,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseItemStatusModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/ExportAsModal.axaml
+++ b/ArgoBooks/Modals/ExportAsModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="700"
              x:Class="ArgoBooks.Modals.ExportAsModal"
              x:DataType="vm:ExportAsModalViewModel">
@@ -42,7 +43,7 @@
                         <Button Grid.Column="1"
                                 Classes="icon-button"
                                 Command="{Binding CloseCommand}">
-                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            <PathIcon Data="{x:Static local:Icons.Close}"
                                       Width="20" Height="20" />
                         </Button>
                     </Grid>
@@ -211,7 +212,7 @@
                         <Button Classes="primary-button"
                                 Command="{Binding ExportCommand}">
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <PathIcon Data="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                                <PathIcon Data="{x:Static local:Icons.ExportData}"
                                           Width="16" Height="16" />
                                 <TextBlock Text="{loc:Loc Export}" />
                             </StackPanel>

--- a/ArgoBooks/Modals/ImportModal.axaml
+++ b/ArgoBooks/Modals/ImportModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="500"
              x:Class="ArgoBooks.Modals.ImportModal"
              x:DataType="vm:ImportModalViewModel">
@@ -41,7 +42,7 @@
                         <Button Grid.Column="1"
                                 Classes="icon-button"
                                 Command="{Binding CloseCommand}">
-                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            <PathIcon Data="{x:Static local:Icons.Close}"
                                       Width="20" Height="20" />
                         </Button>
                     </Grid>
@@ -83,7 +84,7 @@
                                                Foreground="{DynamicResource TextTertiaryBrush}" />
                                 </StackPanel>
                                 <PathIcon Grid.Column="2"
-                                          Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                          Data="{x:Static local:Icons.ChevronRightNav}"
                                           Width="16" Height="16"
                                           Foreground="{DynamicResource TextTertiaryBrush}"
                                           VerticalAlignment="Center" />
@@ -107,7 +108,7 @@
                                         CornerRadius="8"
                                         Background="{DynamicResource PrimaryIconBgBrush}"
                                         Margin="0,0,16,0">
-                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                    <PathIcon Data="{x:Static local:Icons.CircleCheck}"
                                               Width="20" Height="20"
                                               Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
@@ -121,7 +122,7 @@
                                                Foreground="{DynamicResource TextTertiaryBrush}" />
                                 </StackPanel>
                                 <PathIcon Grid.Column="2"
-                                          Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                          Data="{x:Static local:Icons.ChevronRightNav}"
                                           Width="16" Height="16"
                                           Foreground="{DynamicResource TextTertiaryBrush}"
                                           VerticalAlignment="Center" />

--- a/ArgoBooks/Modals/InvoiceModals.axaml
+++ b/ArgoBooks/Modals/InvoiceModals.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="800"
              x:Class="ArgoBooks.Modals.InvoiceModals"
@@ -41,7 +42,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseCreateEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -103,7 +104,7 @@
                                             Classes="secondary-button"
                                             Command="{Binding AddLineItemCommand}">
                                         <StackPanel Orientation="Horizontal" Spacing="6">
-                                            <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                            <PathIcon Data="{x:Static icons:Icons.Add}"
                                                       Width="14" Height="14" />
                                             <TextBlock Text="{loc:Loc 'Add Item'}" />
                                         </StackPanel>
@@ -191,7 +192,7 @@
                                                             Command="{Binding $parent[ItemsControl].((vm:InvoiceModalsViewModel)DataContext).RemoveLineItemCommand}"
                                                             CommandParameter="{Binding}"
                                                             ToolTip.Tip="{loc:Loc 'Remove item'}">
-                                                        <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                        <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                   Width="14" Height="14" />
                                                     </Button>
                                                 </Grid>
@@ -353,7 +354,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -497,7 +498,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseHistoryModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/LocationsModals.axaml
+++ b/ArgoBooks/Modals/LocationsModals.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ArgoBooks.Modals.LocationsModals"
@@ -26,7 +27,7 @@
                                        FontSize="18" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -160,7 +161,7 @@
                                        FontSize="18" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -294,7 +295,7 @@
                                        FontSize="18" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>

--- a/ArgoBooks/Modals/LoginModal.axaml
+++ b/ArgoBooks/Modals/LoginModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="450" d:DesignHeight="500"
              x:Class="ArgoBooks.Modals.LoginModal"
              x:DataType="vm:LoginModalViewModel">
@@ -103,7 +104,7 @@
                             HorizontalContentAlignment="Center"
                             Command="{Binding LoginCommand}">
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <PathIcon Data="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
+                            <PathIcon Data="{x:Static local:Icons.Lock}"
                                       Width="16" Height="16"
                                       IsVisible="{Binding !IsLoading}" />
                             <TextBlock Text="{Binding LoginButtonText}" />

--- a/ArgoBooks/Modals/LostDamagedModals.axaml
+++ b/ArgoBooks/Modals/LostDamagedModals.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="ArgoBooks.Modals.LostDamagedModals"
              x:DataType="vm:LostDamagedModalsViewModel">
@@ -32,7 +33,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/PasswordPromptModal.axaml
+++ b/ArgoBooks/Modals/PasswordPromptModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="550" d:DesignHeight="400"
              x:Class="ArgoBooks.Modals.PasswordPromptModal"
              x:DataType="vm:PasswordPromptModalViewModel">
@@ -39,7 +40,7 @@
                                 CornerRadius="28"
                                 Background="{DynamicResource PrimaryLightBrush}"
                                 HorizontalAlignment="Center">
-                            <PathIcon Data="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
+                            <PathIcon Data="{x:Static local:Icons.Lock}"
                                       Width="28" Height="28"
                                       Foreground="{DynamicResource PrimaryBrush}" />
                         </Border>
@@ -67,7 +68,7 @@
                             HorizontalContentAlignment="Center">
                         <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Center">
                             <!-- Windows Hello / Fingerprint Icon -->
-                            <PathIcon Data="M17.81 4.47c-.08 0-.16-.02-.23-.06C15.66 3.42 14 3 12.01 3c-1.98 0-3.86.47-5.57 1.41-.24.13-.54.04-.68-.2-.13-.24-.04-.55.2-.68C7.82 2.52 9.86 2 12.01 2c2.13 0 3.99.47 6.03 1.52.25.13.34.43.21.67-.09.18-.26.28-.44.28zM3.5 9.72a.499.499 0 0 1-.41-.79c.99-1.4 2.25-2.5 3.75-3.27C9.98 4.04 14 4.03 17.15 5.65c1.5.77 2.76 1.86 3.75 3.25a.5.5 0 0 1-.12.7.5.5 0 0 1-.7-.12 9.388 9.388 0 0 0-3.39-2.94c-2.87-1.47-6.54-1.47-9.4.01-1.36.7-2.5 1.7-3.4 2.96-.08.14-.23.21-.39.21zm6.25 12.07a.47.47 0 0 1-.35-.15c-.87-.87-1.34-1.43-2.01-2.64-.69-1.23-1.05-2.73-1.05-4.34 0-2.97 2.54-5.39 5.66-5.39s5.66 2.42 5.66 5.39c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-2.42-2.09-4.39-4.66-4.39-2.57 0-4.66 1.97-4.66 4.39 0 1.44.32 2.77.93 3.85.64 1.15 1.08 1.64 1.85 2.42.19.2.19.51 0 .71-.11.1-.24.15-.37.15zm7.17-1.85c-1.19 0-2.24-.3-3.1-.89-1.49-1.01-2.38-2.65-2.38-4.39 0-.28.22-.5.5-.5s.5.22.5.5c0 1.41.72 2.74 1.94 3.56.71.48 1.54.71 2.54.71.24 0 .64-.03 1.04-.1.27-.05.53.13.58.41.05.27-.13.53-.41.58-.57.11-1.07.12-1.21.12zM14.91 22c-.04 0-.09-.01-.13-.02-1.59-.44-2.63-1.03-3.72-2.1a7.297 7.297 0 0 1-2.17-5.22c0-1.62 1.38-2.94 3.08-2.94 1.7 0 3.08 1.32 3.08 2.94 0 1.07.93 1.94 2.08 1.94s2.08-.87 2.08-1.94c0-3.77-3.25-6.83-7.25-6.83-2.84 0-5.44 1.58-6.61 4.03-.39.81-.59 1.76-.59 2.8 0 .78.07 2.01.67 3.61.1.26-.03.55-.29.64-.26.1-.55-.04-.64-.29a11.14 11.14 0 0 1-.73-3.96c0-1.2.23-2.29.68-3.24 1.33-2.79 4.28-4.6 7.51-4.6 4.55 0 8.25 3.51 8.25 7.83 0 1.62-1.38 2.94-3.08 2.94s-3.08-1.32-3.08-2.94c0-1.07-.93-1.94-2.08-1.94s-2.08.87-2.08 1.94c0 1.71.66 3.31 1.87 4.51.95.94 1.86 1.46 3.27 1.85.27.07.42.35.35.61-.05.23-.26.38-.47.38z"
+                            <PathIcon Data="{x:Static local:Icons.Fingerprint}"
                                       Width="24" Height="24"
                                       IsVisible="{Binding !IsWindowsHelloAuthenticating}" />
                             <!-- Loading spinner when authenticating -->
@@ -158,7 +159,7 @@
                             <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                                 <!-- Loading spinner icon (static) -->
                                 <PathIcon IsVisible="{Binding IsLoading}"
-                                          Data="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                                          Data="{x:Static local:Icons.Refresh}"
                                           Width="16" Height="16"
                                           Foreground="White" />
                                 <TextBlock Text="{loc:Loc Unlock}"

--- a/ArgoBooks/Modals/PaymentModals.axaml
+++ b/ArgoBooks/Modals/PaymentModals.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="550"
              x:Class="ArgoBooks.Modals.PaymentModals"
@@ -41,7 +42,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/ProductModals.axaml
+++ b/ArgoBooks/Modals/ProductModals.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ArgoBooks.Modals.ProductModals"
@@ -35,7 +36,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -146,7 +147,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -248,7 +249,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Grid.Column="0" Text="{loc:Loc 'Filter Products'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/ProfileModal.axaml
+++ b/ArgoBooks/Modals/ProfileModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="400"
              x:Class="ArgoBooks.Modals.ProfileModal"
              x:DataType="vm:ProfileModalViewModel">
@@ -40,7 +41,7 @@
                         <Button Grid.Column="1"
                                 Classes="icon-button"
                                 Command="{Binding CloseCommand}">
-                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            <PathIcon Data="{x:Static local:Icons.Close}"
                                       Width="16" Height="16" />
                         </Button>
                     </Grid>
@@ -82,7 +83,7 @@
                                     Command="{Binding ChangeAvatarCommand}"
                                     HorizontalAlignment="Stretch">
                                 <StackPanel HorizontalAlignment="Center" Spacing="8">
-                                    <PathIcon Data="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                                    <PathIcon Data="{x:Static local:Icons.Employees}"
                                               Width="20" Height="20"
                                               Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <TextBlock Text="{loc:Loc 'Click to upload a new photo'}"

--- a/ArgoBooks/Modals/PurchaseOrdersModals.axaml
+++ b/ArgoBooks/Modals/PurchaseOrdersModals.axaml
@@ -7,6 +7,7 @@
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="ArgoBooks.Modals.PurchaseOrdersModals"
              x:DataType="vm:PurchaseOrdersModalsViewModel">
@@ -33,7 +34,7 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static icons:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -87,7 +88,7 @@
                                     </TextBlock>
                                     <Button Grid.Column="1" Classes="link-button" Command="{Binding AddLineItemCommand}">
                                         <StackPanel Orientation="Horizontal" Spacing="4">
-                                            <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" Width="14" Height="14" />
+                                            <PathIcon Data="{x:Static icons:Icons.Add}" Width="14" Height="14" />
                                             <TextBlock Text="{loc:Loc 'Add Item'}" />
                                         </StackPanel>
                                     </Button>
@@ -141,7 +142,7 @@
                                                                     Classes="icon-button-small danger"
                                                                     Command="{Binding $parent[ItemsControl].((vm:PurchaseOrdersModalsViewModel)DataContext).RemoveLineItemCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" Width="14" Height="14" />
+                                                                <PathIcon Data="{x:Static icons:Icons.Delete}" Width="14" Height="14" />
                                                             </Button>
                                                         </Grid>
                                                     </Border>
@@ -238,7 +239,7 @@
                                            Foreground="{DynamicResource PrimaryBrush}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseViewModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static icons:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -368,7 +369,7 @@
                                            Foreground="{DynamicResource PrimaryBrush}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseReceiveModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static icons:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>

--- a/ArgoBooks/Modals/QuickActionsSettingsModal.axaml
+++ b/ArgoBooks/Modals/QuickActionsSettingsModal.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="600"
              x:Class="ArgoBooks.Modals.QuickActionsSettingsModal"
              x:DataType="vm:QuickActionsSettingsModalViewModel">
@@ -88,7 +89,7 @@
                                 Classes="icon-button"
                                 VerticalAlignment="Top"
                                 Command="{Binding CloseCommand}">
-                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            <PathIcon Data="{x:Static local:Icons.Close}"
                                       Width="16" Height="16" />
                         </Button>
                     </Grid>
@@ -113,7 +114,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource WarningIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                        <PathIcon Data="{x:Static local:Icons.Invoices}"
                                                   Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -161,7 +162,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource InfoIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                        <PathIcon Data="{x:Static local:Icons.ScanReceipt}"
                                                   Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -186,7 +187,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource PrimaryIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                                        <PathIcon Data="{x:Static local:Icons.NewCustomer}"
                                                   Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -227,7 +228,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource SuccessIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+                                        <PathIcon Data="{x:Static local:Icons.NewProduct}"
                                                   Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -243,7 +244,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource SuccessIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
+                                        <PathIcon Data="{x:Static local:Icons.Payments}"
                                                   Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -268,7 +269,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource InfoIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zM7 4V3h10v1H7zm0 14V6h10v12H7zm0 3v-1h10v1H7z"
+                                        <PathIcon Data="{x:Static local:Icons.NewRentalItem}"
                                                   Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -284,7 +285,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource InfoIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z"
+                                        <PathIcon Data="{x:Static local:Icons.RentalRecords}"
                                                   Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -325,7 +326,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource WarningIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                                        <PathIcon Data="{x:Static local:Icons.Departments}"
                                                   Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -341,7 +342,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource WarningIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+                                        <PathIcon Data="{x:Static local:Icons.Locations}"
                                                   Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -366,7 +367,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource PrimaryIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6-2c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm6 16H6V8h2v2c0 .55.45 1 1 1s1-.45 1-1V8h4v2c0 .55.45 1 1 1s1-.45 1-1V8h2v12z"
+                                        <PathIcon Data="{x:Static local:Icons.NewPurchaseOrder}"
                                                   Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">
@@ -382,7 +383,7 @@
                                 <Grid ColumnDefinitions="Auto,*,Auto">
                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="6"
                                             Background="{DynamicResource PrimaryIconBgBrush}" Margin="0,0,12,0">
-                                        <PathIcon Data="M19 3H14.82C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
+                                        <PathIcon Data="{x:Static local:Icons.NewStockAdjustment}"
                                                   Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                     </Border>
                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="1">

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -6,6 +6,7 @@
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="800"
              x:Class="ArgoBooks.Modals.ReceiptsModals"
              x:DataType="vm:ReceiptsModalsViewModel">
@@ -34,7 +35,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -188,7 +189,7 @@
                             BorderThickness="0,0,0,1">
                         <Grid ColumnDefinitions="*,Auto,Auto">
                             <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="12">
-                                <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                <PathIcon Data="{x:Static icons:Icons.ScanReceipt}"
                                           Width="24" Height="24"
                                           Foreground="{DynamicResource PrimaryBrush}" />
                                 <TextBlock Text="{loc:Loc 'AI Receipt Scanner'}"
@@ -218,7 +219,7 @@
                                         <Run Text="{loc:Loc ' scans this month'}" />
                                     </TextBlock>
                                     <!-- Warning icon when near limit -->
-                                    <PathIcon Data="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                                    <PathIcon Data="{x:Static icons:Icons.LostDamaged}"
                                               Width="14" Height="14"
                                               Foreground="#CA8A04"
                                               IsVisible="{Binding IsNearLimit}"
@@ -228,7 +229,7 @@
                             <Button Grid.Column="2"
                                     Classes="icon-button"
                                     Command="{Binding CloseScanReviewModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -372,7 +373,7 @@
                                                 </StackPanel>
                                             </StackPanel>
                                             <PathIcon Grid.Column="1"
-                                                      Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                      Data="{x:Static icons:Icons.Check}"
                                                       Width="24" Height="24"
                                                       Foreground="#16A34A"
                                                       VerticalAlignment="Center"
@@ -448,7 +449,7 @@
                                                     Classes="secondary-button"
                                                     Command="{Binding AddLineItemCommand}">
                                                 <StackPanel Orientation="Horizontal" Spacing="6">
-                                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Add}"
                                                               Width="14" Height="14" />
                                                     <TextBlock Text="{loc:Loc 'Add Item'}" />
                                                 </StackPanel>
@@ -527,7 +528,7 @@
                                                                                 Padding="8,4"
                                                                                 Margin="4,0,0,0"
                                                                                 Cursor="Hand">
-                                                                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                                            <PathIcon Data="{x:Static icons:Icons.Close}"
                                                                                       Width="14" Height="14"
                                                                                       Foreground="#92400E" />
                                                                         </Button>
@@ -558,7 +559,7 @@
                                                                     Command="{Binding $parent[ItemsControl].((vm:ReceiptsModalsViewModel)DataContext).RemoveLineItemCommand}"
                                                                     CommandParameter="{Binding}"
                                                                     ToolTip.Tip="{loc:Loc 'Remove item'}">
-                                                                <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                           Width="14" Height="14" />
                                                             </Button>
                                                         </Grid>
@@ -769,7 +770,7 @@
                                     Classes="primary-button"
                                     Command="{Binding CreateExpenseCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                               Width="16" Height="16" />
                                     <TextBlock Text="{loc:Loc 'Create Expense'}" />
                                 </StackPanel>

--- a/ArgoBooks/Modals/RentalInventoryModals.axaml
+++ b/ArgoBooks/Modals/RentalInventoryModals.axaml
@@ -6,6 +6,7 @@
              xmlns:behaviors="using:ArgoBooks.Behaviors"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="550"
              x:Class="ArgoBooks.Modals.RentalInventoryModals"
              x:DataType="vm:RentalInventoryModalsViewModel">
@@ -32,7 +33,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Grid.Column="0" Text="{loc:Loc 'Add Rental Item'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -149,7 +150,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Grid.Column="0" Text="{loc:Loc 'Edit Rental Item'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -277,7 +278,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Grid.Column="0" Text="{loc:Loc 'Filter Rental Items'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -356,7 +357,7 @@
                                 <TextBlock Text="{Binding RentOutItemName}" FontSize="14" Foreground="{DynamicResource TextSecondaryBrush}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseRentOutModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>

--- a/ArgoBooks/Modals/RentalRecordsModals.axaml
+++ b/ArgoBooks/Modals/RentalRecordsModals.axaml
@@ -7,6 +7,7 @@
              xmlns:behaviors="using:ArgoBooks.Behaviors"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ArgoBooks.Modals.RentalRecordsModals"
              x:DataType="vm:RentalRecordsModalsViewModel">
@@ -29,7 +30,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="{loc:Loc 'New Rental Record'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -170,7 +171,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="{loc:Loc 'Edit Rental Record'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -310,7 +311,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="{loc:Loc 'Filter Rental Records'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -408,7 +409,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBlock Text="{loc:Loc 'Process Return'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseReturnModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -512,7 +513,7 @@
                                 </Border>
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseViewModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -587,7 +588,7 @@
                             <Border Background="{DynamicResource ErrorLightBrush}" CornerRadius="8" Padding="16"
                                     IsVisible="{Binding ViewDaysOverdue, Converter={x:Static conv:IntConverters.IsPositive}}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                    <PathIcon Data="{x:Static local:Icons.CircleCheck}"
                                               Width="20" Height="20" Foreground="{DynamicResource ErrorBrush}" />
                                     <TextBlock Foreground="{DynamicResource ErrorTextBrush}">
                                         <Run Text="{loc:Loc 'This rental is '}" />

--- a/ArgoBooks/Modals/ReturnsModals.axaml
+++ b/ArgoBooks/Modals/ReturnsModals.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="ArgoBooks.Modals.ReturnsModals"
              x:DataType="vm:ReturnsModalsViewModel">
@@ -32,7 +33,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/RevenueModals.axaml
+++ b/ArgoBooks/Modals/RevenueModals.axaml
@@ -6,6 +6,7 @@
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:modals="using:ArgoBooks.Modals"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="800"
              x:Class="ArgoBooks.Modals.RevenueModals"
@@ -42,7 +43,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseAddEditModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -108,7 +109,7 @@
                                             Classes="secondary-button"
                                             Command="{Binding AddLineItemCommand}">
                                         <StackPanel Orientation="Horizontal" Spacing="6">
-                                            <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                            <PathIcon Data="{x:Static icons:Icons.Add}"
                                                       Width="14" Height="14" />
                                             <TextBlock Text="{loc:Loc 'Add Item'}" />
                                         </StackPanel>
@@ -199,7 +200,7 @@
                                                             Command="{Binding $parent[ItemsControl].((vm:RevenueModalsViewModel)DataContext).RemoveLineItemCommand}"
                                                             CommandParameter="{Binding}"
                                                             ToolTip.Tip="{loc:Loc 'Remove item'}">
-                                                        <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                        <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                   Width="14" Height="14" />
                                                     </Button>
                                                 </Grid>
@@ -410,7 +411,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -551,7 +552,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseItemStatusModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/SettingsModal.axaml
+++ b/ArgoBooks/Modals/SettingsModal.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:modals="using:ArgoBooks.Modals"
@@ -44,7 +45,7 @@
                         <Button Grid.Column="1"
                                 Classes="icon-button"
                                 Command="{Binding CloseCommand}">
-                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            <PathIcon Data="{x:Static icons:Icons.Close}"
                                       Width="20" Height="20" />
                         </Button>
                     </Grid>
@@ -402,7 +403,7 @@
                                                 CommandParameter="Blue">
                                             <Grid>
                                                 <Border Width="48" Height="48" CornerRadius="24" Background="#3B82F6">
-                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                                               Width="20" Height="20" Foreground="White">
                                                         <PathIcon.IsVisible>
                                                             <Binding Path="SelectedAccentColor">
@@ -421,7 +422,7 @@
                                                 CommandParameter="Green">
                                             <Grid>
                                                 <Border Width="48" Height="48" CornerRadius="24" Background="#10B981">
-                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                                               Width="20" Height="20" Foreground="White">
                                                         <PathIcon.IsVisible>
                                                             <Binding Path="SelectedAccentColor">
@@ -440,7 +441,7 @@
                                                 CommandParameter="Purple">
                                             <Grid>
                                                 <Border Width="48" Height="48" CornerRadius="24" Background="#8B5CF6">
-                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                                               Width="20" Height="20" Foreground="White">
                                                         <PathIcon.IsVisible>
                                                             <Binding Path="SelectedAccentColor">
@@ -459,7 +460,7 @@
                                                 CommandParameter="Pink">
                                             <Grid>
                                                 <Border Width="48" Height="48" CornerRadius="24" Background="#EC4899">
-                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                                               Width="20" Height="20" Foreground="White">
                                                         <PathIcon.IsVisible>
                                                             <Binding Path="SelectedAccentColor">
@@ -478,7 +479,7 @@
                                                 CommandParameter="Orange">
                                             <Grid>
                                                 <Border Width="48" Height="48" CornerRadius="24" Background="#F97316">
-                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                                               Width="20" Height="20" Foreground="White">
                                                         <PathIcon.IsVisible>
                                                             <Binding Path="SelectedAccentColor">
@@ -497,7 +498,7 @@
                                                 CommandParameter="Teal">
                                             <Grid>
                                                 <Border Width="48" Height="48" CornerRadius="24" Background="#14B8A6">
-                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                                               Width="20" Height="20" Foreground="White">
                                                         <PathIcon.IsVisible>
                                                             <Binding Path="SelectedAccentColor">

--- a/ArgoBooks/Modals/StockAdjustmentsModals.axaml
+++ b/ArgoBooks/Modals/StockAdjustmentsModals.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ArgoBooks.Modals.StockAdjustmentsModals"
              x:DataType="vm:StockAdjustmentsModalsViewModel">
@@ -30,7 +31,7 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -173,7 +174,7 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseViewModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -226,7 +227,7 @@
                                                Foreground="{DynamicResource TextSecondaryBrush}" />
                                 </StackPanel>
                                 <PathIcon Grid.Column="1"
-                                          Data="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                                          Data="{x:Static local:Icons.ChevronRight}"
                                           Width="24" Height="24"
                                           Foreground="{DynamicResource TextTertiaryBrush}"
                                           Margin="16,0" />
@@ -300,7 +301,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/StockLevelsModals.axaml
+++ b/ArgoBooks/Modals/StockLevelsModals.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ArgoBooks.Modals.StockLevelsModals"
              x:DataType="vm:StockLevelsModalsViewModel">
@@ -30,7 +31,7 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                             </StackPanel>
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAdjustStockModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -141,7 +142,7 @@
                                        FontSize="18" FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddItemModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                                <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
                     </Border>
@@ -260,7 +261,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseFilterModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/SupplierModals.axaml
+++ b/ArgoBooks/Modals/SupplierModals.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              x:Class="ArgoBooks.Modals.SupplierModals"
              x:DataType="vm:SupplierModalsViewModel">
@@ -18,7 +19,7 @@
                        <Grid ColumnDefinitions="*,Auto">
                            <TextBlock Text="{loc:Loc 'Add Supplier'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                            <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseAddModalCommand}">
-                               <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                               <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                            </Button>
                        </Grid>
                    </Border>
@@ -101,7 +102,7 @@
                        <Grid ColumnDefinitions="*,Auto">
                            <TextBlock Text="{loc:Loc 'Edit Supplier'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                            <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseEditModalCommand}">
-                               <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                               <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                            </Button>
                        </Grid>
                    </Border>
@@ -184,7 +185,7 @@
                        <Grid ColumnDefinitions="*,Auto">
                            <TextBlock Text="{loc:Loc 'Filter Suppliers'}" FontSize="18" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                            <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseFilterModalCommand}">
-                               <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" Width="20" Height="20" />
+                               <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                            </Button>
                        </Grid>
                    </Border>

--- a/ArgoBooks/Modals/SwitchAccountModal.axaml
+++ b/ArgoBooks/Modals/SwitchAccountModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="500"
              x:Class="ArgoBooks.Modals.SwitchAccountModal"
              x:DataType="vm:SwitchAccountModalViewModel">
@@ -45,7 +46,7 @@
                         <Button Grid.Column="1"
                                 Classes="icon-button"
                                 Command="{Binding CloseCommand}">
-                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            <PathIcon Data="{x:Static local:Icons.Close}"
                                       Width="20" Height="20" />
                         </Button>
                     </Grid>
@@ -63,7 +64,7 @@
                             Padding="12,0">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                      Data="{x:Static local:Icons.Search}"
                                       Width="16" Height="16"
                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                       Margin="0,0,10,0"
@@ -121,7 +122,7 @@
 
                                             <!-- Arrow Indicator -->
                                             <PathIcon Grid.Column="2"
-                                                      Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                                      Data="{x:Static local:Icons.ChevronRightNav}"
                                                       Width="18" Height="18"
                                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                                       VerticalAlignment="Center" />
@@ -141,7 +142,7 @@
                                         CornerRadius="8"
                                         Background="{DynamicResource SurfaceHoverBrush}"
                                         Margin="0,0,14,0">
-                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                    <PathIcon Data="{x:Static local:Icons.Add}"
                                               Width="20" Height="20"
                                               Foreground="{DynamicResource TextSecondaryBrush}" />
                                 </Border>

--- a/ArgoBooks/Modals/UpgradeModal.axaml
+++ b/ArgoBooks/Modals/UpgradeModal.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="500"
              x:Class="ArgoBooks.Modals.UpgradeModal"
              x:DataType="vm:UpgradeModalViewModel">
@@ -39,7 +40,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static local:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -63,7 +64,7 @@
                                                         <GradientStop Color="#f59e0b" Offset="1" />
                                                     </LinearGradientBrush>
                                                 </Border.Background>
-                                                <PathIcon Data="M12 1l3.09 6.26L22 8.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 1z"
+                                                <PathIcon Data="{x:Static local:Icons.Star}"
                                                           Width="24" Height="24"
                                                           Foreground="White" />
                                             </Border>
@@ -116,7 +117,7 @@
                                         <Border Classes="feature-item">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -126,7 +127,7 @@
                                         <Border Classes="feature-item">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -136,7 +137,7 @@
                                         <Border Classes="feature-item">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -146,7 +147,7 @@
                                         <Border Classes="feature-item" BorderThickness="0">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -222,7 +223,7 @@
                                         <Border Classes="feature-item">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -232,7 +233,7 @@
                                         <Border Classes="feature-item">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -242,7 +243,7 @@
                                         <Border Classes="feature-item">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -252,7 +253,7 @@
                                         <Border Classes="feature-item">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -262,7 +263,7 @@
                                         <Border Classes="feature-item" BorderThickness="0">
                                             <Grid ColumnDefinitions="Auto,*">
                                                 <PathIcon Grid.Column="0"
-                                                          Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                          Data="{x:Static local:Icons.Check}"
                                                           Width="14" Height="14"
                                                           Foreground="#22C55E"
                                                           Margin="0,0,10,0" />
@@ -387,7 +388,7 @@
                                         Command="{Binding VerifyKeyCommand}"
                                         IsEnabled="{Binding !IsVerifying}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                        <PathIcon Data="{x:Static local:Icons.Check}"
                                                   Width="16" Height="16"
                                                   IsVisible="{Binding !IsVerifying}" />
                                         <TextBlock Text="{loc:Loc 'Verify Key'}" IsVisible="{Binding !IsVerifying}" />
@@ -440,7 +441,7 @@
                                 <Border.RenderTransform>
                                     <ScaleTransform ScaleX="0" ScaleY="0" />
                                 </Border.RenderTransform>
-                                <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                <PathIcon Data="{x:Static local:Icons.Check}"
                                           Width="48" Height="48"
                                           Foreground="White"
                                           HorizontalAlignment="Center"

--- a/ArgoBooks/Panels/CompanySwitcherPanel.axaml
+++ b/ArgoBooks/Panels/CompanySwitcherPanel.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="280" d:DesignHeight="400"
              x:Class="ArgoBooks.Panels.CompanySwitcherPanel"
              x:DataType="vm:CompanySwitcherPanelViewModel">
@@ -109,7 +110,7 @@
                                     ToolTip.Tip="{loc:Loc 'Edit Company'}"
                                     VerticalAlignment="Center"
                                     Margin="8,0,8,0">
-                                <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                <PathIcon Data="{x:Static local:Icons.Edit}"
                                           Width="14" Height="14" />
                             </Button>
 
@@ -119,7 +120,7 @@
                                     CornerRadius="12"
                                     Background="{DynamicResource SuccessBrush}"
                                     VerticalAlignment="Center">
-                                <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                <PathIcon Data="{x:Static local:Icons.Check}"
                                           Width="14" Height="14"
                                           Foreground="White" />
                             </Border>
@@ -194,7 +195,7 @@
                                     CornerRadius="8"
                                     Background="{DynamicResource PrimaryBrush}"
                                     Margin="0,0,12,0">
-                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                <PathIcon Data="{x:Static local:Icons.Add}"
                                           Width="18" Height="18"
                                           Foreground="White" />
                             </Border>
@@ -219,7 +220,7 @@
                                     CornerRadius="8"
                                     Background="{DynamicResource SurfaceAltBrush}"
                                     Margin="0,0,12,0">
-                                <PathIcon Data="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z"
+                                <PathIcon Data="{x:Static local:Icons.Folder}"
                                           Width="18" Height="18"
                                           Foreground="{DynamicResource TextSecondaryBrush}" />
                             </Border>

--- a/ArgoBooks/Panels/FileMenuPanel.axaml
+++ b/ArgoBooks/Panels/FileMenuPanel.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="260" d:DesignHeight="400"
              x:Class="ArgoBooks.Panels.FileMenuPanel"
              x:DataType="vm:FileMenuPanelViewModel">
@@ -48,7 +49,7 @@
                         Command="{Binding NewCompanyCommand}">
                     <Grid ColumnDefinitions="Auto,*">
                         <PathIcon Grid.Column="0"
-                                  Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                  Data="{x:Static local:Icons.Add}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Create New Company'}" VerticalAlignment="Center" />
@@ -61,7 +62,7 @@
                         Command="{Binding OpenCompanyCommand}">
                     <Grid ColumnDefinitions="Auto,*">
                         <PathIcon Grid.Column="0"
-                                  Data="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z"
+                                  Data="{x:Static local:Icons.Folder}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Open Company...'}" VerticalAlignment="Center" />
@@ -75,12 +76,12 @@
                         PointerExited="OpenRecent_PointerExited">
                     <Grid ColumnDefinitions="Auto,*,Auto">
                         <PathIcon Grid.Column="0"
-                                  Data="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                                  Data="{x:Static local:Icons.Clock}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Open Recent'}" VerticalAlignment="Center" />
                         <PathIcon Grid.Column="2"
-                                  Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                  Data="{x:Static local:Icons.ChevronRightNav}"
                                   Width="12" Height="12"
                                   Foreground="{DynamicResource TextTertiaryBrush}" />
                     </Grid>
@@ -97,7 +98,7 @@
                         Command="{Binding SaveCommand}">
                     <Grid ColumnDefinitions="Auto,*,Auto">
                         <PathIcon Grid.Column="0"
-                                  Data="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"
+                                  Data="{x:Static local:Icons.Save}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc Save}" VerticalAlignment="Center" />
@@ -114,7 +115,7 @@
                         Command="{Binding SaveAsCommand}">
                     <Grid ColumnDefinitions="Auto,*,Auto">
                         <PathIcon Grid.Column="0"
-                                  Data="M19 12v7H5v-7H3v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zm-6 .67l2.59-2.58L17 11.5l-5 5-5-5 1.41-1.41L11 12.67V3h2v9.67z"
+                                  Data="{x:Static local:Icons.Download}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Save As...'}" VerticalAlignment="Center" />
@@ -131,7 +132,7 @@
                         Command="{Binding CloseCompanyCommand}">
                     <Grid ColumnDefinitions="Auto,*">
                         <PathIcon Grid.Column="0"
-                                  Data="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                                  Data="{x:Static local:Icons.CloseCircle}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Close Company'}" VerticalAlignment="Center" />
@@ -149,7 +150,7 @@
                         Command="{Binding ImportCommand}">
                     <Grid ColumnDefinitions="Auto,*">
                         <PathIcon Grid.Column="0"
-                                  Data="M9 16h6v-6h4l-7-7-7 7h4zm-4 2h14v2H5z"
+                                  Data="{x:Static local:Icons.ImportData}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Import...'}" VerticalAlignment="Center" />
@@ -162,7 +163,7 @@
                         Command="{Binding ExportAsCommand}">
                     <Grid ColumnDefinitions="Auto,*">
                         <PathIcon Grid.Column="0"
-                                  Data="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                                  Data="{x:Static local:Icons.ExportData}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Export As...'}" VerticalAlignment="Center" />
@@ -180,7 +181,7 @@
                         Command="{Binding ShowInFolderCommand}">
                     <Grid ColumnDefinitions="Auto,*">
                         <PathIcon Grid.Column="0"
-                                  Data="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"
+                                  Data="{x:Static local:Icons.FolderFilled}"
                                   Width="18" Height="18"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Show Company in Folder'}" VerticalAlignment="Center" />
@@ -223,7 +224,7 @@
                                     CommandParameter="{Binding}">
                                 <Grid ColumnDefinitions="Auto,*">
                                     <PathIcon Grid.Column="0"
-                                              Data="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                                              Data="{x:Static local:Icons.Departments}"
                                               Width="16" Height="16"
                                               Margin="0,0,12,0" />
                                     <TextBlock Grid.Column="1" Text="{Binding Name}" VerticalAlignment="Center" />
@@ -246,7 +247,7 @@
                         IsVisible="{Binding HasFilteredRecentCompanies}">
                     <Grid ColumnDefinitions="Auto,*">
                         <PathIcon Grid.Column="0"
-                                  Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                  Data="{x:Static local:Icons.Delete}"
                                   Width="16" Height="16"
                                   Margin="0,0,12,0" />
                         <TextBlock Grid.Column="1" Text="{loc:Loc 'Clear Recent'}" VerticalAlignment="Center" />

--- a/ArgoBooks/Panels/HelpPanel.axaml
+++ b/ArgoBooks/Panels/HelpPanel.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="280" d:DesignHeight="350"
              x:Class="ArgoBooks.Panels.HelpPanel"
              x:DataType="vm:HelpPanelViewModel">
@@ -60,7 +61,7 @@
                             Command="{Binding OpenWhatsNewCommand}">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M20 6h-2.18c.11-.31.18-.65.18-1 0-1.66-1.34-3-3-3-1.05 0-1.96.54-2.5 1.35l-.5.67-.5-.68C10.96 2.54 10.05 2 9 2 7.34 2 6 3.34 6 5c0 .35.07.69.18 1H4c-1.11 0-1.99.89-1.99 2L2 19c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V8c0-1.11-.89-2-2-2zm-5-2c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zM9 4c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm11 15H4v-2h16v2zm0-5H4V8h5.08L7 10.83 8.62 12 11 8.76l1-1.36 1 1.36L15.38 12 17 10.83 14.92 8H20v6z"
+                                      Data="{x:Static local:Icons.Gift}"
                                       Width="20" Height="20"
                                       Foreground="{DynamicResource TextSecondaryBrush}"
                                       Margin="0,0,12,0" />
@@ -74,7 +75,7 @@
                             Command="{Binding OpenDocumentationCommand}">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z"
+                                      Data="{x:Static local:Icons.Book}"
                                       Width="20" Height="20"
                                       Foreground="{DynamicResource TextSecondaryBrush}"
                                       Margin="0,0,12,0" />
@@ -88,7 +89,7 @@
                             Command="{Binding OpenCommunityCommand}">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"
+                                      Data="{x:Static local:Icons.Customers}"
                                       Width="20" Height="20"
                                       Foreground="{DynamicResource TextSecondaryBrush}"
                                       Margin="0,0,12,0" />
@@ -102,7 +103,7 @@
                             Command="{Binding OpenSupportCommand}">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M20 15.5c-1.25 0-2.45-.2-3.57-.57-.35-.11-.74-.03-1.02.24l-2.2 2.2c-2.83-1.44-5.15-3.75-6.59-6.59l2.2-2.21c.28-.26.36-.65.25-1C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.5c0-.55-.45-1-1-1zM19 12h2c0-4.97-4.03-9-9-9v2c3.87 0 7 3.13 7 7zm-4 0h2c0-2.76-2.24-5-5-5v2c1.66 0 3 1.34 3 3z"
+                                      Data="{x:Static local:Icons.Phone}"
                                       Width="20" Height="20"
                                       Foreground="{DynamicResource TextSecondaryBrush}"
                                       Margin="0,0,12,0" />
@@ -121,7 +122,7 @@
                             Command="{Binding CheckForUpdatesCommand}">
                         <Grid ColumnDefinitions="Auto,*,Auto">
                             <PathIcon Grid.Column="0"
-                                      Data="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                                      Data="{x:Static local:Icons.Refresh}"
                                       Width="20" Height="20"
                                       Foreground="{DynamicResource TextSecondaryBrush}"
                                       Margin="0,0,12,0" />

--- a/ArgoBooks/Panels/NotificationPanel.axaml
+++ b/ArgoBooks/Panels/NotificationPanel.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="360" d:DesignHeight="500"
              x:Class="ArgoBooks.Panels.NotificationPanel"
              x:DataType="vm:NotificationPanelViewModel">
@@ -82,7 +83,7 @@
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     Margin="0,60">
-                            <PathIcon Data="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
+                            <PathIcon Data="{x:Static local:Icons.Notification}"
                                       Width="48" Height="48"
                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                       HorizontalAlignment="Center"
@@ -122,27 +123,27 @@
                                                 </Border.Styles>
                                                 <Panel>
                                                     <!-- Info Icon -->
-                                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                                                    <PathIcon Data="{x:Static local:Icons.Info}"
                                                               Width="18" Height="18"
                                                               Foreground="{DynamicResource PrimaryBrush}"
                                                               IsVisible="{Binding Type, Converter={x:Static vm:NotificationTypeConverters.IsInfo}}" />
                                                     <!-- Success Icon -->
-                                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                                    <PathIcon Data="{x:Static local:Icons.CircleCheck}"
                                                               Width="18" Height="18"
                                                               Foreground="{DynamicResource SuccessBrush}"
                                                               IsVisible="{Binding Type, Converter={x:Static vm:NotificationTypeConverters.IsSuccess}}" />
                                                     <!-- Warning Icon -->
-                                                    <PathIcon Data="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                                                    <PathIcon Data="{x:Static local:Icons.LostDamaged}"
                                                               Width="18" Height="18"
                                                               Foreground="{DynamicResource WarningBrush}"
                                                               IsVisible="{Binding Type, Converter={x:Static vm:NotificationTypeConverters.IsWarning}}" />
                                                     <!-- Error Icon -->
-                                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                                    <PathIcon Data="{x:Static local:Icons.Info}"
                                                               Width="18" Height="18"
                                                               Foreground="{DynamicResource DangerBrush}"
                                                               IsVisible="{Binding Type, Converter={x:Static vm:NotificationTypeConverters.IsError}}" />
                                                     <!-- System Icon -->
-                                                    <PathIcon Data="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+                                                    <PathIcon Data="{x:Static local:Icons.Settings}"
                                                               Width="18" Height="18"
                                                               Foreground="{DynamicResource TextSecondaryBrush}"
                                                               IsVisible="{Binding Type, Converter={x:Static vm:NotificationTypeConverters.IsSystem}}" />
@@ -180,7 +181,7 @@
                                                         CommandParameter="{Binding}"
                                                         ToolTip.Tip="{loc:Loc 'Mark as read'}"
                                                         IsVisible="{Binding !IsRead}">
-                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                    <PathIcon Data="{x:Static local:Icons.Check}"
                                                               Width="14" Height="14" />
                                                 </Button>
                                                 <!-- Dismiss Button -->
@@ -188,7 +189,7 @@
                                                         Command="{Binding $parent[UserControl].((vm:NotificationPanelViewModel)DataContext).RemoveNotificationCommand}"
                                                         CommandParameter="{Binding}"
                                                         ToolTip.Tip="{loc:Loc Dismiss}">
-                                                    <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                    <PathIcon Data="{x:Static local:Icons.Close}"
                                                               Width="14" Height="14" />
                                                 </Button>
                                             </StackPanel>
@@ -217,7 +218,7 @@
                                 Command="{Binding OpenSettingsCommand}"
                                 HorizontalAlignment="Right">
                             <StackPanel Orientation="Horizontal" Spacing="6">
-                                <PathIcon Data="M12 15.5A3.5 3.5 0 0 1 8.5 12 3.5 3.5 0 0 1 12 8.5a3.5 3.5 0 0 1 3.5 3.5 3.5 3.5 0 0 1-3.5 3.5m7.43-2.53c.04-.32.07-.64.07-.97s-.03-.66-.07-1l2.11-1.63c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.31-.61-.22l-2.49 1c-.52-.39-1.06-.73-1.69-.98l-.37-2.65A.506.506 0 0 0 14 2h-4c-.25 0-.46.18-.5.42l-.37 2.65c-.63.25-1.17.59-1.69.98l-2.49-1c-.22-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64L4.57 11c-.04.34-.07.67-.07 1s.03.65.07.97l-2.11 1.66c-.19.15-.25.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1.01c.52.4 1.06.74 1.69.99l.37 2.65c.04.24.25.42.5.42h4c.25 0 .46-.18.5-.42l.37-2.65c.63-.26 1.17-.59 1.69-.99l2.49 1.01c.22.08.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.66z"
+                                <PathIcon Data="{x:Static local:Icons.Settings}"
                                           Width="14" Height="14" />
                                 <TextBlock Text="{loc:Loc Settings}" />
                             </StackPanel>

--- a/ArgoBooks/Panels/UserPanel.axaml
+++ b/ArgoBooks/Panels/UserPanel.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="260" d:DesignHeight="300"
              x:Class="ArgoBooks.Panels.UserPanel"
              x:DataType="vm:UserPanelViewModel">
@@ -96,7 +97,7 @@
                             IsVisible="False">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                                      Data="{x:Static local:Icons.Employees}"
                                       Width="18" Height="18"
                                       Margin="0,0,12,0" />
                             <TextBlock Grid.Column="1" Text="{loc:Loc 'My Profile'}" VerticalAlignment="Center" />
@@ -110,7 +111,7 @@
                             IsVisible="{Binding HasPremium}">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M12 1l3.09 6.26L22 8.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 1z"
+                                      Data="{x:Static local:Icons.Star}"
                                       Width="18" Height="18"
                                       Margin="0,0,12,0" />
                             <TextBlock Grid.Column="1" Text="{loc:Loc 'My Plan'}" VerticalAlignment="Center" />
@@ -123,7 +124,7 @@
                             Command="{Binding OpenSettingsCommand}">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+                                      Data="{x:Static local:Icons.Settings}"
                                       Width="18" Height="18"
                                       Margin="0,0,12,0" />
                             <TextBlock Grid.Column="1" Text="{loc:Loc Settings}" VerticalAlignment="Center" />
@@ -141,7 +142,7 @@
                             Command="{Binding SwitchAccountCommand}">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"
+                                      Data="{x:Static local:Icons.Transfers}"
                                       Width="18" Height="18"
                                       Margin="0,0,12,0" />
                             <TextBlock Grid.Column="1" Text="{loc:Loc 'Switch Account'}" VerticalAlignment="Center" />
@@ -154,7 +155,7 @@
                             Command="{Binding SignOutCommand}">
                         <Grid ColumnDefinitions="Auto,*">
                             <PathIcon Grid.Column="0"
-                                      Data="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"
+                                      Data="{x:Static local:Icons.Logout}"
                                       Width="18" Height="18"
                                       Margin="0,0,12,0" />
                             <TextBlock Grid.Column="1" Text="{loc:Loc 'Log Out'}" VerticalAlignment="Center" />

--- a/ArgoBooks/ViewModels/QuickActionsViewModel.cs
+++ b/ArgoBooks/ViewModels/QuickActionsViewModel.cs
@@ -133,72 +133,72 @@ public partial class QuickActionsViewModel : ViewModelBase
     {
         // Quick Actions - Creation tasks
         _allActions.AddRange([
-            new QuickActionItem("New Invoice", "Create a new invoice", "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z", QuickActionType.QuickAction, "Invoices", "OpenAddModal"),
-            new QuickActionItem("New Expense", "Record a new expense", "M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z", QuickActionType.QuickAction, "Expenses", "OpenAddModal"),
-            new QuickActionItem("New Revenue", "Record a new revenue entry", "M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z", QuickActionType.QuickAction, "Revenue", "OpenAddModal"),
-            new QuickActionItem("Scan Receipt", "Scan and import a receipt using AI", "M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z", QuickActionType.QuickAction, "Receipts", "OpenScanModal"),
-            new QuickActionItem("New Customer", "Add a new customer", "M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z", QuickActionType.QuickAction, "Customers", "OpenAddModal"),
-            new QuickActionItem("New Product", "Add a new product or service", "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z", QuickActionType.QuickAction, "Products", "OpenAddModal"),
-            new QuickActionItem("New Supplier", "Add a new supplier", "M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4z", QuickActionType.QuickAction, "Suppliers", "OpenAddModal"),
-            new QuickActionItem("Record Payment", "Record a payment received", "M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z", QuickActionType.QuickAction, "Payments", "OpenAddModal"),
-            new QuickActionItem("New Rental Item", "Add a new rental item", "M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zM7 4V3h10v1H7zm0 14V6h10v12H7zm0 3v-1h10v1H7z", QuickActionType.QuickAction, "RentalInventory", "OpenAddModal"),
-            new QuickActionItem("New Rental Record", "Create a new rental transaction", "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z", QuickActionType.QuickAction, "RentalRecords", "OpenAddModal"),
-            new QuickActionItem("New Category", "Add a new category", "M12 2l-5.5 9h11L12 2zm0 3.84L13.93 9h-3.87L12 5.84z", QuickActionType.QuickAction, "Categories", "OpenAddModal"),
-            new QuickActionItem("New Location", "Add a new location", "M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z", QuickActionType.QuickAction, "Locations", "OpenAddModal"),
-            new QuickActionItem("New Purchase Order", "Create a new purchase order", "M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6-2c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm6 16H6V8h2v2c0 .55.45 1 1 1s1-.45 1-1V8h4v2c0 .55.45 1 1 1s1-.45 1-1V8h2v12z", QuickActionType.QuickAction, "PurchaseOrders", "OpenAddModal"),
-            new QuickActionItem("New Stock Adjustment", "Record a stock adjustment", "M19 3H14.82C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z", QuickActionType.QuickAction, "Adjustments", "OpenAddModal"),
-            new QuickActionItem("New Accountant", "Add a new accountant", "M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-2 14l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z", QuickActionType.QuickAction, "Accountants", "OpenAddModal"),
-            new QuickActionItem("New Return", "Record a customer return", "M19 8l-4 4h3c0 3.31-2.69 6-6 6-1.01 0-1.97-.25-2.8-.7l-1.46 1.46C8.97 19.54 10.43 20 12 20c4.42 0 8-3.58 8-8h3l-4-4zM6 12c0-3.31 2.69-6 6-6 1.01 0 1.97.25 2.8.7l1.46-1.46C15.03 4.46 13.57 4 12 4c-4.42 0-8 3.58-8 8H1l4 4 4-4H6z", QuickActionType.QuickAction, "Returns", "OpenAddModal"),
-            new QuickActionItem("New Transfer", "Create inventory transfer", "M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z", QuickActionType.QuickAction, "Transfers", "OpenAddModal"),
+            new QuickActionItem("New Invoice", "Create a new invoice", Icons.Invoices, QuickActionType.QuickAction, "Invoices", "OpenAddModal"),
+            new QuickActionItem("New Expense", "Record a new expense", Icons.Expenses, QuickActionType.QuickAction, "Expenses", "OpenAddModal"),
+            new QuickActionItem("New Revenue", "Record a new revenue entry", Icons.Revenue, QuickActionType.QuickAction, "Revenue", "OpenAddModal"),
+            new QuickActionItem("Scan Receipt", "Scan and import a receipt using AI", Icons.ScanReceipt, QuickActionType.QuickAction, "Receipts", "OpenScanModal"),
+            new QuickActionItem("New Customer", "Add a new customer", Icons.NewCustomer, QuickActionType.QuickAction, "Customers", "OpenAddModal"),
+            new QuickActionItem("New Product", "Add a new product or service", Icons.NewProduct, QuickActionType.QuickAction, "Products", "OpenAddModal"),
+            new QuickActionItem("New Supplier", "Add a new supplier", Icons.Suppliers, QuickActionType.QuickAction, "Suppliers", "OpenAddModal"),
+            new QuickActionItem("Record Payment", "Record a payment received", Icons.Payments, QuickActionType.QuickAction, "Payments", "OpenAddModal"),
+            new QuickActionItem("New Rental Item", "Add a new rental item", Icons.NewRentalItem, QuickActionType.QuickAction, "RentalInventory", "OpenAddModal"),
+            new QuickActionItem("New Rental Record", "Create a new rental transaction", Icons.RentalRecords, QuickActionType.QuickAction, "RentalRecords", "OpenAddModal"),
+            new QuickActionItem("New Category", "Add a new category", Icons.Categories, QuickActionType.QuickAction, "Categories", "OpenAddModal"),
+            new QuickActionItem("New Location", "Add a new location", Icons.Locations, QuickActionType.QuickAction, "Locations", "OpenAddModal"),
+            new QuickActionItem("New Purchase Order", "Create a new purchase order", Icons.NewPurchaseOrder, QuickActionType.QuickAction, "PurchaseOrders", "OpenAddModal"),
+            new QuickActionItem("New Stock Adjustment", "Record a stock adjustment", Icons.NewStockAdjustment, QuickActionType.QuickAction, "Adjustments", "OpenAddModal"),
+            new QuickActionItem("New Accountant", "Add a new accountant", Icons.NewAccountant, QuickActionType.QuickAction, "Accountants", "OpenAddModal"),
+            new QuickActionItem("New Return", "Record a customer return", Icons.NewReturn, QuickActionType.QuickAction, "Returns", "OpenAddModal"),
+            new QuickActionItem("New Transfer", "Create inventory transfer", Icons.Transfers, QuickActionType.QuickAction, "Transfers", "OpenAddModal"),
         ]);
 
         // Navigation - Go to pages
         _allActions.AddRange([
             // Main
-            new QuickActionItem("Dashboard", "Go to Dashboard", "M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z", QuickActionType.Navigation, "Dashboard"),
-            new QuickActionItem("Analytics", "View analytics and charts", "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z", QuickActionType.Navigation, "Analytics"),
-            new QuickActionItem("Reports", "Generate and view reports", "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z", QuickActionType.Navigation, "Reports"),
-            new QuickActionItem("Insights", "View business insights (Premium)", "M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6C7.8 12.16 7 10.63 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z", QuickActionType.Navigation, "Insights"),
+            new QuickActionItem("Dashboard", "Go to Dashboard", Icons.Dashboard, QuickActionType.Navigation, "Dashboard"),
+            new QuickActionItem("Analytics", "View analytics and charts", Icons.Analytics, QuickActionType.Navigation, "Analytics"),
+            new QuickActionItem("Reports", "Generate and view reports", Icons.Reports, QuickActionType.Navigation, "Reports"),
+            new QuickActionItem("Insights", "View business insights (Premium)", Icons.Insights, QuickActionType.Navigation, "Insights"),
 
             // Transactions
-            new QuickActionItem("Expenses", "View and manage expenses", "M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z", QuickActionType.Navigation, "Expenses"),
-            new QuickActionItem("Revenue", "View and manage revenue", "M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z", QuickActionType.Navigation, "Revenue"),
-            new QuickActionItem("Invoices", "Manage invoices", "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6z", QuickActionType.Navigation, "Invoices"),
-            new QuickActionItem("Payments", "View payment records", "M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2z", QuickActionType.Navigation, "Payments"),
-            new QuickActionItem("Receipts", "View and manage receipts", "M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z", QuickActionType.Navigation, "Receipts"),
-            new QuickActionItem("Purchase Orders", "Manage purchase orders", "M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6-2c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm6 16H6V8h2v2c0 .55.45 1 1 1s1-.45 1-1V8h4v2c0 .55.45 1 1 1s1-.45 1-1V8h2v12z", QuickActionType.Navigation, "PurchaseOrders"),
-            new QuickActionItem("Returns", "Manage returns", "M19 8l-4 4h3c0 3.31-2.69 6-6 6-1.01 0-1.97-.25-2.8-.7l-1.46 1.46C8.97 19.54 10.43 20 12 20c4.42 0 8-3.58 8-8h3l-4-4zM6 12c0-3.31 2.69-6 6-6 1.01 0 1.97.25 2.8.7l1.46-1.46C15.03 4.46 13.57 4 12 4c-4.42 0-8 3.58-8 8H1l4 4 4-4H6z", QuickActionType.Navigation, "Returns"),
-            new QuickActionItem("Lost & Damaged", "Track lost and damaged items", "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z", QuickActionType.Navigation, "LostDamaged"),
+            new QuickActionItem("Expenses", "View and manage expenses", Icons.Expenses, QuickActionType.Navigation, "Expenses"),
+            new QuickActionItem("Revenue", "View and manage revenue", Icons.Revenue, QuickActionType.Navigation, "Revenue"),
+            new QuickActionItem("Invoices", "Manage invoices", Icons.Invoices, QuickActionType.Navigation, "Invoices"),
+            new QuickActionItem("Payments", "View payment records", Icons.Payments, QuickActionType.Navigation, "Payments"),
+            new QuickActionItem("Receipts", "View and manage receipts", Icons.Receipts, QuickActionType.Navigation, "Receipts"),
+            new QuickActionItem("Purchase Orders", "Manage purchase orders", Icons.PurchaseOrders, QuickActionType.Navigation, "PurchaseOrders"),
+            new QuickActionItem("Returns", "Manage returns", Icons.Returns, QuickActionType.Navigation, "Returns"),
+            new QuickActionItem("Lost & Damaged", "Track lost and damaged items", Icons.LostDamaged, QuickActionType.Navigation, "LostDamaged"),
 
             // Contacts
-            new QuickActionItem("Customers", "Manage customers", "M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3z", QuickActionType.Navigation, "Customers"),
-            new QuickActionItem("Suppliers", "Manage suppliers", "M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4z", QuickActionType.Navigation, "Suppliers"),
-            new QuickActionItem("Accountants", "Manage accountants", "M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-2 14l-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z", QuickActionType.Navigation, "Accountants"),
+            new QuickActionItem("Customers", "Manage customers", Icons.Customers, QuickActionType.Navigation, "Customers"),
+            new QuickActionItem("Suppliers", "Manage suppliers", Icons.Suppliers, QuickActionType.Navigation, "Suppliers"),
+            new QuickActionItem("Accountants", "Manage accountants", Icons.Accountants, QuickActionType.Navigation, "Accountants"),
 
             // Inventory
-            new QuickActionItem("Products", "Manage products and services", "M20 2H4c-1 0-2 .9-2 2v3.01c0 .72.43 1.34 1 1.69V20c0 1.1 1.1 2 2 2h14c.9 0 2-.9 2-2V8.7c.57-.35 1-.97 1-1.69V4c0-1.1-1-2-2-2z", QuickActionType.Navigation, "Products"),
-            new QuickActionItem("Stock Levels", "Monitor inventory levels", "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM7 10h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z", QuickActionType.Navigation, "StockLevels"),
-            new QuickActionItem("Adjustments", "Manage stock adjustments", "M19 3H14.82C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z", QuickActionType.Navigation, "Adjustments"),
-            new QuickActionItem("Categories", "Manage categories", "M12 2l-5.5 9h11L12 2zm0 3.84L13.93 9h-3.87L12 5.84z", QuickActionType.Navigation, "Categories"),
-            new QuickActionItem("Locations", "Manage locations (Enterprise)", "M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z", QuickActionType.Navigation, "Locations"),
-            new QuickActionItem("Transfers", "Manage inventory transfers (Enterprise)", "M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z", QuickActionType.Navigation, "Transfers"),
+            new QuickActionItem("Products", "Manage products and services", Icons.Products, QuickActionType.Navigation, "Products"),
+            new QuickActionItem("Stock Levels", "Monitor inventory levels", Icons.StockLevels, QuickActionType.Navigation, "StockLevels"),
+            new QuickActionItem("Adjustments", "Manage stock adjustments", Icons.Adjustments, QuickActionType.Navigation, "Adjustments"),
+            new QuickActionItem("Categories", "Manage categories", Icons.Categories, QuickActionType.Navigation, "Categories"),
+            new QuickActionItem("Locations", "Manage locations (Enterprise)", Icons.Locations, QuickActionType.Navigation, "Locations"),
+            new QuickActionItem("Transfers", "Manage inventory transfers (Enterprise)", Icons.Transfers, QuickActionType.Navigation, "Transfers"),
 
             // Rentals
-            new QuickActionItem("Rental Inventory", "Manage rental items", "M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2z", QuickActionType.Navigation, "RentalInventory"),
-            new QuickActionItem("Rental Records", "View rental transactions", "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z", QuickActionType.Navigation, "RentalRecords"),
+            new QuickActionItem("Rental Inventory", "Manage rental items", Icons.RentalInventory, QuickActionType.Navigation, "RentalInventory"),
+            new QuickActionItem("Rental Records", "View rental transactions", Icons.RentalRecords, QuickActionType.Navigation, "RentalRecords"),
         ]);
 
         // Tools & Settings
         _allActions.AddRange([
-            new QuickActionItem("Settings", "Configure application settings", "M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z", QuickActionType.Tools, null, "OpenSettings"),
-            new QuickActionItem("Edit Company", "Edit company information", "M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z", QuickActionType.Tools, null, "OpenEditCompany"),
-            new QuickActionItem("View Profile", "View your profile", "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z", QuickActionType.Tools, null, "OpenProfile"),
-            new QuickActionItem("Switch Account", "Switch to another account", "M16.67 13.13C18.04 14.06 19 15.32 19 17v3h4v-3c0-2.18-3.57-3.47-6.33-3.87zM15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4c-.47 0-.91.1-1.33.24C14.5 5.27 15 6.58 15 8s-.5 2.73-1.33 3.76c.42.14.86.24 1.33.24zM9 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0-6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zM9 13c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4z", QuickActionType.Tools, null, "OpenSwitchAccount"),
-            new QuickActionItem("Check for Updates", "Check for application updates", "M21 10.12h-6.78l2.74-2.82c-2.73-2.7-7.15-2.8-9.88-.1-2.73 2.71-2.73 7.08 0 9.79 2.73 2.71 7.15 2.71 9.88 0C18.32 15.65 19 14.08 19 12.1h2c0 1.98-.88 4.55-2.64 6.29-3.51 3.48-9.21 3.48-12.72 0-3.5-3.47-3.53-9.11-.02-12.58 3.51-3.47 9.14-3.47 12.65 0L21 3v7.12zM12.5 8v4.25l3.5 2.08-.72 1.21L11 13V8h1.5z", QuickActionType.Tools, null, "OpenCheckForUpdates"),
-            new QuickActionItem("Export Data", "Export your data", "M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z", QuickActionType.Tools, null, "OpenExport"),
-            new QuickActionItem("Import Data", "Import data from file", "M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z", QuickActionType.Tools, null, "OpenImport"),
-            new QuickActionItem("Help & Support", "Get help and documentation", "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z", QuickActionType.Tools, null, "OpenHelp"),
-            new QuickActionItem("Keyboard Shortcuts", "View keyboard shortcuts", "M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z", QuickActionType.Tools, null, "OpenKeyboardShortcuts"),
+            new QuickActionItem("Settings", "Configure application settings", Icons.Settings, QuickActionType.Tools, null, "OpenSettings"),
+            new QuickActionItem("Edit Company", "Edit company information", Icons.EditCompany, QuickActionType.Tools, null, "OpenEditCompany"),
+            new QuickActionItem("View Profile", "View your profile", Icons.ViewProfile, QuickActionType.Tools, null, "OpenProfile"),
+            new QuickActionItem("Switch Account", "Switch to another account", Icons.SwitchAccount, QuickActionType.Tools, null, "OpenSwitchAccount"),
+            new QuickActionItem("Check for Updates", "Check for application updates", Icons.CheckForUpdates, QuickActionType.Tools, null, "OpenCheckForUpdates"),
+            new QuickActionItem("Export Data", "Export your data", Icons.ExportData, QuickActionType.Tools, null, "OpenExport"),
+            new QuickActionItem("Import Data", "Import data from file", Icons.ImportData, QuickActionType.Tools, null, "OpenImport"),
+            new QuickActionItem("Help & Support", "Get help and documentation", Icons.Help, QuickActionType.Tools, null, "OpenHelp"),
+            new QuickActionItem("Keyboard Shortcuts", "View keyboard shortcuts", Icons.KeyboardShortcuts, QuickActionType.Tools, null, "OpenKeyboardShortcuts"),
         ]);
     }
 

--- a/ArgoBooks/ViewModels/SidebarViewModel.cs
+++ b/ArgoBooks/ViewModels/SidebarViewModel.cs
@@ -145,77 +145,52 @@ public partial class SidebarViewModel : ViewModelBase
     private void InitializeNavigationItems()
     {
         // Main Section (mockup: Dashboard, Analytics, Insights, Reports)
-        MainItems.Add(CreateItem("Dashboard", "Dashboard",
-            "M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z")); // fa-home
-        MainItems.Add(CreateItem("Analytics", "Analytics",
-            "M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z")); // fa-chart-line
-        _insightsItem = CreateItem("Insights", "Insights",
-            "M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6C7.8 12.16 7 10.63 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z"); // fa-lightbulb
+        MainItems.Add(CreateItem("Dashboard", "Dashboard", Icons.Dashboard));
+        MainItems.Add(CreateItem("Analytics", "Analytics", Icons.Analytics));
+        _insightsItem = CreateItem("Insights", "Insights", Icons.Insights);
         _insightsItem.IsVisible = HasPremium; // Hide by default unless premium
         MainItems.Add(_insightsItem);
-        MainItems.Add(CreateItem("Reports", "Reports",
-            "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z")); // fa-file-alt
+        MainItems.Add(CreateItem("Reports", "Reports", Icons.Reports));
 
         // Transactions Section (mockup: Expenses, Revenue, Invoices, Payments)
-        TransactionItems.Add(CreateItem("Expenses", "Expenses",
-            "M20 12l-1-1L13 16V4h-2v12l-5-5L4 12l8 8 8-8z")); // fa-arrow-down (shortened wings)
-        TransactionItems.Add(CreateItem("Revenue", "Revenue",
-            "M4 12l1 1L11 8V20h2V8l5 5L20 12l-8-8-8 8z")); // fa-arrow-up (shortened wings)
-        _invoicesItem = CreateItem("Invoices", "Invoices",
-            "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"); // fa-file-invoice
+        TransactionItems.Add(CreateItem("Expenses", "Expenses", Icons.Expenses));
+        TransactionItems.Add(CreateItem("Revenue", "Revenue", Icons.Revenue));
+        _invoicesItem = CreateItem("Invoices", "Invoices", Icons.Invoices);
         _invoicesItem.IsVisible = HasPremium; // Hide by default unless premium
         TransactionItems.Add(_invoicesItem);
-        _paymentsItem = CreateItem("Payments", "Payments",
-            "M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"); // fa-credit-card
+        _paymentsItem = CreateItem("Payments", "Payments", Icons.Payments);
         _paymentsItem.IsVisible = HasPremium; // Hide by default unless premium
         TransactionItems.Add(_paymentsItem);
 
         // Rentals Section (mockup: Rental Inventory, Rental Records)
-        RentalItems.Add(CreateItem("Rental Inventory", "RentalInventory",
-            "M21 3H3C1.9 3 1 3.9 1 5v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14zM5 15h14v2H5zm0-4h14v2H5zm0-4h14v2H5z")); // fa-box
-        RentalItems.Add(CreateItem("Rental Records", "RentalRecords",
-            "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z")); // fa-clipboard-list (with check)
+        RentalItems.Add(CreateItem("Rental Inventory", "RentalInventory", Icons.RentalInventory));
+        RentalItems.Add(CreateItem("Rental Records", "RentalRecords", Icons.RentalRecords));
 
         // Management Section (mockup: Customers, Products/Services, Categories, Suppliers)
-        ManagementItems.Add(CreateItem("Customers", "Customers",
-            "M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z")); // fa-users
-        ManagementItems.Add(CreateItem("Products/Services", "Products",
-            "M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.16.12-.36.18-.57.18-.21 0-.41-.06-.57-.18l-7.9-4.44A.991.991 0 0 1 3 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.16-.12.36-.18.57-.18.21 0 .41.06.57.18l7.9 4.44c.32.17.53.5.53.88v9zM12 4.15L6.04 7.5 12 10.85l5.96-3.35L12 4.15z")); // fa-cube
-        ManagementItems.Add(CreateItem("Categories", "Categories",
-            "M17.63 5.84C17.27 5.33 16.67 5 16 5L5 5.01C3.9 5.01 3 5.9 3 7v10c0 1.1.9 1.99 2 1.99L16 19c.67 0 1.27-.33 1.63-.84L22 12l-4.37-6.16z")); // fa-tags
-        ManagementItems.Add(CreateItem("Suppliers", "Suppliers",
-            "M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm13.5-9l1.96 2.5H17V9.5h2.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z")); // fa-truck
+        ManagementItems.Add(CreateItem("Customers", "Customers", Icons.Customers));
+        ManagementItems.Add(CreateItem("Products/Services", "Products", Icons.Products));
+        ManagementItems.Add(CreateItem("Categories", "Categories", Icons.Categories));
+        ManagementItems.Add(CreateItem("Suppliers", "Suppliers", Icons.Suppliers));
 
         // Inventory Section (mockup: Stock Levels, Adjustments, Locations, Transfers, Purchase Orders)
-        InventoryItems.Add(CreateItem("Stock Levels", "StockLevels",
-            "M22 18V3H2v15H0v2h24v-2h-2zm-2-1H4V5h16v12zM6 15h2v-5H6v5zm4 0h2V8h-2v7zm4 0h2v-3h-2v3z")); // fa-warehouse
-        InventoryItems.Add(CreateItem("Adjustments", "StockAdjustments",
-            "M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z")); // fa-sliders-h
-        _locationsItem = CreateItem("Locations", "Locations",
-            "M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"); // fa-map-marker-alt
+        InventoryItems.Add(CreateItem("Stock Levels", "StockLevels", Icons.StockLevels));
+        InventoryItems.Add(CreateItem("Adjustments", "StockAdjustments", Icons.Adjustments));
+        _locationsItem = CreateItem("Locations", "Locations", Icons.Locations);
         InventoryItems.Add(_locationsItem);
-        _transfersItem = CreateItem("Transfers", "Transfers",
-            "M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"); // fa-exchange-alt
+        _transfersItem = CreateItem("Transfers", "Transfers", Icons.Transfers);
         _transfersItem.IsVisible = HasEnterprise; // Hidden until enterprise plan
         InventoryItems.Add(_transfersItem);
-        InventoryItems.Add(CreateItem("Purchase Orders", "PurchaseOrders",
-            "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z")); // fa-clipboard-list
+        InventoryItems.Add(CreateItem("Purchase Orders", "PurchaseOrders", Icons.PurchaseOrders));
 
         // Team Section (mockup: Employees, Departments, Accountants)
-        TeamItems.Add(CreateItem("Employees", "Employees",
-            "M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z")); // fa-user-tie (simplified)
-        TeamItems.Add(CreateItem("Departments", "Departments",
-            "M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z")); // fa-building
-        TeamItems.Add(CreateItem("Accountants", "Accountants",
-            "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-6 14h-2v-4H7v-2h4V7h2v4h4v2h-4v4z")); // fa-calculator (centered plus)
+        TeamItems.Add(CreateItem("Employees", "Employees", Icons.Employees));
+        TeamItems.Add(CreateItem("Departments", "Departments", Icons.Departments));
+        TeamItems.Add(CreateItem("Accountants", "Accountants", Icons.Accountants));
 
         // Tracking Section (mockup: Returns, Lost/Damaged, Receipts)
-        TrackingItems.Add(CreateItem("Returns", "Returns",
-            "M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z")); // fa-undo
-        TrackingItems.Add(CreateItem("Lost/Damaged", "LostDamaged",
-            "M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z")); // fa-exclamation-triangle
-        TrackingItems.Add(CreateItem("Receipts", "Receipts",
-            "M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z")); // fa-receipt
+        TrackingItems.Add(CreateItem("Returns", "Returns", Icons.Returns));
+        TrackingItems.Add(CreateItem("Lost/Damaged", "LostDamaged", Icons.LostDamaged));
+        TrackingItems.Add(CreateItem("Receipts", "Receipts", Icons.Receipts));
 
         // Set Dashboard as active by default
         SetActivePage("Dashboard");

--- a/ArgoBooks/Views/AnalyticsPage.axaml
+++ b/ArgoBooks/Views/AnalyticsPage.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:modals="using:ArgoBooks.Modals"
+             xmlns:local="using:ArgoBooks"
              xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1400" d:DesignHeight="900"

--- a/ArgoBooks/Views/CategoriesPage.axaml
+++ b/ArgoBooks/Views/CategoriesPage.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
@@ -70,7 +71,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -89,7 +90,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'Add Category'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Category'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -271,7 +272,7 @@
                                                                         IsVisible="{Binding !IsChild}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:CategoriesPageViewModel)DataContext).OpenAddSubCategoryModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Add}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <!-- Move to different parent/make sub-category -->
@@ -279,21 +280,21 @@
                                                                         ToolTip.Tip="{loc:Loc 'Move to different category'}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:CategoriesPageViewModel)DataContext).OpenMoveModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.ChevronRight}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button"
                                                                         ToolTip.Tip="{loc:Loc Edit}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:CategoriesPageViewModel)DataContext).OpenEditModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button danger"
                                                                         ToolTip.Tip="{loc:Loc Delete}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:CategoriesPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -314,7 +315,7 @@
                                         CornerRadius="32"
                                         Background="{DynamicResource SurfaceAltBrush}"
                                         HorizontalAlignment="Center">
-                                    <PathIcon Data="M17.63 5.84C17.27 5.33 16.67 5 16 5L5 5.01C3.9 5.01 3 5.9 3 7v10c0 1.1.9 1.99 2 1.99L16 19c.67 0 1.27-.33 1.63-.84L22 12l-4.37-6.16z"
+                                    <PathIcon Data="{x:Static icons:Icons.Categories}"
                                               Width="28" Height="28"
                                               Foreground="{DynamicResource TextTertiaryBrush}" />
                                 </Border>
@@ -335,7 +336,7 @@
                                         Margin="0,8,0,0"
                                         Command="{Binding OpenAddModalCommand}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Category'}" />
@@ -387,7 +388,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToPreviousPageCommand}"
                                             IsEnabled="{Binding CanGoToPreviousPage}">
-                                        <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                                   Width="16" Height="16" />
                                     </Button>
 
@@ -419,7 +420,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToNextPageCommand}"
                                             IsEnabled="{Binding CanGoToNextPage}">
-                                        <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                                   Width="16" Height="16" />
                                     </Button>
                                 </StackPanel>

--- a/ArgoBooks/Views/CustomersPage.axaml
+++ b/ArgoBooks/Views/CustomersPage.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
@@ -73,7 +74,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -105,7 +106,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'Add Customer'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Customer'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -427,14 +428,14 @@
                                                                     ToolTip.Tip="{loc:Loc Edit}"
                                                                     Command="{Binding $parent[ItemsControl].((vm:CustomersPageViewModel)DataContext).OpenEditModalCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <Button Classes="icon-button danger"
                                                                     ToolTip.Tip="{loc:Loc Delete}"
                                                                     Command="{Binding $parent[ItemsControl].((vm:CustomersPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                         </StackPanel>
@@ -455,7 +456,7 @@
                                                 CornerRadius="32"
                                                 Background="{DynamicResource SurfaceAltBrush}"
                                                 HorizontalAlignment="Center">
-                                            <PathIcon Data="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                                            <PathIcon Data="{x:Static icons:Icons.Employees}"
                                                       Width="28" Height="28"
                                                       Foreground="{DynamicResource TextTertiaryBrush}" />
                                         </Border>
@@ -476,7 +477,7 @@
                                                 Margin="0,8,0,0"
                                                 Command="{Binding OpenAddModalCommand}">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'Add Customer'}" />
@@ -530,7 +531,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -562,7 +563,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:modals="using:ArgoBooks.Modals"
+             xmlns:local="using:ArgoBooks"
              xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1400" d:DesignHeight="900"
@@ -163,7 +164,7 @@
                                 Classes="icon-button"
                                 ToolTip.Tip="{loc:Loc 'Configure Quick Actions'}"
                                 Command="{Binding OpenQuickActionsSettingsCommand}">
-                            <PathIcon Data="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+                            <PathIcon Data="{x:Static local:Icons.Settings}"
                                       Width="16" Height="16"
                                       Foreground="{DynamicResource TextSecondaryBrush}" />
                         </Button>
@@ -183,7 +184,7 @@
                                 IsVisible="{Binding ShowNewInvoice}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource WarningIconBgBrush}">
-                                    <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                    <PathIcon Data="{x:Static local:Icons.Invoices}"
                                               Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'New Invoice'}" FontSize="13" FontWeight="Medium"
@@ -225,7 +226,7 @@
                                 IsVisible="{Binding ShowScanReceipt}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource InfoIconBgBrush}">
-                                    <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                    <PathIcon Data="{x:Static local:Icons.ScanReceipt}"
                                               Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'Scan Receipt'}" FontSize="13" FontWeight="Medium"
@@ -239,7 +240,7 @@
                                 IsVisible="{Binding ShowNewCustomer}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource PrimaryIconBgBrush}">
-                                    <PathIcon Data="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                                    <PathIcon Data="{x:Static local:Icons.NewCustomer}"
                                               Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'New Customer'}" FontSize="13" FontWeight="Medium"
@@ -253,7 +254,7 @@
                                 IsVisible="{Binding ShowNewSupplier}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource PrimaryIconBgBrush}">
-                                    <PathIcon Data="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4z"
+                                    <PathIcon Data="{x:Static local:Icons.Suppliers}"
                                               Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'New Supplier'}" FontSize="13" FontWeight="Medium"
@@ -267,7 +268,7 @@
                                 IsVisible="{Binding ShowNewProduct}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource SuccessIconBgBrush}">
-                                    <PathIcon Data="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+                                    <PathIcon Data="{x:Static local:Icons.NewProduct}"
                                               Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'New Product'}" FontSize="13" FontWeight="Medium"
@@ -281,7 +282,7 @@
                                 IsVisible="{Binding ShowRecordPayment}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource SuccessIconBgBrush}">
-                                    <PathIcon Data="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
+                                    <PathIcon Data="{x:Static local:Icons.Payments}"
                                               Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'Record Payment'}" FontSize="13" FontWeight="Medium"
@@ -295,7 +296,7 @@
                                 IsVisible="{Binding ShowNewRentalItem}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource InfoIconBgBrush}">
-                                    <PathIcon Data="M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zM7 4V3h10v1H7zm0 14V6h10v12H7zm0 3v-1h10v1H7z"
+                                    <PathIcon Data="{x:Static local:Icons.NewRentalItem}"
                                               Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'New Rental Item'}" FontSize="13" FontWeight="Medium"
@@ -309,7 +310,7 @@
                                 IsVisible="{Binding ShowNewRentalRecord}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource InfoIconBgBrush}">
-                                    <PathIcon Data="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L12 14.17l4.59-4.58L18 11l-6 6z"
+                                    <PathIcon Data="{x:Static local:Icons.RentalRecords}"
                                               Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'New Rental'}" FontSize="13" FontWeight="Medium"
@@ -337,7 +338,7 @@
                                 IsVisible="{Binding ShowNewDepartment}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource WarningIconBgBrush}">
-                                    <PathIcon Data="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                                    <PathIcon Data="{x:Static local:Icons.Departments}"
                                               Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'New Department'}" FontSize="13" FontWeight="Medium"
@@ -351,7 +352,7 @@
                                 IsVisible="{Binding ShowNewLocation}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource WarningIconBgBrush}">
-                                    <PathIcon Data="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+                                    <PathIcon Data="{x:Static local:Icons.Locations}"
                                               Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'New Location'}" FontSize="13" FontWeight="Medium"
@@ -365,7 +366,7 @@
                                 IsVisible="{Binding ShowNewPurchaseOrder}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource PrimaryIconBgBrush}">
-                                    <PathIcon Data="M18 6h-2c0-2.21-1.79-4-4-4S8 3.79 8 6H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6-2c1.1 0 2 .9 2 2h-4c0-1.1.9-2 2-2zm6 16H6V8h2v2c0 .55.45 1 1 1s1-.45 1-1V8h4v2c0 .55.45 1 1 1s1-.45 1-1V8h2v12z"
+                                    <PathIcon Data="{x:Static local:Icons.NewPurchaseOrder}"
                                               Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'Purchase Order'}" FontSize="13" FontWeight="Medium"
@@ -379,7 +380,7 @@
                                 IsVisible="{Binding ShowNewStockAdjustment}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource PrimaryIconBgBrush}">
-                                    <PathIcon Data="M19 3H14.82C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
+                                    <PathIcon Data="{x:Static local:Icons.NewStockAdjustment}"
                                               Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
                                 <TextBlock Text="{loc:Loc 'Stock Adjustment'}" FontSize="13" FontWeight="Medium"
@@ -678,7 +679,7 @@
                                                             <Setter Property="Background" Value="{DynamicResource DangerIconBgBrush}" />
                                                         </Style>
                                                     </Border.Styles>
-                                                    <PathIcon Data="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"
+                                                    <PathIcon Data="{x:Static local:Icons.Bookmark}"
                                                               Width="18" Height="18"
                                                               Classes.active="{Binding !IsOverdue}"
                                                               Classes.overdue="{Binding IsOverdue}">
@@ -757,7 +758,7 @@
                             <StackPanel HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         Spacing="12">
-                                <PathIcon Data="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"
+                                <PathIcon Data="{x:Static local:Icons.Bookmark}"
                                           Width="48" Height="48"
                                           Foreground="{DynamicResource TextTertiaryBrush}" />
                                 <TextBlock Text="{loc:Loc 'No active rentals'}"

--- a/ArgoBooks/Views/DepartmentsPage.axaml
+++ b/ArgoBooks/Views/DepartmentsPage.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.DepartmentsPage"
@@ -25,19 +26,19 @@
         <controls:StatCardsRow Grid.Row="0" Margin="0,0,0,24">
             <controls:StatCard Label="{loc:Loc 'Total Departments'}"
                                Value="{Binding TotalDepartments}"
-                               Icon="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                               Icon="{x:Static icons:Icons.Departments}"
                                IconColor="Primary" />
             <controls:StatCard Label="{loc:Loc 'Active Departments'}"
                                Value="{Binding ActiveDepartments}"
-                               Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                               Icon="{x:Static icons:Icons.CircleCheck}"
                                IconColor="Success" />
             <controls:StatCard Label="{loc:Loc 'Total Employees'}"
                                Value="{Binding TotalEmployees}"
-                               Icon="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"
+                               Icon="{x:Static icons:Icons.Customers}"
                                IconColor="Warning" />
             <controls:StatCard Label="{loc:Loc 'New This Month'}"
                                Value="{Binding NewThisMonth}"
-                               Icon="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                               Icon="{x:Static icons:Icons.Add}"
                                IconColor="Info" />
         </controls:StatCardsRow>
 
@@ -75,7 +76,7 @@
                                     MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                 <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                     <PathIcon Grid.Column="0"
-                                              Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                              Data="{x:Static icons:Icons.Search}"
                                               Width="16" Height="16"
                                               Foreground="{DynamicResource TextTertiaryBrush}"
                                               Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -94,7 +95,7 @@
                                     Command="{Binding OpenAddModalCommand}"
                                     ToolTip.Tip="{loc:Loc 'Add Department'}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                    <PathIcon Data="{x:Static icons:Icons.Add}"
                                               Width="16" Height="16"
                                               Foreground="White" />
                                     <TextBlock Text="{loc:Loc 'Add Department'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -234,14 +235,14 @@
                                                                     ToolTip.Tip="{loc:Loc 'Edit'}"
                                                                     Command="{Binding $parent[ItemsControl].((vm:DepartmentsPageViewModel)DataContext).OpenEditModalCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <Button Classes="icon-button danger"
                                                                     ToolTip.Tip="{loc:Loc 'Delete'}"
                                                                     Command="{Binding $parent[ItemsControl].((vm:DepartmentsPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                         </StackPanel>
@@ -262,7 +263,7 @@
                                                 CornerRadius="32"
                                                 Background="{DynamicResource SurfaceAltBrush}"
                                                 HorizontalAlignment="Center">
-                                            <PathIcon Data="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                                            <PathIcon Data="{x:Static icons:Icons.Departments}"
                                                       Width="28" Height="28"
                                                       Foreground="{DynamicResource TextTertiaryBrush}" />
                                         </Border>
@@ -283,7 +284,7 @@
                                                 Margin="0,8,0,0"
                                                 Command="{Binding OpenAddModalCommand}">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'Add Department'}" />
@@ -337,7 +338,7 @@
                             <Button Classes="pagination-button"
                                     Command="{Binding GoToPreviousPageCommand}"
                                     IsEnabled="{Binding CanGoToPreviousPage}">
-                                <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                           Width="16" Height="16" />
                             </Button>
 
@@ -369,7 +370,7 @@
                             <Button Classes="pagination-button"
                                     Command="{Binding GoToNextPageCommand}"
                                     IsEnabled="{Binding CanGoToNextPage}">
-                                <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                           Width="16" Height="16" />
                             </Button>
                         </StackPanel>

--- a/ArgoBooks/Views/ExpensesPage.axaml
+++ b/ArgoBooks/Views/ExpensesPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.ExpensesPage"
              x:DataType="vm:ExpensesPageViewModel">
@@ -27,15 +28,15 @@
             <controls:StatCardsRow Grid.Row="0" Margin="0,0,0,24">
                 <controls:StatCard Label="{loc:Loc 'Monthly Expenses'}"
                                    Value="{Binding TotalMonthlyExpenses}"
-                                   Icon="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
+                                   Icon="{x:Static icons:Icons.Payments}"
                                    IconColor="Danger" />
                 <controls:StatCard Label="{loc:Loc 'Transactions'}"
                                    Value="{Binding TransactionCount}"
-                                   Icon="M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
+                                   Icon="{x:Static icons:Icons.NewStockAdjustment}"
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Receipts on File'}"
                                    Value="{Binding ReceiptsOnFile}"
-                                   Icon="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                   Icon="{x:Static icons:Icons.Invoices}"
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc 'Returns'}"
                                    Value="{Binding ReturnsCount}"
@@ -77,7 +78,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -110,7 +111,7 @@
                                         Click="OnAiScanButtonClick"
                                         ToolTip.Tip="{Binding ResponsiveHeader.ShowButtonText, Converter={x:Static local:BoolConverters.ToParameterWhenFalse}, ConverterParameter={loc:Loc 'AI Scan Receipt'}}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                        <PathIcon Data="{x:Static icons:Icons.ScanReceipt}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'AI Scan Receipt'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -124,7 +125,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{Binding ResponsiveHeader.ShowButtonText, Converter={x:Static local:BoolConverters.ToParameterWhenFalse}, ConverterParameter={loc:Loc 'Add Expense'}}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Expense'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -462,13 +463,13 @@
                                                     <!-- Receipt Icon -->
                                                     <Panel Width="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).ColumnWidths.ReceiptColumnWidth}"
                                                            IsVisible="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).ShowReceiptColumn}">
-                                                        <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                        <PathIcon Data="{x:Static icons:Icons.Check}"
                                                                   Width="16" Height="16"
                                                                   Foreground="#22C55E"
                                                                   HorizontalAlignment="Center"
                                                                   VerticalAlignment="Center"
                                                                   IsVisible="{Binding HasReceipt}" />
-                                                        <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                        <PathIcon Data="{x:Static icons:Icons.Close}"
                                                                   Width="16" Height="16"
                                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                                   HorizontalAlignment="Center"
@@ -508,14 +509,14 @@
                                                                 Command="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).ViewReceiptCommand}"
                                                                 CommandParameter="{Binding}"
                                                                 IsVisible="{Binding HasReceipt}">
-                                                            <PathIcon Data="M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Receipts}"
                                                                       Width="16" Height="16" />
                                                         </Button>
                                                         <Button Classes="icon-button"
                                                                 ToolTip.Tip="{loc:Loc 'Edit'}"
                                                                 Command="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).OpenEditModalCommand}"
                                                                 CommandParameter="{Binding}">
-                                                            <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                       Width="16" Height="16" />
                                                         </Button>
                                                         <!-- Mark as Lost/Damaged (shown when not already marked) -->
@@ -524,7 +525,7 @@
                                                                 Command="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).MarkAsLostDamagedCommand}"
                                                                 CommandParameter="{Binding}"
                                                                 IsVisible="{Binding CanMarkAsLostDamaged}">
-                                                            <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Info}"
                                                                       Width="16" Height="16" />
                                                         </Button>
                                                         <!-- Undo Lost/Damaged (shown when already marked as lost/damaged) -->
@@ -533,7 +534,7 @@
                                                                 Command="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).UndoLostDamagedCommand}"
                                                                 CommandParameter="{Binding}"
                                                                 IsVisible="{Binding IsLostDamaged}">
-                                                            <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Returns}"
                                                                       Width="16" Height="16" />
                                                         </Button>
                                                         <!-- Mark as Returned (shown when not already marked) -->
@@ -542,7 +543,7 @@
                                                                 Command="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).MarkAsReturnedCommand}"
                                                                 CommandParameter="{Binding}"
                                                                 IsVisible="{Binding CanMarkAsReturned}">
-                                                            <PathIcon Data="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Undo}"
                                                                       Width="16" Height="16" />
                                                         </Button>
                                                         <!-- Undo Return (shown when already returned) -->
@@ -551,14 +552,14 @@
                                                                 Command="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).UndoReturnCommand}"
                                                                 CommandParameter="{Binding}"
                                                                 IsVisible="{Binding IsReturned}">
-                                                            <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Returns}"
                                                                       Width="16" Height="16" />
                                                         </Button>
                                                         <Button Classes="icon-button danger"
                                                                 ToolTip.Tip="{loc:Loc 'Delete'}"
                                                                 Command="{Binding $parent[ItemsControl].((vm:ExpensesPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                 CommandParameter="{Binding}">
-                                                            <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                       Width="16" Height="16" />
                                                         </Button>
                                                     </StackPanel>
@@ -578,7 +579,7 @@
                                                 CornerRadius="32"
                                                 Background="{DynamicResource SurfaceAltBrush}"
                                                 HorizontalAlignment="Center">
-                                            <PathIcon Data="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
+                                            <PathIcon Data="{x:Static icons:Icons.Payments}"
                                                       Width="28" Height="28"
                                                       Foreground="{DynamicResource TextTertiaryBrush}" />
                                         </Border>
@@ -599,7 +600,7 @@
                                                 Margin="0,8,0,0"
                                                 Command="{Binding OpenAddModalCommand}">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'Add Expense'}" />
@@ -653,7 +654,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -685,7 +686,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/InsightsPage.axaml
+++ b/ArgoBooks/Views/InsightsPage.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:local="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.InsightsPage"
@@ -63,7 +64,7 @@
                                 CornerRadius="8"
                                 Background="#DBEAFE"
                                 Margin="0,0,12,0">
-                            <PathIcon Data="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"
+                            <PathIcon Data="{x:Static local:Icons.TrendUp}"
                                       Width="16" Height="16"
                                       Foreground="#3B82F6" />
                         </Border>
@@ -81,7 +82,7 @@
                                         VerticalAlignment="Center"
                                         Command="{Binding ShowPredictionInfoCommand}"
                                         ToolTip.Tip="How predictions are calculated">
-                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                                    <PathIcon Data="{x:Static local:Icons.Info}"
                                               Width="18" Height="18"
                                               Foreground="{DynamicResource TextSecondaryBrush}" />
                                 </Button>
@@ -155,7 +156,7 @@
                                     Command="{Binding RefreshInsightsCommand}"
                                     HorizontalAlignment="Center">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <PathIcon Data="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                                    <PathIcon Data="{x:Static local:Icons.Refresh}"
                                               Width="14" Height="14" />
                                     <TextBlock Text="Try Again" />
                                 </StackPanel>
@@ -172,7 +173,7 @@
                             <!-- Main confidence row -->
                             <Grid ColumnDefinitions="Auto,*,Auto">
                                 <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
-                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                    <PathIcon Data="{x:Static local:Icons.CircleCheck}"
                                               Width="16" Height="16"
                                               Foreground="#22C55E" />
                                     <TextBlock Text="{loc:Loc 'Prediction Confidence:'}"
@@ -212,7 +213,7 @@
                             <Grid ColumnDefinitions="Auto,*,Auto"
                                   IsVisible="{Binding HasAccuracyData}">
                                 <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
-                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                    <PathIcon Data="{x:Static local:Icons.Check}"
                                               Width="14" Height="14"
                                               Foreground="#3B82F6" />
                                     <TextBlock Text="Historical Accuracy:"
@@ -236,7 +237,7 @@
                             <Grid ColumnDefinitions="Auto,*"
                                   IsVisible="{Binding HasSeasonalPattern}">
                                 <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
-                                    <PathIcon Data="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                                    <PathIcon Data="{x:Static local:Icons.Clock}"
                                               Width="14" Height="14"
                                               Foreground="#8B5CF6" />
                                     <TextBlock Text="Seasonal Pattern:"
@@ -275,7 +276,7 @@
                         Margin="0,0,0,16">
                     <Grid ColumnDefinitions="*,Auto">
                         <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
-                            <PathIcon Data="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                            <PathIcon Data="{x:Static local:Icons.Clock}"
                                       Width="16" Height="16"
                                       Foreground="{DynamicResource TextTertiaryBrush}" />
                             <TextBlock Text="{loc:Loc 'Business Insights'}"
@@ -321,7 +322,7 @@
                                             CornerRadius="8"
                                             Background="#DCFCE7"
                                             Margin="0,0,12,0">
-                                        <PathIcon Data="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"
+                                        <PathIcon Data="{x:Static local:Icons.TrendUp}"
                                                   Width="16" Height="16"
                                                   Foreground="#22C55E" />
                                     </Border>
@@ -342,7 +343,7 @@
                                             CornerRadius="8"
                                             Background="#DCFCE7"
                                             Margin="0,0,12,0">
-                                        <PathIcon Data="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"
+                                        <PathIcon Data="{x:Static local:Icons.TrendUp}"
                                                   Width="16" Height="16"
                                                   Foreground="#22C55E" />
                                     </Border>
@@ -504,7 +505,7 @@
                                             CornerRadius="8"
                                             Background="#FEF3C7"
                                             Margin="0,0,12,0">
-                                        <PathIcon Data="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                                        <PathIcon Data="{x:Static local:Icons.LostDamaged}"
                                                   Width="16" Height="16"
                                                   Foreground="#F59E0B" />
                                     </Border>
@@ -525,7 +526,7 @@
                                             CornerRadius="8"
                                             Background="#FEF3C7"
                                             Margin="0,0,12,0">
-                                        <PathIcon Data="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                                        <PathIcon Data="{x:Static local:Icons.LostDamaged}"
                                                   Width="16" Height="16"
                                                   Foreground="#F59E0B" />
                                     </Border>
@@ -594,7 +595,7 @@
                                             CornerRadius="8"
                                             Background="#DBEAFE"
                                             Margin="0,0,12,0">
-                                        <PathIcon Data="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+                                        <PathIcon Data="{x:Static local:Icons.Star}"
                                                   Width="16" Height="16"
                                                   Foreground="#3B82F6" />
                                     </Border>
@@ -615,7 +616,7 @@
                                             CornerRadius="8"
                                             Background="#DBEAFE"
                                             Margin="0,0,12,0">
-                                        <PathIcon Data="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+                                        <PathIcon Data="{x:Static local:Icons.Star}"
                                                   Width="16" Height="16"
                                                   Foreground="#3B82F6" />
                                     </Border>

--- a/ArgoBooks/Views/InvoicesPage.axaml
+++ b/ArgoBooks/Views/InvoicesPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.InvoicesPage"
              x:DataType="vm:InvoicesPageViewModel">
@@ -43,19 +44,19 @@
             <controls:StatCardsRow Grid.Row="0" Margin="0,0,0,24">
                 <controls:StatCard Label="{loc:Loc 'Total Outstanding'}"
                                    Value="{Binding TotalOutstanding}"
-                                   Icon="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                   Icon="{x:Static icons:Icons.Invoices}"
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Paid This Month'}"
                                    Value="{Binding PaidThisMonth}"
-                                   Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                   Icon="{x:Static icons:Icons.CircleCheck}"
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc Overdue}"
                                    Value="{Binding OverdueAmount}"
-                                   Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                   Icon="{x:Static icons:Icons.Info}"
                                    IconColor="Danger" />
                 <controls:StatCard Label="{loc:Loc 'Due This Week'}"
                                    Value="{Binding DueThisWeekCount}"
-                                   Icon="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                                   Icon="{x:Static icons:Icons.Clock}"
                                    IconColor="Info" />
             </controls:StatCardsRow>
 
@@ -93,7 +94,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -126,7 +127,7 @@
                                         Command="{Binding OpenCreateModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'Create Invoice'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Create Invoice'}"
@@ -367,7 +368,7 @@
                                                                         IsVisible="{Binding CanEdit}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:InvoicesPageViewModel)DataContext).OpenEditModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button"
@@ -381,7 +382,7 @@
                                                                         ToolTip.Tip="{loc:Loc Delete}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:InvoicesPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -402,7 +403,7 @@
                                                     CornerRadius="32"
                                                     Background="{DynamicResource SurfaceAltBrush}"
                                                     HorizontalAlignment="Center">
-                                                <PathIcon Data="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                                                <PathIcon Data="{x:Static icons:Icons.Invoices}"
                                                           Width="28" Height="28"
                                                           Foreground="{DynamicResource TextTertiaryBrush}" />
                                             </Border>
@@ -423,7 +424,7 @@
                                                     Margin="0,8,0,0"
                                                     Command="{Binding OpenCreateModalCommand}">
                                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Add}"
                                                               Width="16" Height="16"
                                                               Foreground="White" />
                                                     <TextBlock Text="{loc:Loc 'Create Invoice'}" />
@@ -477,7 +478,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -509,7 +510,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/LocationsPage.axaml
+++ b/ArgoBooks/Views/LocationsPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.LocationsPage"
              x:DataType="vm:LocationsPageViewModel">
@@ -27,7 +28,7 @@
             <controls:StatCardsRow Grid.Row="0" Margin="0,0,0,24">
                 <controls:StatCard Label="{loc:Loc 'Total Locations'}"
                                    Value="{Binding TotalLocations}"
-                                   Icon="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+                                   Icon="{x:Static icons:Icons.Locations}"
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Total Stock Items'}"
                                    Value="{Binding TotalStockItems}"
@@ -35,7 +36,7 @@
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc 'Total Inventory Value'}"
                                    Value="{Binding TotalInventoryValue}"
-                                   Icon="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z"
+                                   Icon="{x:Static icons:Icons.Dollar}"
                                    IconColor="Warning" />
                 <controls:StatCard Label="{loc:Loc 'Avg Capacity Used'}"
                                    Value="{Binding AverageCapacityUsed}"
@@ -77,7 +78,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -110,7 +111,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'Add Location'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Location'}"
@@ -418,14 +419,14 @@
                                                                         ToolTip.Tip="{loc:Loc 'Edit'}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:LocationsPageViewModel)DataContext).OpenEditModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button danger"
                                                                         ToolTip.Tip="{loc:Loc 'Delete'}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:LocationsPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -446,7 +447,7 @@
                                                     CornerRadius="32"
                                                     Background="{DynamicResource SurfaceAltBrush}"
                                                     HorizontalAlignment="Center">
-                                                <PathIcon Data="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+                                                <PathIcon Data="{x:Static icons:Icons.Locations}"
                                                           Width="28" Height="28"
                                                           Foreground="{DynamicResource TextTertiaryBrush}" />
                                             </Border>
@@ -467,7 +468,7 @@
                                                     Margin="0,8,0,0"
                                                     Command="{Binding OpenAddModalCommand}">
                                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Add}"
                                                               Width="16" Height="16"
                                                               Foreground="White" />
                                                     <TextBlock Text="{loc:Loc 'Add Location'}" />
@@ -521,7 +522,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -553,7 +554,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/LostDamagedPage.axaml
+++ b/ArgoBooks/Views/LostDamagedPage.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.LostDamagedPage"
@@ -39,7 +40,7 @@
                                        IconColor="Info" />
                     <controls:StatCard Label="{loc:Loc 'Total Loss Value'}"
                                        Value="{Binding TotalLossValue}"
-                                       Icon="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z"
+                                       Icon="{x:Static icons:Icons.Dollar}"
                                        IconColor="Primary" />
                 </controls:StatCardsRow>
 
@@ -77,7 +78,7 @@
                                             MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                         <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                             <PathIcon Grid.Column="0"
-                                                      Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                      Data="{x:Static icons:Icons.Search}"
                                                       Width="16" Height="16"
                                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                                       Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -339,7 +340,7 @@
                                                                             ToolTip.Tip="{loc:Loc 'Undo'}"
                                                                             Command="{Binding $parent[ItemsControl].((vm:LostDamagedPageViewModel)DataContext).UndoItemCommand}"
                                                                             CommandParameter="{Binding}">
-                                                                        <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                                                        <PathIcon Data="{x:Static icons:Icons.Returns}"
                                                                                   Width="14" Height="14" />
                                                                     </Button>
                                                                 </StackPanel>
@@ -360,7 +361,7 @@
                                                         CornerRadius="32"
                                                         Background="{DynamicResource SurfaceAltBrush}"
                                                         HorizontalAlignment="Center">
-                                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Info}"
                                                               Width="28" Height="28"
                                                               Foreground="{DynamicResource TextTertiaryBrush}" />
                                                 </Border>
@@ -424,7 +425,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToPreviousPageCommand}"
                                             IsEnabled="{Binding CanGoToPreviousPage}">
-                                        <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                                   Width="16" Height="16" />
                                     </Button>
 
@@ -456,7 +457,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToNextPageCommand}"
                                             IsEnabled="{Binding CanGoToNextPage}">
-                                        <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                                   Width="16" Height="16" />
                                     </Button>
                                 </StackPanel>
@@ -487,7 +488,7 @@
                                 <Border Width="40" Height="40"
                                         CornerRadius="8"
                                         Background="#FEE2E2">
-                                    <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                    <PathIcon Data="{x:Static icons:Icons.Info}"
                                               Width="20" Height="20"
                                               Foreground="#DC2626" />
                                 </Border>
@@ -504,7 +505,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseViewDetailsModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -638,7 +639,7 @@
                                 <Border Width="40" Height="40"
                                         CornerRadius="8"
                                         Background="#FEF3C7">
-                                    <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                    <PathIcon Data="{x:Static icons:Icons.Returns}"
                                               Width="20" Height="20"
                                               Foreground="#D97706" />
                                 </Border>
@@ -651,7 +652,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseUndoItemModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Views/PaymentsPage.axaml
+++ b/ArgoBooks/Views/PaymentsPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.PaymentsPage"
              x:DataType="vm:PaymentsPageViewModel">
@@ -30,15 +31,15 @@
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc 'Transactions'}"
                                    Value="{Binding TotalTransactions}"
-                                   Icon="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
+                                   Icon="{x:Static icons:Icons.Payments}"
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Pending'}"
                                    Value="{Binding PendingPayments}"
-                                   Icon="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                                   Icon="{x:Static icons:Icons.Refresh}"
                                    IconColor="Info" />
                 <controls:StatCard Label="{loc:Loc 'Refunds'}"
                                    Value="{Binding RefundedPayments}"
-                                   Icon="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                   Icon="{x:Static icons:Icons.Returns}"
                                    IconColor="Warning" />
             </controls:StatCardsRow>
 
@@ -58,7 +59,7 @@
                             Background="{DynamicResource PrimaryIconBgBrush}"
                             Margin="0,0,16,0"
                             VerticalAlignment="Center">
-                        <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"
+                        <PathIcon Data="{x:Static icons:Icons.Globe}"
                                   Width="24" Height="24"
                                   Foreground="{DynamicResource PrimaryBrush}" />
                     </Border>
@@ -85,7 +86,7 @@
                                    Foreground="{DynamicResource TextSecondaryBrush}"
                                    TextWrapping="Wrap" />
                         <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,4,0,0">
-                            <PathIcon Data="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                            <PathIcon Data="{x:Static icons:Icons.Clock}"
                                       Width="14" Height="14"
                                       VerticalAlignment="Center"
                                       Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -105,7 +106,7 @@
                                 Command="{Binding SyncPortalCommand}">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <PathIcon Classes.sync-spinning="{Binding IsSyncing}"
-                                          Data="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"
+                                          Data="{x:Static icons:Icons.Refresh}"
                                           Width="16" Height="16"
                                           RenderTransformOrigin="50%,50%">
                                     <PathIcon.RenderTransform>
@@ -162,7 +163,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -194,7 +195,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{Binding ResponsiveHeader.ShowButtonText, Converter={x:Static local:BoolConverters.ToParameterWhenFalse}, ConverterParameter={loc:Loc 'Record Payment'}}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Record Payment'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -422,14 +423,14 @@
                                                                     ToolTip.Tip="{loc:Loc 'Edit'}"
                                                                     Command="{Binding $parent[ItemsControl].((vm:PaymentsPageViewModel)DataContext).OpenEditModalCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <Button Classes="icon-button danger"
                                                                     ToolTip.Tip="{loc:Loc 'Delete'}"
                                                                     Command="{Binding $parent[ItemsControl].((vm:PaymentsPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                         </StackPanel>
@@ -450,7 +451,7 @@
                                                 CornerRadius="32"
                                                 Background="{DynamicResource SurfaceAltBrush}"
                                                 HorizontalAlignment="Center">
-                                            <PathIcon Data="M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z"
+                                            <PathIcon Data="{x:Static icons:Icons.Payments}"
                                                       Width="28" Height="28"
                                                       Foreground="{DynamicResource TextTertiaryBrush}" />
                                         </Border>
@@ -471,7 +472,7 @@
                                                 Margin="0,8,0,0"
                                                 Command="{Binding OpenAddModalCommand}">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'Record Payment'}" />
@@ -525,7 +526,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -557,7 +558,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/ProductsPage.axaml
+++ b/ArgoBooks/Views/ProductsPage.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
+             xmlns:icons="using:ArgoBooks"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
@@ -56,7 +57,7 @@
                                     CornerRadius="10"
                                     Background="{DynamicResource PrimaryLightBrush}"
                                     Margin="0,0,16,0">
-                                <PathIcon Data="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.16.12-.36.18-.57.18-.21 0-.41-.06-.57-.18l-7.9-4.44A.991.991 0 0 1 3 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.16-.12.36-.18.57-.18.21 0 .41.06.57.18l7.9 4.44c.32.17.53.5.53.88v9zM12 4.15L6.04 7.5 12 10.85l5.96-3.35L12 4.15zM5 15.91l6 3.38v-6.71L5 9.21v6.7zm14 0v-6.7l-6 3.37v6.71l6-3.38z"
+                                <PathIcon Data="{x:Static icons:Icons.Products}"
                                           Width="24" Height="24"
                                           Foreground="{DynamicResource PrimaryBrush}" />
                             </Border>
@@ -155,7 +156,7 @@
                                             MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                         <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                             <PathIcon Grid.Column="0"
-                                                      Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                      Data="{x:Static icons:Icons.Search}"
                                                       Width="16" Height="16"
                                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                                       Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -205,7 +206,7 @@
                                             IsEnabled="{Binding CanAddProduct}"
                                             ToolTip.Tip="{Binding ResponsiveHeader.ShowButtonText, Converter={x:Static local:BoolConverters.ToParameterWhenFalse}, ConverterParameter={loc:Loc 'Add Product'}}">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                            <PathIcon Data="{x:Static icons:Icons.Add}"
                                                       Width="16" Height="16"
                                                       Foreground="White" />
                                             <TextBlock Text="{loc:Loc 'Add Product'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -727,14 +728,14 @@
                                                                         ToolTip.Tip="{loc:Loc Edit}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:ProductsPageViewModel)DataContext).OpenEditModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button danger"
                                                                         ToolTip.Tip="{loc:Loc Delete}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:ProductsPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -823,14 +824,14 @@
                                                                         ToolTip.Tip="{loc:Loc Edit}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:ProductsPageViewModel)DataContext).OpenEditModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button danger"
                                                                         ToolTip.Tip="{loc:Loc Delete}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:ProductsPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -851,7 +852,7 @@
                                                 CornerRadius="32"
                                                 Background="{DynamicResource SurfaceAltBrush}"
                                                 HorizontalAlignment="Center">
-                                            <PathIcon Data="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.16.12-.36.18-.57.18-.21 0-.41-.06-.57-.18l-7.9-4.44A.991.991 0 0 1 3 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.16-.12.36-.18.57-.18.21 0 .41.06.57.18l7.9 4.44c.32.17.53.5.53.88v9zM12 4.15L6.04 7.5 12 10.85l5.96-3.35L12 4.15zM5 15.91l6 3.38v-6.71L5 9.21v6.7zm14 0v-6.7l-6 3.37v6.71l6-3.38z"
+                                            <PathIcon Data="{x:Static icons:Icons.Products}"
                                                       Width="28" Height="28"
                                                       Foreground="{DynamicResource TextTertiaryBrush}" />
                                         </Border>
@@ -872,7 +873,7 @@
                                                 Margin="0,8,0,0"
                                                 Command="{Binding OpenAddModalCommand}">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'Add Product'}" />
@@ -926,7 +927,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToPreviousPageCommand}"
                                             IsEnabled="{Binding CanGoToPreviousPage}">
-                                        <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                                   Width="16" Height="16" />
                                     </Button>
 
@@ -958,7 +959,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToNextPageCommand}"
                                             IsEnabled="{Binding CanGoToNextPage}">
-                                        <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                                   Width="16" Height="16" />
                                     </Button>
                                 </StackPanel>

--- a/ArgoBooks/Views/PurchaseOrdersPage.axaml
+++ b/ArgoBooks/Views/PurchaseOrdersPage.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.PurchaseOrdersPage"
@@ -93,7 +94,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -125,7 +126,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'New Order'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'New Order'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -544,7 +545,7 @@
                                                                         IsVisible="{Binding CanEdit}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:PurchaseOrdersPageViewModel)DataContext).EditOrderCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <!-- Approve -->
@@ -553,7 +554,7 @@
                                                                         IsVisible="{Binding CanApprove}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:PurchaseOrdersPageViewModel)DataContext).ApproveOrderCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <!-- Receive -->
@@ -570,7 +571,7 @@
                                                                         ToolTip.Tip="{loc:Loc Delete}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:PurchaseOrdersPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -612,7 +613,7 @@
                                                     Margin="0,8,0,0"
                                                     Command="{Binding OpenAddModalCommand}">
                                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Add}"
                                                               Width="16" Height="16"
                                                               Foreground="White" />
                                                     <TextBlock Text="{loc:Loc 'New Order'}" />
@@ -666,7 +667,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -698,7 +699,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/ReceiptsPage.axaml
+++ b/ArgoBooks/Views/ReceiptsPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.ReceiptsPage"
              x:DataType="vm:ReceiptsPageViewModel"
@@ -28,7 +29,7 @@
                 <controls:StatCardsRow Grid.Row="0" Margin="0,0,0,24">
                     <controls:StatCard Label="{loc:Loc 'Total Receipts'}"
                                        Value="{Binding TotalReceipts}"
-                                       Icon="M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z"
+                                       Icon="{x:Static icons:Icons.Receipts}"
                                        IconColor="Primary" />
                     <controls:StatCard Label="{loc:Loc 'Expense Receipts'}"
                                        Value="{Binding ExpenseReceipts}"
@@ -40,7 +41,7 @@
                                        IconColor="Success" />
                     <controls:StatCard Label="{loc:Loc 'AI Scanned'}"
                                        Value="{Binding AiScannedReceipts}"
-                                       Icon="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                       Icon="{x:Static icons:Icons.ScanReceipt}"
                                        IconColor="Info" />
                 </controls:StatCardsRow>
 
@@ -74,7 +75,7 @@
                                         <Button Classes="icon-button"
                                                 Command="{Binding ExitSelectionModeCommand}"
                                                 ToolTip.Tip="{loc:Loc 'Cancel Selection'}">
-                                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                            <PathIcon Data="{x:Static icons:Icons.Close}"
                                                       Width="20" Height="20"
                                                       Foreground="{DynamicResource PrimaryBrush}" />
                                         </Button>
@@ -119,7 +120,7 @@
                                             MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                         <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                             <PathIcon Grid.Column="0"
-                                                      Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                      Data="{x:Static icons:Icons.Search}"
                                                       Width="16" Height="16"
                                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                                       Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -165,7 +166,7 @@
                                             Click="OnAiScanButtonClick"
                                             ToolTip.Tip="{loc:Loc 'AI Scan Receipt'}">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                            <PathIcon Data="{x:Static icons:Icons.ScanReceipt}"
                                                       Width="16" Height="16"
                                                       Foreground="White" />
                                             <TextBlock Text="{loc:Loc 'AI Scan Receipt'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -233,7 +234,7 @@
                                             IsEnabled="{Binding HasSelectedReceipts}"
                                             ToolTip.Tip="{loc:Loc 'Export Selected'}">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <PathIcon Data="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                                            <PathIcon Data="{x:Static icons:Icons.ExportData}"
                                                       Width="16" Height="16"
                                                       Foreground="White" />
                                             <TextBlock Text="{loc:Loc 'Export Selected'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -626,7 +627,7 @@
                                                                                         ToolTip.Tip="{loc:Loc 'Download'}"
                                                                                         Command="{Binding $parent[ItemsControl].((vm:ReceiptsPageViewModel)DataContext).DownloadReceiptCommand}"
                                                                                         CommandParameter="{Binding}">
-                                                                                    <PathIcon Data="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                                                                                    <PathIcon Data="{x:Static icons:Icons.ExportData}"
                                                                                               Width="16" Height="16" />
                                                                                 </Button>
                                                                             </StackPanel>
@@ -652,7 +653,7 @@
                                                 CornerRadius="32"
                                                 Background="{DynamicResource SurfaceAltBrush}"
                                                 HorizontalAlignment="Center">
-                                            <PathIcon Data="M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z"
+                                            <PathIcon Data="{x:Static icons:Icons.Receipts}"
                                                       Width="28" Height="28"
                                                       Foreground="{DynamicResource TextTertiaryBrush}" />
                                         </Border>
@@ -673,7 +674,7 @@
                                                 Margin="0,8,0,0"
                                                 Click="OnAiScanButtonClick">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                                <PathIcon Data="{x:Static icons:Icons.ScanReceipt}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'Scan Receipt'}" />
@@ -725,7 +726,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToPreviousPageCommand}"
                                             IsEnabled="{Binding CanGoToPreviousPage}">
-                                        <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                                   Width="16" Height="16" />
                                     </Button>
 
@@ -757,7 +758,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToNextPageCommand}"
                                             IsEnabled="{Binding CanGoToNextPage}">
-                                        <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                                   Width="16" Height="16" />
                                     </Button>
                                 </StackPanel>

--- a/ArgoBooks/Views/RentalInventoryPage.axaml
+++ b/ArgoBooks/Views/RentalInventoryPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.RentalInventoryPage"
              x:DataType="vm:RentalInventoryPageViewModel">
@@ -30,7 +31,7 @@
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Available'}"
                                    Value="{Binding AvailableItems}"
-                                   Icon="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                   Icon="{x:Static icons:Icons.Check}"
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc 'Rented Out'}"
                                    Value="{Binding RentedOutItems}"
@@ -76,7 +77,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -108,7 +109,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'Add Item'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Item'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -384,14 +385,14 @@
                                                                         ToolTip.Tip="{loc:Loc 'Edit'}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:RentalInventoryPageViewModel)DataContext).OpenEditModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button danger"
                                                                         ToolTip.Tip="{loc:Loc 'Delete'}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:RentalInventoryPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -433,7 +434,7 @@
                                                 Margin="0,8,0,0"
                                                 Command="{Binding OpenAddModalCommand}">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'Add Item'}" />
@@ -487,7 +488,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -519,7 +520,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/RentalRecordsPage.axaml
+++ b/ArgoBooks/Views/RentalRecordsPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.RentalRecordsPage"
              x:DataType="vm:RentalRecordsPageViewModel">
@@ -30,15 +31,15 @@
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Active'}"
                                    Value="{Binding ActiveRentals}"
-                                   Icon="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                   Icon="{x:Static icons:Icons.Check}"
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc 'Overdue'}"
                                    Value="{Binding OverdueRentals}"
-                                   Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                   Icon="{x:Static icons:Icons.Info}"
                                    IconColor="Danger" />
                 <controls:StatCard Label="{loc:Loc 'Total Revenue'}"
                                    Value="{Binding TotalRevenueFormatted}"
-                                   Icon="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z"
+                                   Icon="{x:Static icons:Icons.Dollar}"
                                    IconColor="Info" />
             </controls:StatCardsRow>
 
@@ -76,7 +77,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -108,7 +109,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'New Rental'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'New Rental'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -402,7 +403,7 @@
                                                                         Command="{Binding $parent[ItemsControl].((vm:RentalRecordsPageViewModel)DataContext).OpenReturnModalCommand}"
                                                                         CommandParameter="{Binding}"
                                                                         IsVisible="{Binding IsActive}">
-                                                                    <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Check}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button"
@@ -417,14 +418,14 @@
                                                                         Command="{Binding $parent[ItemsControl].((vm:RentalRecordsPageViewModel)DataContext).OpenEditModalCommand}"
                                                                         CommandParameter="{Binding}"
                                                                         IsVisible="{Binding IsActive}">
-                                                                    <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                                 <Button Classes="icon-button danger"
                                                                         ToolTip.Tip="{loc:Loc 'Delete'}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:RentalRecordsPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -466,7 +467,7 @@
                                                 Margin="0,8,0,0"
                                                 Command="{Binding OpenAddModalCommand}">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'New Rental'}" />
@@ -520,7 +521,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -552,7 +553,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -7,6 +7,7 @@
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:reports="using:ArgoBooks.Controls.Reports"
              xmlns:converters="using:ArgoBooks.Converters"
+             xmlns:local="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1400" d:DesignHeight="900"
              x:Class="ArgoBooks.Views.ReportsPage"
@@ -39,7 +40,7 @@
                                 IsVisible="{Binding IsStep1Active}">
                             <Panel>
                                 <!-- Show checkmark only if completed AND not currently on step 1 -->
-                                <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                <PathIcon Data="{x:Static local:Icons.Check}"
                                           Width="16" Height="16"
                                           Foreground="White"
                                           IsVisible="{Binding IsStep1CompletedAndPast}" />
@@ -84,7 +85,7 @@
                                 IsVisible="{Binding IsStep2Active}">
                             <Panel>
                                 <!-- Show checkmark only if completed AND not currently on step 2 -->
-                                <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                <PathIcon Data="{x:Static local:Icons.Check}"
                                           Width="16" Height="16"
                                           Foreground="White"
                                           IsVisible="{Binding IsStep2CompletedAndPast}" />
@@ -910,7 +911,7 @@
                                 </Transitions>
                             </Border.Transitions>
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                <PathIcon Data="{x:Static local:Icons.Check}"
                                           Width="16" Height="16"
                                           Foreground="White" />
                                 <TextBlock Text="{loc:Loc 'Saved'}"
@@ -1673,7 +1674,7 @@
                         Command="{Binding ExportReportCommand}"
                         IsVisible="{Binding IsOnFinalStep}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                        <PathIcon Data="{x:Static local:Icons.Check}"
                                   Width="16" Height="16"
                                   Foreground="White" />
                         <TextBlock Text="{loc:Loc 'Create Report'}" />

--- a/ArgoBooks/Views/ReturnsPage.axaml
+++ b/ArgoBooks/Views/ReturnsPage.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.ReturnsPage"
@@ -54,7 +55,7 @@
                                        IconColor="Success" />
                     <controls:StatCard Label="{loc:Loc 'Total Refunded'}"
                                        Value="{Binding TotalRefunded}"
-                                       Icon="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z"
+                                       Icon="{x:Static icons:Icons.Dollar}"
                                        IconColor="Info" />
                 </controls:StatCardsRow>
 
@@ -97,7 +98,7 @@
                                             MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                         <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                             <PathIcon Grid.Column="0"
-                                                      Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                      Data="{x:Static icons:Icons.Search}"
                                                       Width="16" Height="16"
                                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                                       Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -361,7 +362,7 @@
                                                                             ToolTip.Tip="{loc:Loc 'Undo Return'}"
                                                                             Command="{Binding $parent[ItemsControl].((vm:ReturnsPageViewModel)DataContext).UndoReturnCommand}"
                                                                             CommandParameter="{Binding}">
-                                                                        <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                                                        <PathIcon Data="{x:Static icons:Icons.Returns}"
                                                                                   Width="14" Height="14" />
                                                                     </Button>
                                                                 </StackPanel>
@@ -446,7 +447,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToPreviousPageCommand}"
                                             IsEnabled="{Binding CanGoToPreviousPage}">
-                                        <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                                   Width="16" Height="16" />
                                     </Button>
 
@@ -478,7 +479,7 @@
                                     <Button Classes="pagination-button"
                                             Command="{Binding GoToNextPageCommand}"
                                             IsEnabled="{Binding CanGoToNextPage}">
-                                        <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                                   Width="16" Height="16" />
                                     </Button>
                                 </StackPanel>
@@ -527,7 +528,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseViewDetailsModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -640,7 +641,7 @@
                                 <Border Width="40" Height="40"
                                         CornerRadius="8"
                                         Background="#FEF3C7">
-                                    <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                    <PathIcon Data="{x:Static icons:Icons.Returns}"
                                               Width="20" Height="20"
                                               Foreground="#D97706" />
                                 </Border>
@@ -653,7 +654,7 @@
                             <Button Grid.Column="1"
                                     Classes="icon-button"
                                     Command="{Binding CloseUndoReturnModalCommand}">
-                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="20" Height="20" />
                             </Button>
                         </Grid>

--- a/ArgoBooks/Views/RevenuePage.axaml
+++ b/ArgoBooks/Views/RevenuePage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.RevenuePage"
              x:DataType="vm:RevenuePageViewModel">
@@ -35,7 +36,7 @@
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Unique Customers'}"
                                    Value="{Binding UniqueCustomers}"
-                                   Icon="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"
+                                   Icon="{x:Static icons:Icons.Customers}"
                                    IconColor="Info" />
                 <controls:StatCard Label="{loc:Loc 'Returns'}"
                                    Value="{Binding ReturnsCount}"
@@ -77,7 +78,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -110,7 +111,7 @@
                                         Click="OnAiScanButtonClick"
                                         ToolTip.Tip="{loc:Loc 'AI Scan Receipt'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11zm-9.18-6.95L7.4 14.46 10.94 18l5.66-5.66-1.41-1.41-4.24 4.24-2.13-2.12z"
+                                        <PathIcon Data="{x:Static icons:Icons.ScanReceipt}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'AI Scan Receipt'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -124,7 +125,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'Add Revenue'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Revenue'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -465,11 +466,11 @@
                                                     <Panel Width="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).ColumnWidths.ReceiptColumnWidth}"
                                                            IsVisible="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).ShowReceiptColumn}">
                                                         <Panel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                            <PathIcon Data="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Check}"
                                                                       Width="16" Height="16"
                                                                       Foreground="#22C55E"
                                                                       IsVisible="{Binding HasReceipt}" />
-                                                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                            <PathIcon Data="{x:Static icons:Icons.Close}"
                                                                       Width="16" Height="16"
                                                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                                                       IsVisible="{Binding !HasReceipt}" />
@@ -507,14 +508,14 @@
                                                                     Command="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).ViewReceiptCommand}"
                                                                     CommandParameter="{Binding}"
                                                                     IsVisible="{Binding HasReceipt}">
-                                                                <PathIcon Data="M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Receipts}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <Button Classes="icon-button"
                                                                     ToolTip.Tip="{loc:Loc 'Edit'}"
                                                                     Command="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).OpenEditModalCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <!-- Mark as Lost/Damaged (shown when not already marked) -->
@@ -523,7 +524,7 @@
                                                                     Command="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).MarkAsLostDamagedCommand}"
                                                                     CommandParameter="{Binding}"
                                                                     IsVisible="{Binding CanMarkAsLostDamaged}">
-                                                                <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Info}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <!-- Undo Lost/Damaged (shown when already marked as lost/damaged) -->
@@ -532,7 +533,7 @@
                                                                     Command="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).UndoLostDamagedCommand}"
                                                                     CommandParameter="{Binding}"
                                                                     IsVisible="{Binding IsLostDamaged}">
-                                                                <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Returns}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <!-- Mark as Returned (shown when not already marked) -->
@@ -541,7 +542,7 @@
                                                                     Command="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).MarkAsReturnedCommand}"
                                                                     CommandParameter="{Binding}"
                                                                     IsVisible="{Binding CanMarkAsReturned}">
-                                                                <PathIcon Data="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Undo}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <!-- Undo Return (shown when already returned) -->
@@ -550,14 +551,14 @@
                                                                     Command="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).UndoReturnCommand}"
                                                                     CommandParameter="{Binding}"
                                                                     IsVisible="{Binding IsReturned}">
-                                                                <PathIcon Data="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Returns}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                             <Button Classes="icon-button danger"
                                                                     ToolTip.Tip="{loc:Loc 'Delete'}"
                                                                     Command="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                     CommandParameter="{Binding}">
-                                                                <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                           Width="16" Height="16" />
                                                             </Button>
                                                         </StackPanel>
@@ -599,7 +600,7 @@
                                                 Margin="0,8,0,0"
                                                 Command="{Binding OpenAddModalCommand}">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
                                                           Width="16" Height="16"
                                                           Foreground="White" />
                                                 <TextBlock Text="{loc:Loc 'Add Revenue'}" />
@@ -653,7 +654,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -685,7 +686,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/StockAdjustmentsPage.axaml
+++ b/ArgoBooks/Views/StockAdjustmentsPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.StockAdjustmentsPage"
              x:DataType="vm:StockAdjustmentsPageViewModel">
@@ -42,11 +43,11 @@
             <controls:StatCardsRow Grid.Row="0" Margin="0,0,0,24">
                 <controls:StatCard Label="{loc:Loc 'Total Adjustments'}"
                                    Value="{Binding TotalAdjustments}"
-                                   Icon="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"
+                                   Icon="{x:Static icons:Icons.Adjustments}"
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Items Added'}"
                                    Value="{Binding TotalAdded}"
-                                   Icon="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                   Icon="{x:Static icons:Icons.Add}"
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc 'Items Removed'}"
                                    Value="{Binding TotalRemoved}"
@@ -54,7 +55,7 @@
                                    IconColor="Danger" />
                 <controls:StatCard Label="{loc:Loc 'Net Change'}"
                                    Value="{Binding NetChange}"
-                                   Icon="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"
+                                   Icon="{x:Static icons:Icons.TrendUp}"
                                    IconColor="Warning" />
             </controls:StatCardsRow>
 
@@ -92,7 +93,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -124,7 +125,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'New Adjustment'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'New Adjustment'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -637,7 +638,7 @@
                                                                         ToolTip.Tip="{loc:Loc Delete}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:StockAdjustmentsPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -658,7 +659,7 @@
                                                     CornerRadius="32"
                                                     Background="{DynamicResource SurfaceAltBrush}"
                                                     HorizontalAlignment="Center">
-                                                <PathIcon Data="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"
+                                                <PathIcon Data="{x:Static icons:Icons.Adjustments}"
                                                           Width="28" Height="28"
                                                           Foreground="{DynamicResource TextTertiaryBrush}" />
                                             </Border>
@@ -679,7 +680,7 @@
                                                     Margin="0,8,0,0"
                                                     Command="{Binding OpenAddModalCommand}">
                                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                                    <PathIcon Data="{x:Static icons:Icons.Add}"
                                                               Width="16" Height="16"
                                                               Foreground="White" />
                                                     <TextBlock Text="{loc:Loc 'New Adjustment'}" />
@@ -733,7 +734,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -765,7 +766,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/StockLevelsPage.axaml
+++ b/ArgoBooks/Views/StockLevelsPage.axaml
@@ -6,6 +6,7 @@
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
              xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.StockLevelsPage"
              x:DataType="vm:StockLevelsPageViewModel">
@@ -52,15 +53,15 @@
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'In Stock'}"
                                    Value="{Binding InStockCount}"
-                                   Icon="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                   Icon="{x:Static icons:Icons.Check}"
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc 'Low Stock'}"
                                    Value="{Binding LowStockCount}"
-                                   Icon="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                                   Icon="{x:Static icons:Icons.LostDamaged}"
                                    IconColor="Warning" />
                 <controls:StatCard Label="{loc:Loc 'Out of Stock'}"
                                    Value="{Binding OutOfStockCount}"
-                                   Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                                   Icon="{x:Static icons:Icons.Info}"
                                    IconColor="Danger" />
                 <controls:StatCard Label="{loc:Loc Overstock}"
                                    Value="{Binding OverstockCount}"
@@ -102,7 +103,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -134,7 +135,7 @@
                                         Command="{Binding OpenAddItemModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'Add Item'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16" />
                                         <TextBlock Text="{loc:Loc 'Add Item'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
                                     </StackPanel>
@@ -633,7 +634,7 @@
                                                                         ToolTip.Tip="{loc:Loc 'Adjust Stock'}"
                                                                         Command="{Binding $parent[ItemsControl].((vm:StockLevelsPageViewModel)DataContext).OpenAdjustStockModalCommand}"
                                                                         CommandParameter="{Binding}">
-                                                                    <PathIcon Data="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"
+                                                                    <PathIcon Data="{x:Static icons:Icons.Adjustments}"
                                                                               Width="16" Height="16" />
                                                                 </Button>
                                                             </StackPanel>
@@ -718,7 +719,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -750,7 +751,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/SuppliersPage.axaml
+++ b/ArgoBooks/Views/SuppliersPage.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:local="using:ArgoBooks.Converters"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.SuppliersPage"
@@ -25,19 +26,19 @@
             <controls:StatCardsRow Grid.Row="0" Margin="0,0,0,24">
                 <controls:StatCard Label="{loc:Loc 'Total Suppliers'}"
                                    Value="{Binding TotalSuppliers}"
-                                   Icon="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                                   Icon="{x:Static icons:Icons.Departments}"
                                    IconColor="Primary" />
                 <controls:StatCard Label="{loc:Loc 'Active Suppliers'}"
                                    Value="{Binding ActiveSuppliers}"
-                                   Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                   Icon="{x:Static icons:Icons.CircleCheck}"
                                    IconColor="Success" />
                 <controls:StatCard Label="{loc:Loc 'Countries'}"
                                    Value="{Binding TotalCountries}"
-                                   Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"
+                                   Icon="{x:Static icons:Icons.Globe}"
                                    IconColor="Warning" />
                 <controls:StatCard Label="{loc:Loc 'Products Supplied'}"
                                    Value="{Binding TotalProductsSupplied}"
-                                   Icon="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.16.12-.36.18-.57.18-.21 0-.41-.06-.57-.18l-7.9-4.44A.991.991 0 013 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.16-.12.36-.18.57-.18.21 0 .41.06.57.18l7.9 4.44c.32.17.53.5.53.88v9zM12 4.15L6.04 7.5 12 10.85l5.96-3.35L12 4.15zM5 15.91l6 3.38v-6.71L5 9.21v6.7zm14 0v-6.7l-6 3.37v6.71l6-3.38z"
+                                   Icon="{x:Static icons:Icons.Products}"
                                    IconColor="Info" />
             </controls:StatCardsRow>
 
@@ -75,7 +76,7 @@
                                         MinHeight="{Binding ResponsiveHeader.SearchBoxMinHeight}">
                                     <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                         <PathIcon Grid.Column="0"
-                                                  Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                                  Data="{x:Static icons:Icons.Search}"
                                                   Width="16" Height="16"
                                                   Foreground="{DynamicResource TextTertiaryBrush}"
                                                   Margin="{Binding ResponsiveHeader.SearchIconMargin}" />
@@ -107,7 +108,7 @@
                                         Command="{Binding OpenAddModalCommand}"
                                         ToolTip.Tip="{loc:Loc 'Add Supplier'}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Supplier'}" IsVisible="{Binding ResponsiveHeader.ShowButtonText}" />
@@ -426,14 +427,14 @@
                                                             ToolTip.Tip="{loc:Loc 'Edit'}"
                                                             Command="{Binding $parent[ItemsControl].((vm:SuppliersPageViewModel)DataContext).OpenEditModalCommand}"
                                                             CommandParameter="{Binding}">
-                                                        <PathIcon Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                                                        <PathIcon Data="{x:Static icons:Icons.Edit}"
                                                                   Width="16" Height="16" />
                                                     </Button>
                                                     <Button Classes="icon-button danger"
                                                             ToolTip.Tip="{loc:Loc 'Delete'}"
                                                             Command="{Binding $parent[ItemsControl].((vm:SuppliersPageViewModel)DataContext).OpenDeleteConfirmCommand}"
                                                             CommandParameter="{Binding}">
-                                                        <PathIcon Data="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                                        <PathIcon Data="{x:Static icons:Icons.Delete}"
                                                                   Width="16" Height="16" />
                                                     </Button>
                                                 </StackPanel>
@@ -454,7 +455,7 @@
                                         CornerRadius="32"
                                         Background="{DynamicResource SurfaceAltBrush}"
                                         HorizontalAlignment="Center">
-                                    <PathIcon Data="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4zM6 18.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm13.5-9l1.96 2.5H17V9.5h2.5zm-1.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"
+                                    <PathIcon Data="{x:Static icons:Icons.Suppliers}"
                                               Width="28" Height="28"
                                               Foreground="{DynamicResource TextTertiaryBrush}" />
                                 </Border>
@@ -475,7 +476,7 @@
                                         Margin="0,8,0,0"
                                         Command="{Binding OpenAddModalCommand}">
                                     <StackPanel Orientation="Horizontal" Spacing="8">
-                                        <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                        <PathIcon Data="{x:Static icons:Icons.Add}"
                                                   Width="16" Height="16"
                                                   Foreground="White" />
                                         <TextBlock Text="{loc:Loc 'Add Supplier'}" />
@@ -529,7 +530,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToPreviousPageCommand}"
                                         IsEnabled="{Binding CanGoToPreviousPage}">
-                                    <PathIcon Data="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
                                               Width="16" Height="16" />
                                 </Button>
 
@@ -561,7 +562,7 @@
                                 <Button Classes="pagination-button"
                                         Command="{Binding GoToNextPageCommand}"
                                         IsEnabled="{Binding CanGoToNextPage}">
-                                    <PathIcon Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                    <PathIcon Data="{x:Static icons:Icons.ChevronRightNav}"
                                               Width="16" Height="16" />
                                 </Button>
                             </StackPanel>

--- a/ArgoBooks/Views/WelcomeScreen.axaml
+++ b/ArgoBooks/Views/WelcomeScreen.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
+             xmlns:local="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="800"
              x:Class="ArgoBooks.Views.WelcomeScreen"
@@ -74,7 +75,7 @@
                                 <Border Width="64" Height="64"
                                         CornerRadius="32"
                                         Background="{DynamicResource PrimaryLightBrush}">
-                                    <PathIcon Data="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                    <PathIcon Data="{x:Static local:Icons.Add}"
                                               Width="28" Height="28"
                                               Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
@@ -103,7 +104,7 @@
                                 <Border Width="64" Height="64"
                                         CornerRadius="32"
                                         Background="#E6F4EA">
-                                    <PathIcon Data="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z"
+                                    <PathIcon Data="{x:Static local:Icons.Folder}"
                                               Width="28" Height="28"
                                               Foreground="#22C55E" />
                                 </Border>
@@ -157,7 +158,7 @@
                                                     CornerRadius="8"
                                                     Background="{DynamicResource SurfaceAltBrush}"
                                                     Margin="0,0,16,0">
-                                                <PathIcon Data="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"
+                                                <PathIcon Data="{x:Static local:Icons.Departments}"
                                                           Width="22" Height="22"
                                                           Foreground="{DynamicResource TextSecondaryBrush}" />
                                             </Border>
@@ -190,7 +191,7 @@
                                                     Command="{Binding $parent[ItemsControl].((vm:WelcomeScreenViewModel)DataContext).RemoveFromRecentCommand}"
                                                     CommandParameter="{Binding}"
                                                     ToolTip.Tip="{loc:Loc 'Remove from recent'}">
-                                                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                <PathIcon Data="{x:Static local:Icons.Close}"
                                                           Width="14" Height="14" />
                                             </Button>
                                         </Grid>
@@ -213,7 +214,7 @@
                                     CornerRadius="24"
                                     Background="#FEF3C7"
                                     Margin="0,0,16,0">
-                                <PathIcon Data="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+                                <PathIcon Data="{x:Static local:Icons.Star}"
                                           Width="24" Height="24"
                                           Foreground="#F59E0B" />
                             </Border>
@@ -233,7 +234,7 @@
 
                             <!-- Arrow -->
                             <PathIcon Grid.Column="2"
-                                      Data="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                                      Data="{x:Static local:Icons.ChevronRightNav}"
                                       Width="20" Height="20"
                                       Foreground="{DynamicResource TextTertiaryBrush}"
                                       VerticalAlignment="Center" />
@@ -248,7 +249,7 @@
                     <Button Classes="footer-link"
                             Command="{Binding OpenHelpCommand}">
                         <StackPanel Orientation="Horizontal" Spacing="6">
-                            <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                            <PathIcon Data="{x:Static local:Icons.Help}"
                                       Width="16" Height="16" />
                             <TextBlock Text="{loc:Loc 'Help &amp; Support'}" />
                         </StackPanel>


### PR DESCRIPTION
Create a single source of truth for all SVG path data used throughout the application. This ensures quick action items use exactly the same icons as the sidebar, fixing visual inconsistencies.

- Add Icons.cs with categorized icon constants (navigation, tools, UI)
- Update QuickActionsViewModel to reference Icons class
- Update SidebarViewModel to reference Icons class