### PR TITLE
Improve invoice template modal and logo/image selection UI

### DIFF
--- a/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceEmailService.cs
+++ b/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceEmailService.cs
@@ -285,9 +285,9 @@ public class InvoiceEmailService : IDisposable
     /// <summary>
     /// Renders a preview with sample data.
     /// </summary>
-    public string RenderTemplatePreview(InvoiceTemplate template, CompanySettings companySettings)
+    public string RenderTemplatePreview(InvoiceTemplate template, CompanySettings companySettings, bool lockAspectRatio = true)
     {
-        return _htmlRenderer.RenderPreview(template, companySettings);
+        return _htmlRenderer.RenderPreview(template, companySettings, lockAspectRatio);
     }
 
     private static string BuildSubject(string template, Invoice invoice, CompanySettings settings)

--- a/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceHtmlRenderer.cs
+++ b/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceHtmlRenderer.cs
@@ -34,7 +34,7 @@ public partial class InvoiceHtmlRenderer
         var html = InvoiceHtmlTemplates.GetTemplate(template.BaseTemplate);
 
         // Build the data context for template rendering
-        var context = BuildContext(invoice, template, customer, companySettings, currencySymbol);
+        var context = BuildContext(invoice, template, customer, companySettings, currencySymbol, lockAspectRatio: true);
 
         // Process the template
         html = ProcessTemplate(html, context);
@@ -45,13 +45,13 @@ public partial class InvoiceHtmlRenderer
     /// <summary>
     /// Renders a preview invoice (for template designer) with sample data.
     /// </summary>
-    public string RenderPreview(InvoiceTemplate template, CompanySettings companySettings)
+    public string RenderPreview(InvoiceTemplate template, CompanySettings companySettings, bool lockAspectRatio = true)
     {
         // Create sample invoice data for preview
         var sampleInvoice = new Invoice
         {
-            Id = "INV-2024-00001",
-            InvoiceNumber = "INV-2024-00001",
+            Id = "INV-0001",
+            InvoiceNumber = "INV-0001",
             IssueDate = DateTime.Today,
             DueDate = DateTime.Today.AddDays(30),
             Subtotal = 1250.00m,
@@ -60,32 +60,46 @@ public partial class InvoiceHtmlRenderer
             Total = 1375.00m,
             AmountPaid = 0m,
             Balance = 1375.00m,
-            Notes = "Thank you for your business. Please remit payment within 30 days.",
+            Notes = "Example notes section. This area can contain additional information for your customer.",
             LineItems =
             [
-                new() { Description = "Website Design Services", Quantity = 1, UnitPrice = 800.00m },
-                new() { Description = "Logo Design", Quantity = 1, UnitPrice = 250.00m },
-                new() { Description = "Business Card Design", Quantity = 2, UnitPrice = 100.00m }
+                new() { Description = "Example Product 1", Quantity = 1, UnitPrice = 800.00m },
+                new() { Description = "Example Product 2", Quantity = 1, UnitPrice = 250.00m },
+                new() { Description = "Example Product 3", Quantity = 2, UnitPrice = 100.00m }
             ]
         };
 
         // Create sample customer
         var sampleCustomer = new Models.Entities.Customer
         {
-            Name = "Acme Corporation",
-            Email = "billing@acme.com",
+            Name = "Example Customer",
+            Email = "customer@example.com",
             Address = new Models.Common.Address
             {
-                Street = "123 Business Ave, Suite 100",
-                City = "New York",
-                State = "NY",
-                ZipCode = "10001",
-                Country = "USA"
+                Street = "123 Example Street",
+                City = "Example City",
+                State = "EX",
+                ZipCode = "12345",
+                Country = "Example Country"
+            }
+        };
+
+        // Override company info with generic placeholders for the preview
+        var previewCompanySettings = new CompanySettings
+        {
+            Company = new CompanyInfo
+            {
+                Name = "Your Company",
+                Address = companySettings.Company.Address ?? "Your Address",
+                Email = companySettings.Company.Email ?? "your@email.com",
+                Phone = companySettings.Company.Phone ?? "Your Phone",
+                City = companySettings.Company.City ?? "Your City",
+                Country = companySettings.Company.Country ?? "Your Country"
             }
         };
 
         var html = InvoiceHtmlTemplates.GetTemplate(template.BaseTemplate);
-        var context = BuildContext(sampleInvoice, template, sampleCustomer, companySettings, "$");
+        var context = BuildContext(sampleInvoice, template, sampleCustomer, previewCompanySettings, "$", lockAspectRatio);
         return ProcessTemplate(html, context);
     }
 
@@ -187,7 +201,8 @@ public partial class InvoiceHtmlRenderer
         InvoiceTemplate template,
         Models.Entities.Customer? customer,
         CompanySettings companySettings,
-        string currencySymbol)
+        string currencySymbol,
+        bool lockAspectRatio)
     {
         var isOverdue = invoice.DueDate.Date < DateTime.Today &&
                         invoice.Balance > 0;
@@ -222,6 +237,7 @@ public partial class InvoiceHtmlRenderer
                 ? $"data:image/png;base64,{template.LogoBase64}"
                 : "",
             ["LogoWidth"] = template.LogoWidth.ToString(),
+            ["LockAspectRatio"] = lockAspectRatio,
 
             // Company info
             ["CompanyName"] = companySettings.Company.Name,

--- a/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceHtmlTemplates.cs
+++ b/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceHtmlTemplates.cs
@@ -31,7 +31,7 @@ public static class InvoiceHtmlTemplates
                                 <tr>
                                     <td>
                                         {{#ShowLogo}}
-                                        <img src="{{LogoSrc}}" alt="Company Logo" width="{{LogoWidth}}" style="display: block; max-height: 60px;">
+                                        <img src="{{LogoSrc}}" alt="Company Logo" width="{{LogoWidth}}" style="display: block; {{#LockAspectRatio}}height: auto;{{/LockAspectRatio}}{{^LockAspectRatio}}max-height: 60px;{{/LockAspectRatio}}">
                                         {{/ShowLogo}}
                                         {{^ShowLogo}}
                                         <span style="font-size: 24px; font-weight: bold; color: #ffffff;">{{CompanyName}}</span>
@@ -190,13 +190,11 @@ public static class InvoiceHtmlTemplates
                     <tr>
                         <td style="padding: 25px 40px; background-color: #f9fafb; border-radius: 0 0 8px 8px; text-align: center;">
                             <p style="margin: 0 0 10px 0; font-size: 14px; color: #374151;">{{FooterText}}</p>
-                            {{#ShowCompanyAddress}}
                             <p style="margin: 0; font-size: 12px; color: #9ca3af;">
-                                {{CompanyName}}{{#CompanyAddress}} • {{CompanyAddress}}{{/CompanyAddress}}{{#ShowCompanyCity}}{{#CompanyCity}} • {{CompanyCity}}{{/CompanyCity}}{{/ShowCompanyCity}}{{#ShowCompanyCountry}}{{#CompanyCountry}} • {{CompanyCountry}}{{/CompanyCountry}}{{/ShowCompanyCountry}}
+                                {{CompanyName}}{{#ShowCompanyAddress}}{{#CompanyAddress}} • {{CompanyAddress}}{{/CompanyAddress}}{{/ShowCompanyAddress}}{{#ShowCompanyCity}}{{#CompanyCity}} • {{CompanyCity}}{{/CompanyCity}}{{/ShowCompanyCity}}{{#ShowCompanyCountry}}{{#CompanyCountry}} • {{CompanyCountry}}{{/CompanyCountry}}{{/ShowCompanyCountry}}
                             </p>
                             {{#CompanyEmail}}<p style="margin: 5px 0 0 0; font-size: 12px; color: #9ca3af;">{{CompanyEmail}}{{#ShowCompanyPhone}}{{#CompanyPhone}} • {{CompanyPhone}}{{/CompanyPhone}}{{/ShowCompanyPhone}}</p>{{/CompanyEmail}}
                             {{^CompanyEmail}}{{#ShowCompanyPhone}}{{#CompanyPhone}}<p style="margin: 5px 0 0 0; font-size: 12px; color: #9ca3af;">{{CompanyPhone}}</p>{{/CompanyPhone}}{{/ShowCompanyPhone}}{{/CompanyEmail}}
-                            {{/ShowCompanyAddress}}
                         </td>
                     </tr>
                 </table>
@@ -208,7 +206,7 @@ public static class InvoiceHtmlTemplates
 """;
 
     /// <summary>
-    /// Modern template: Clean, minimalist design with plenty of whitespace.
+    /// Modern template: Contemporary design with sidebar accent and clean layout.
     /// </summary>
     public const string Modern = """
 <!DOCTYPE html>
@@ -218,58 +216,77 @@ public static class InvoiceHtmlTemplates
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Invoice {{InvoiceNumber}}</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: {{FontFamily}}; background-color: {{BackgroundColor}};">
-    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color: {{BackgroundColor}};">
+<body style="margin: 0; padding: 0; font-family: {{FontFamily}}; background-color: #f0f4f8;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color: #f0f4f8;">
         <tr>
-            <td align="center" style="padding: 60px 20px;">
-                <table role="presentation" cellpadding="0" cellspacing="0" width="600">
-                    <!-- Header -->
+            <td align="center" style="padding: 40px 20px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="background-color: {{BackgroundColor}}; border-radius: 8px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,0.08);">
+                    <!-- Header with accent bar -->
                     <tr>
-                        <td style="padding-bottom: 40px;">
+                        <td>
                             <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
-                                    <td style="vertical-align: middle;">
-                                        {{#ShowLogo}}
-                                        <img src="{{LogoSrc}}" alt="Company Logo" width="{{LogoWidth}}" style="display: block; max-height: 50px;">
-                                        {{/ShowLogo}}
-                                        {{^ShowLogo}}
-                                        <span style="font-size: 22px; font-weight: 600; color: {{TextColor}};">{{CompanyName}}</span>
-                                        {{/ShowLogo}}
-                                    </td>
-                                    <td style="text-align: right; vertical-align: middle;">
-                                        <span style="font-size: 11px; text-transform: uppercase; letter-spacing: 2px; color: #9ca3af;">{{HeaderText}}</span>
+                                    <td style="width: 8px; background-color: {{PrimaryColor}};"></td>
+                                    <td style="padding: 30px 35px; background-color: {{SecondaryColor}};">
+                                        <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                                            <tr>
+                                                <td style="vertical-align: middle;">
+                                                    {{#ShowLogo}}
+                                                    <img src="{{LogoSrc}}" alt="Company Logo" width="{{LogoWidth}}" style="display: block; {{#LockAspectRatio}}height: auto;{{/LockAspectRatio}}{{^LockAspectRatio}}max-height: 55px;{{/LockAspectRatio}}">
+                                                    {{/ShowLogo}}
+                                                    {{^ShowLogo}}
+                                                    <span style="font-size: 22px; font-weight: 700; color: {{TextColor}};">{{CompanyName}}</span>
+                                                    {{/ShowLogo}}
+                                                </td>
+                                                <td style="text-align: right; vertical-align: middle;">
+                                                    <p style="margin: 0 0 4px 0; font-size: 24px; font-weight: 700; color: {{PrimaryColor}}; letter-spacing: -0.5px;">{{HeaderText}}</p>
+                                                    <p style="margin: 0; font-size: 14px; color: #6b7280;">{{InvoiceNumber}}</p>
+                                                </td>
+                                            </tr>
+                                        </table>
                                     </td>
                                 </tr>
                             </table>
                         </td>
                     </tr>
 
-                    <!-- Invoice Number -->
+                    <!-- Invoice Details -->
                     <tr>
-                        <td style="padding-bottom: 40px;">
-                            <span style="font-size: 32px; font-weight: 300; color: {{TextColor}};">{{InvoiceNumber}}</span>
-                        </td>
-                    </tr>
-
-                    <!-- Details Grid -->
-                    <tr>
-                        <td style="padding-bottom: 40px;">
+                        <td style="padding: 30px 35px;">
                             <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
-                                    <td style="width: 50%; vertical-align: top; padding-right: 20px;">
-                                        <p style="margin: 0 0 8px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af;">Billed To</p>
-                                        <p style="margin: 0; font-size: 15px; font-weight: 500; color: {{TextColor}}; line-height: 1.6;">
-                                            {{CustomerName}}<br>
-                                            {{#CustomerAddress}}<span style="font-weight: 400; color: #6b7280;">{{CustomerAddress}}</span>{{/CustomerAddress}}
-                                        </p>
+                                    <td style="width: 55%; vertical-align: top; padding-right: 20px;">
+                                        <p style="margin: 0 0 8px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 1.5px; color: {{PrimaryColor}}; font-weight: 600;">Bill To</p>
+                                        <p style="margin: 0 0 4px 0; font-size: 16px; font-weight: 600; color: {{TextColor}};">{{CustomerName}}</p>
+                                        {{#CustomerAddress}}<p style="margin: 0 0 2px 0; font-size: 13px; color: #6b7280; line-height: 1.5;">{{CustomerAddress}}</p>{{/CustomerAddress}}
+                                        {{#CustomerEmail}}<p style="margin: 4px 0 0 0; font-size: 13px; color: #6b7280;">{{CustomerEmail}}</p>{{/CustomerEmail}}
                                     </td>
-                                    <td style="width: 25%; vertical-align: top;">
-                                        <p style="margin: 0 0 8px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af;">Issued</p>
-                                        <p style="margin: 0; font-size: 15px; color: {{TextColor}};">{{IssueDate}}</p>
-                                    </td>
-                                    <td style="width: 25%; vertical-align: top; text-align: right;">
-                                        <p style="margin: 0 0 8px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af;">Due</p>
-                                        <p style="margin: 0; font-size: 15px; {{#IsOverdue}}color: #dc2626; font-weight: 500;{{/IsOverdue}}{{^IsOverdue}}color: {{TextColor}};{{/IsOverdue}}">{{DueDate}}</p>
+                                    <td style="width: 45%; vertical-align: top;">
+                                        <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color: {{SecondaryColor}}; border-radius: 6px;">
+                                            <tr>
+                                                <td style="padding: 15px;">
+                                                    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                                                        <tr>
+                                                            <td style="padding: 4px 0; font-size: 12px; color: #6b7280;">Issue Date</td>
+                                                            <td style="padding: 4px 0; font-size: 13px; font-weight: 500; color: {{TextColor}}; text-align: right;">{{IssueDate}}</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td style="padding: 4px 0; font-size: 12px; color: #6b7280;">Due Date</td>
+                                                            <td style="padding: 4px 0; font-size: 13px; font-weight: 500; text-align: right; {{#IsOverdue}}color: #dc2626;{{/IsOverdue}}{{^IsOverdue}}color: {{TextColor}};{{/IsOverdue}}">{{DueDate}}</td>
+                                                        </tr>
+                                                        {{#ShowDueDateProminent}}
+                                                        <tr>
+                                                            <td colspan="2" style="padding-top: 10px;">
+                                                                <span style="display: inline-block; width: 100%; text-align: center; background-color: {{#IsOverdue}}#fef2f2{{/IsOverdue}}{{^IsOverdue}}{{BackgroundColor}}{{/IsOverdue}}; color: {{#IsOverdue}}#dc2626{{/IsOverdue}}{{^IsOverdue}}{{PrimaryColor}}{{/IsOverdue}}; padding: 8px 0; border-radius: 4px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px;">
+                                                                    {{#IsOverdue}}⚠ Overdue{{/IsOverdue}}{{^IsOverdue}}Due: {{DueDate}}{{/IsOverdue}}
+                                                                </span>
+                                                            </td>
+                                                        </tr>
+                                                        {{/ShowDueDateProminent}}
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                        </table>
                                     </td>
                                 </tr>
                             </table>
@@ -278,55 +295,73 @@ public static class InvoiceHtmlTemplates
 
                     <!-- Line Items -->
                     <tr>
-                        <td>
-                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-top: 1px solid {{SecondaryColor}};">
+                        <td style="padding: 0 35px;">
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
+                                <tr style="background-color: {{PrimaryColor}};">
+                                    <td style="padding: 12px 15px; font-size: 11px; font-weight: 600; color: #ffffff; text-transform: uppercase; letter-spacing: 0.5px; border-radius: 6px 0 0 6px;">Description</td>
+                                    <td style="padding: 12px 10px; font-size: 11px; font-weight: 600; color: #ffffff; text-transform: uppercase; letter-spacing: 0.5px; text-align: center; width: 70px;">Qty</td>
+                                    <td style="padding: 12px 10px; font-size: 11px; font-weight: 600; color: #ffffff; text-transform: uppercase; letter-spacing: 0.5px; text-align: right; width: 90px;">Rate</td>
+                                    <td style="padding: 12px 15px; font-size: 11px; font-weight: 600; color: #ffffff; text-transform: uppercase; letter-spacing: 0.5px; text-align: right; width: 100px; border-radius: 0 6px 6px 0;">Amount</td>
+                                </tr>
                                 {{#LineItems}}
                                 <tr>
-                                    <td style="padding: 20px 0; border-bottom: 1px solid {{SecondaryColor}};">
-                                        <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
-                                            <tr>
-                                                <td style="vertical-align: top;">
-                                                    <p style="margin: 0; font-size: 15px; color: {{TextColor}};">{{Description}}</p>
-                                                    {{#ShowItemDescriptions}}{{#ItemDescription}}<p style="margin: 4px 0 0 0; font-size: 13px; color: #9ca3af;">{{ItemDescription}}</p>{{/ItemDescription}}{{/ShowItemDescriptions}}
-                                                </td>
-                                                <td style="width: 80px; text-align: center; vertical-align: top;">
-                                                    <p style="margin: 0; font-size: 14px; color: #6b7280;">{{Quantity}}</p>
-                                                </td>
-                                                <td style="width: 100px; text-align: right; vertical-align: top;">
-                                                    <p style="margin: 0; font-size: 14px; color: #6b7280;">{{UnitPrice}}</p>
-                                                </td>
-                                                <td style="width: 100px; text-align: right; vertical-align: top;">
-                                                    <p style="margin: 0; font-size: 15px; font-weight: 500; color: {{TextColor}};">{{Amount}}</p>
-                                                </td>
-                                            </tr>
-                                        </table>
+                                    <td style="padding: 16px 15px; font-size: 14px; color: {{TextColor}}; border-bottom: 1px solid {{SecondaryColor}};">
+                                        {{Description}}
+                                        {{#ShowItemDescriptions}}{{#ItemDescription}}<br><span style="font-size: 12px; color: #9ca3af;">{{ItemDescription}}</span>{{/ItemDescription}}{{/ShowItemDescriptions}}
                                     </td>
+                                    <td style="padding: 16px 10px; font-size: 14px; color: #6b7280; text-align: center; border-bottom: 1px solid {{SecondaryColor}};">{{Quantity}}</td>
+                                    <td style="padding: 16px 10px; font-size: 14px; color: #6b7280; text-align: right; border-bottom: 1px solid {{SecondaryColor}};">{{UnitPrice}}</td>
+                                    <td style="padding: 16px 15px; font-size: 14px; font-weight: 600; color: {{TextColor}}; text-align: right; border-bottom: 1px solid {{SecondaryColor}};">{{Amount}}</td>
                                 </tr>
                                 {{/LineItems}}
                             </table>
                         </td>
                     </tr>
 
-                    <!-- Totals -->
+                    <!-- Totals and Notes Row -->
                     <tr>
-                        <td style="padding: 30px 0;">
-                            <table role="presentation" cellpadding="0" cellspacing="0" width="250" style="margin-left: auto;">
+                        <td style="padding: 25px 35px;">
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
-                                    <td style="padding: 6px 0; font-size: 14px; color: #6b7280;">Subtotal</td>
-                                    <td style="padding: 6px 0; font-size: 14px; color: {{TextColor}}; text-align: right;">{{Subtotal}}</td>
-                                </tr>
-                                {{#ShowTaxBreakdown}}
-                                <tr>
-                                    <td style="padding: 6px 0; font-size: 14px; color: #6b7280;">Tax ({{TaxRate}}%)</td>
-                                    <td style="padding: 6px 0; font-size: 14px; color: {{TextColor}}; text-align: right;">{{TaxAmount}}</td>
-                                </tr>
-                                {{/ShowTaxBreakdown}}
-                                <tr>
-                                    <td colspan="2" style="padding: 15px 0 0 0; border-top: 1px solid {{SecondaryColor}};"></td>
-                                </tr>
-                                <tr>
-                                    <td style="font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af;">Total Due</td>
-                                    <td style="font-size: 24px; font-weight: 300; color: {{PrimaryColor}}; text-align: right;">{{Total}}</td>
+                                    <td style="width: 55%; vertical-align: top; padding-right: 30px;">
+                                        {{#ShowNotes}}
+                                        {{#Notes}}
+                                        <p style="margin: 0 0 8px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: {{PrimaryColor}}; font-weight: 600;">Notes</p>
+                                        <p style="margin: 0; font-size: 13px; color: #6b7280; line-height: 1.6;">{{Notes}}</p>
+                                        {{/Notes}}
+                                        {{/ShowNotes}}
+                                    </td>
+                                    <td style="width: 45%;">
+                                        <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                                            <tr>
+                                                <td style="padding: 8px 0; font-size: 13px; color: #6b7280;">Subtotal</td>
+                                                <td style="padding: 8px 0; font-size: 13px; color: {{TextColor}}; text-align: right;">{{Subtotal}}</td>
+                                            </tr>
+                                            {{#ShowTaxBreakdown}}
+                                            <tr>
+                                                <td style="padding: 8px 0; font-size: 13px; color: #6b7280;">Tax ({{TaxRate}}%)</td>
+                                                <td style="padding: 8px 0; font-size: 13px; color: {{TextColor}}; text-align: right;">{{TaxAmount}}</td>
+                                            </tr>
+                                            {{/ShowTaxBreakdown}}
+                                            <tr>
+                                                <td colspan="2" style="padding-top: 12px; border-top: 2px solid {{PrimaryColor}};"></td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding: 8px 0; font-size: 16px; font-weight: 700; color: {{TextColor}};">Total</td>
+                                                <td style="padding: 8px 0; font-size: 20px; font-weight: 700; color: {{PrimaryColor}}; text-align: right;">{{Total}}</td>
+                                            </tr>
+                                            {{#AmountPaid}}
+                                            <tr>
+                                                <td style="padding: 6px 0; font-size: 13px; color: {{AccentColor}};">Paid</td>
+                                                <td style="padding: 6px 0; font-size: 13px; color: {{AccentColor}}; text-align: right;">-{{AmountPaid}}</td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding: 6px 0; font-size: 15px; font-weight: 600; color: {{TextColor}};">Balance Due</td>
+                                                <td style="padding: 6px 0; font-size: 17px; font-weight: 700; color: {{PrimaryColor}}; text-align: right;">{{Balance}}</td>
+                                            </tr>
+                                            {{/AmountPaid}}
+                                        </table>
+                                    </td>
                                 </tr>
                             </table>
                         </td>
@@ -336,30 +371,34 @@ public static class InvoiceHtmlTemplates
                     {{#PaymentInstructions}}
                     <!-- Payment Instructions -->
                     <tr>
-                        <td style="padding: 30px 0; border-top: 1px solid {{SecondaryColor}};">
-                            <p style="margin: 0 0 10px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af;">Payment Details</p>
-                            <p style="margin: 0; font-size: 14px; color: #6b7280; line-height: 1.6; white-space: pre-line;">{{PaymentInstructions}}</p>
+                        <td style="padding: 0 35px 25px 35px;">
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color: {{SecondaryColor}}; border-radius: 6px; border-left: 4px solid {{AccentColor}};">
+                                <tr>
+                                    <td style="padding: 18px 20px;">
+                                        <p style="margin: 0 0 8px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: {{AccentColor}}; font-weight: 600;">Payment Instructions</p>
+                                        <p style="margin: 0; font-size: 13px; color: #4b5563; line-height: 1.6; white-space: pre-line;">{{PaymentInstructions}}</p>
+                                    </td>
+                                </tr>
+                            </table>
                         </td>
                     </tr>
                     {{/PaymentInstructions}}
                     {{/ShowPaymentInstructions}}
 
-                    {{#ShowNotes}}
-                    {{#Notes}}
-                    <!-- Notes -->
-                    <tr>
-                        <td style="padding: 30px 0; border-top: 1px solid {{SecondaryColor}};">
-                            <p style="margin: 0 0 10px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af;">Notes</p>
-                            <p style="margin: 0; font-size: 14px; color: #6b7280; line-height: 1.6;">{{Notes}}</p>
-                        </td>
-                    </tr>
-                    {{/Notes}}
-                    {{/ShowNotes}}
-
                     <!-- Footer -->
                     <tr>
-                        <td style="padding-top: 40px; text-align: center;">
-                            <p style="margin: 0; font-size: 13px; color: #9ca3af;">{{FooterText}}</p>
+                        <td>
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td style="width: 8px; background-color: {{PrimaryColor}};"></td>
+                                    <td style="padding: 20px 35px; background-color: {{SecondaryColor}}; text-align: center;">
+                                        <p style="margin: 0 0 6px 0; font-size: 13px; color: #4b5563;">{{FooterText}}</p>
+                                        <p style="margin: 0; font-size: 11px; color: #9ca3af;">
+                                            {{CompanyName}}{{#ShowCompanyAddress}}{{#CompanyAddress}} • {{CompanyAddress}}{{/CompanyAddress}}{{/ShowCompanyAddress}}{{#ShowCompanyCity}}{{#CompanyCity}} • {{CompanyCity}}{{/CompanyCity}}{{/ShowCompanyCity}}{{#ShowCompanyCountry}}{{#CompanyCountry}} • {{CompanyCountry}}{{/CompanyCountry}}{{/ShowCompanyCountry}}{{#ShowCompanyPhone}}{{#CompanyPhone}} • {{CompanyPhone}}{{/CompanyPhone}}{{/ShowCompanyPhone}}
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
                         </td>
                     </tr>
                 </table>
@@ -393,16 +432,14 @@ public static class InvoiceHtmlTemplates
                                 <tr>
                                     <td style="width: 60%;">
                                         {{#ShowLogo}}
-                                        <img src="{{LogoSrc}}" alt="Company Logo" width="{{LogoWidth}}" style="display: block; max-height: 60px; margin-bottom: 10px;">
+                                        <img src="{{LogoSrc}}" alt="Company Logo" width="{{LogoWidth}}" style="display: block; {{#LockAspectRatio}}height: auto;{{/LockAspectRatio}}{{^LockAspectRatio}}max-height: 60px;{{/LockAspectRatio}} margin-bottom: 10px;">
                                         {{/ShowLogo}}
                                         <p style="margin: 0; font-size: 18px; font-weight: bold; color: {{TextColor}};">{{CompanyName}}</p>
-                                        {{#ShowCompanyAddress}}
-                                        {{#CompanyAddress}}<p style="margin: 5px 0 0 0; font-size: 12px; color: #666666; line-height: 1.5;">{{CompanyAddress}}</p>{{/CompanyAddress}}
+                                        {{#ShowCompanyAddress}}{{#CompanyAddress}}<p style="margin: 5px 0 0 0; font-size: 12px; color: #666666; line-height: 1.5;">{{CompanyAddress}}</p>{{/CompanyAddress}}{{/ShowCompanyAddress}}
                                         {{#ShowCompanyCity}}{{#CompanyCity}}<p style="margin: 2px 0 0 0; font-size: 12px; color: #666666;">{{CompanyCity}}{{#ShowCompanyCountry}}{{#CompanyCountry}}, {{CompanyCountry}}{{/CompanyCountry}}{{/ShowCompanyCountry}}</p>{{/CompanyCity}}{{/ShowCompanyCity}}
                                         {{^ShowCompanyCity}}{{#ShowCompanyCountry}}{{#CompanyCountry}}<p style="margin: 2px 0 0 0; font-size: 12px; color: #666666;">{{CompanyCountry}}</p>{{/CompanyCountry}}{{/ShowCompanyCountry}}{{/ShowCompanyCity}}
                                         {{#CompanyEmail}}<p style="margin: 2px 0 0 0; font-size: 12px; color: #666666;">{{CompanyEmail}}</p>{{/CompanyEmail}}
                                         {{#ShowCompanyPhone}}{{#CompanyPhone}}<p style="margin: 2px 0 0 0; font-size: 12px; color: #666666;">{{CompanyPhone}}</p>{{/CompanyPhone}}{{/ShowCompanyPhone}}
-                                        {{/ShowCompanyAddress}}
                                     </td>
                                     <td style="width: 40%; text-align: right; vertical-align: top;">
                                         <p style="margin: 0; font-size: 28px; font-weight: bold; color: {{PrimaryColor}};">{{HeaderText}}</p>
@@ -546,18 +583,16 @@ public static class InvoiceHtmlTemplates
                                 <tr>
                                     <td style="width: 60%; vertical-align: top;">
                                         {{#ShowLogo}}
-                                        <img src="{{LogoSrc}}" alt="Company Logo" width="{{LogoWidth}}" style="display: block; max-height: 55px; margin-bottom: 15px;">
+                                        <img src="{{LogoSrc}}" alt="Company Logo" width="{{LogoWidth}}" style="display: block; {{#LockAspectRatio}}height: auto;{{/LockAspectRatio}}{{^LockAspectRatio}}max-height: 55px;{{/LockAspectRatio}} margin-bottom: 15px;">
                                         {{/ShowLogo}}
                                         {{^ShowLogo}}
                                         <p style="margin: 0 0 15px 0; font-size: 20px; font-weight: 600; color: {{TextColor}}; letter-spacing: -0.5px;">{{CompanyName}}</p>
                                         {{/ShowLogo}}
-                                        {{#ShowCompanyAddress}}
-                                        {{#CompanyAddress}}<p style="margin: 0 0 3px 0; font-size: 13px; color: #6b7280; line-height: 1.5;">{{CompanyAddress}}</p>{{/CompanyAddress}}
+                                        {{#ShowCompanyAddress}}{{#CompanyAddress}}<p style="margin: 0 0 3px 0; font-size: 13px; color: #6b7280; line-height: 1.5;">{{CompanyAddress}}</p>{{/CompanyAddress}}{{/ShowCompanyAddress}}
                                         {{#ShowCompanyCity}}{{#CompanyCity}}<p style="margin: 0 0 3px 0; font-size: 13px; color: #6b7280;">{{CompanyCity}}{{#ShowCompanyCountry}}{{#CompanyCountry}}, {{CompanyCountry}}{{/CompanyCountry}}{{/ShowCompanyCountry}}</p>{{/CompanyCity}}{{/ShowCompanyCity}}
                                         {{^ShowCompanyCity}}{{#ShowCompanyCountry}}{{#CompanyCountry}}<p style="margin: 0 0 3px 0; font-size: 13px; color: #6b7280;">{{CompanyCountry}}</p>{{/CompanyCountry}}{{/ShowCompanyCountry}}{{/ShowCompanyCity}}
                                         {{#CompanyEmail}}<p style="margin: 0 0 3px 0; font-size: 13px; color: #6b7280;">{{CompanyEmail}}</p>{{/CompanyEmail}}
                                         {{#ShowCompanyPhone}}{{#CompanyPhone}}<p style="margin: 0; font-size: 13px; color: #6b7280;">{{CompanyPhone}}</p>{{/CompanyPhone}}{{/ShowCompanyPhone}}
-                                        {{/ShowCompanyAddress}}
                                     </td>
                                     <td style="width: 40%; text-align: right; vertical-align: top;">
                                         <p style="margin: 0 0 8px 0; font-size: 11px; text-transform: uppercase; letter-spacing: 2px; color: {{PrimaryColor}}; font-weight: 600;">{{HeaderText}}</p>
@@ -697,11 +732,9 @@ public static class InvoiceHtmlTemplates
                     <tr>
                         <td style="padding: 25px 40px; background-color: {{SecondaryColor}}; text-align: center; border-radius: 0 0 4px 4px;">
                             <p style="margin: 0; font-size: 13px; color: #6b7280;">{{FooterText}}</p>
-                            {{#ShowCompanyAddress}}
                             <p style="margin: 8px 0 0 0; font-size: 12px; color: #9ca3af;">
-                                {{CompanyName}}{{#CompanyEmail}} • {{CompanyEmail}}{{/CompanyEmail}}{{#ShowCompanyPhone}}{{#CompanyPhone}} • {{CompanyPhone}}{{/CompanyPhone}}{{/ShowCompanyPhone}}
+                                {{CompanyName}}{{#ShowCompanyAddress}}{{#CompanyAddress}} • {{CompanyAddress}}{{/CompanyAddress}}{{/ShowCompanyAddress}}{{#ShowCompanyCity}}{{#CompanyCity}} • {{CompanyCity}}{{/CompanyCity}}{{/ShowCompanyCity}}{{#ShowCompanyCountry}}{{#CompanyCountry}} • {{CompanyCountry}}{{/CompanyCountry}}{{/ShowCompanyCountry}}{{#CompanyEmail}} • {{CompanyEmail}}{{/CompanyEmail}}{{#ShowCompanyPhone}}{{#CompanyPhone}} • {{CompanyPhone}}{{/CompanyPhone}}{{/ShowCompanyPhone}}
                             </p>
-                            {{/ShowCompanyAddress}}
                         </td>
                     </tr>
                 </table>

--- a/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceTemplateFactory.cs
+++ b/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceTemplateFactory.cs
@@ -70,7 +70,7 @@ public static class InvoiceTemplateFactory
             HeaderText = "Invoice",
             FooterText = "Thank you for your business.",
             ShowLogo = true,
-            ShowCompanyAddress = false,
+            ShowCompanyAddress = true,
             ShowTaxBreakdown = true,
             ShowItemDescriptions = true,
             ShowNotes = true,

--- a/ArgoBooks/Controls/ModalOverlay.axaml
+++ b/ArgoBooks/Controls/ModalOverlay.axaml
@@ -17,10 +17,10 @@
                     VerticalAlignment="Stretch"
                     PointerPressed="OnBackdropPointerPressed" />
 
-            <!-- Modal content container - centered, sizes to content -->
+            <!-- Modal content container - stretches to fill, content controls its own alignment -->
             <ContentPresenter x:Name="ModalContentPresenter"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center" />
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch" />
         </Panel>
     </Panel>
 </UserControl>

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
@@ -15,13 +15,45 @@
         <vm:InvoiceTemplateDesignerViewModel />
     </Design.DataContext>
 
+    <UserControl.Resources>
+        <local:EqualConverter x:Key="EqualConverter" />
+    </UserControl.Resources>
+
+    <UserControl.Styles>
+        <Style Selector="Button.property-tab-button">
+            <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="8,6" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Margin" Value="1" />
+        </Style>
+        <Style Selector="Button.property-tab-button /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+        </Style>
+        <Style Selector="Button.property-tab-button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+        </Style>
+        <Style Selector="Button.property-tab-button.selected">
+            <Setter Property="Background" Value="{DynamicResource PrimaryBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style Selector="Button.property-tab-button.selected /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource PrimaryBrush}" />
+        </Style>
+    </UserControl.Styles>
+
     <Panel>
         <controls:ModalOverlay IsOpen="{Binding IsOpen}">
             <controls:ModalOverlay.ModalContent>
-                <Border Width="{Binding IsFullscreen, Converter={x:Static local:BoolConverters.ToFullscreenWidth}, ConverterParameter=1000}"
+                <Border Width="{Binding IsFullscreen, Converter={x:Static local:BoolConverters.ToFullscreenWidth}, ConverterParameter='1000,1100'}"
                         Height="{Binding IsFullscreen, Converter={x:Static local:BoolConverters.ToFullscreenHeight}, ConverterParameter=750}"
-                        MinWidth="1000"
-                        MaxWidth="1300"
+                        MaxWidth="{Binding IsFullscreen, Converter={x:Static local:BoolConverters.ToFullscreenMaxWidth}, ConverterParameter=1300}"
                         Margin="{Binding IsFullscreen, Converter={x:Static local:BoolConverters.ToFullscreenMargin}}"
                         HorizontalAlignment="{Binding IsFullscreen, Converter={x:Static local:BoolConverters.ToFullscreenHorizontalAlignment}}"
                         VerticalAlignment="{Binding IsFullscreen, Converter={x:Static local:BoolConverters.ToFullscreenVerticalAlignment}}"
@@ -60,9 +92,9 @@
                             <Border Grid.Column="0"
                                     BorderBrush="{DynamicResource BorderBrush}"
                                     BorderThickness="0,0,1,0">
-                                <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              HorizontalScrollBarVisibility="Disabled">
-                                    <StackPanel Margin="20" Spacing="16">
+                                <Grid RowDefinitions="Auto,*">
+                                    <!-- Fixed Header: Template Name, Base Template, Default -->
+                                    <StackPanel Grid.Row="0" Margin="20,20,20,0" Spacing="16">
                                         <!-- Template Name -->
                                         <StackPanel Spacing="6">
                                             <TextBlock Text="{loc:Loc 'Template Name'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
@@ -89,153 +121,186 @@
                                         <CheckBox IsChecked="{Binding IsDefault}"
                                                   Content="{loc:Loc 'Set as default template'}" />
 
-                                        <Border Height="1" Background="{DynamicResource BorderBrush}" />
+                                        <Border Height="1" Background="{DynamicResource BorderBrush}" Margin="0,4,0,0" />
 
-                                        <!-- Colors Section -->
-                                        <StackPanel Spacing="10">
-                                            <TextBlock Text="{loc:Loc Colors}" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
-
-                                            <!-- Primary Color -->
-                                            <Grid ColumnDefinitions="*,150">
-                                                <TextBlock Grid.Column="0" Text="{loc:Loc 'Primary Color'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
-                                                <controls:ColorPickerInput Grid.Column="1" ColorValue="{Binding PrimaryColor, Mode=TwoWay}" />
-                                            </Grid>
-
-                                            <!-- Secondary Color -->
-                                            <Grid ColumnDefinitions="*,150">
-                                                <TextBlock Grid.Column="0" Text="{loc:Loc 'Secondary Color'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
-                                                <controls:ColorPickerInput Grid.Column="1" ColorValue="{Binding SecondaryColor, Mode=TwoWay}" />
-                                            </Grid>
-
-                                            <!-- Accent Color -->
-                                            <Grid ColumnDefinitions="*,150">
-                                                <TextBlock Grid.Column="0" Text="{loc:Loc 'Accent Color'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
-                                                <controls:ColorPickerInput Grid.Column="1" ColorValue="{Binding AccentColor, Mode=TwoWay}" />
-                                            </Grid>
-
-                                            <!-- Text Color -->
-                                            <Grid ColumnDefinitions="*,150">
-                                                <TextBlock Grid.Column="0" Text="{loc:Loc 'Text Color'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
-                                                <controls:ColorPickerInput Grid.Column="1" ColorValue="{Binding TextColor, Mode=TwoWay}" />
-                                            </Grid>
-                                        </StackPanel>
-
-                                        <Border Height="1" Background="{DynamicResource BorderBrush}" />
-
-                                        <!-- Logo Section -->
-                                        <StackPanel Spacing="10">
-                                            <TextBlock Text="{loc:Loc Logo}" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
-
-                                            <CheckBox IsChecked="{Binding ShowLogo}"
-                                                      Content="{loc:Loc 'Show logo on invoice'}" />
-
-                                            <StackPanel Spacing="4">
-                                                <TextBlock Text="{loc:Loc 'Image Path'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                                <Grid ColumnDefinitions="*,Auto">
-                                                    <TextBox Grid.Column="0"
-                                                             Text="{Binding LogoPath}"
-                                                             Watermark="{loc:Loc 'Path to logo image...'}"
-                                                             IsReadOnly="True"
-                                                             TextWrapping="NoWrap" />
-                                                    <Button Grid.Column="1"
-                                                            Margin="4,0,0,0"
-                                                            Padding="8,6"
-                                                            Command="{Binding SelectLogoCommand}"
-                                                            ToolTip.Tip="{loc:Loc 'Browse...'}">
-                                                        <PathIcon Data="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"
-                                                                  Width="14" Height="14"
-                                                                  Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                    </Button>
-                                                </Grid>
-                                            </StackPanel>
-
-                                            <!-- Remove Button -->
-                                            <Button Classes="secondary-button danger"
-                                                    Content="{loc:Loc 'Remove Logo'}"
-                                                    Command="{Binding RemoveLogoCommand}"
-                                                    IsVisible="{Binding HasLogo}"
-                                                    HorizontalAlignment="Left" />
-
-                                            <StackPanel Spacing="4" IsVisible="{Binding ShowLogo}">
-                                                <Grid ColumnDefinitions="*,80">
-                                                    <TextBlock Grid.Column="0" Text="{loc:Loc 'Logo Width (px)'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
-                                                    <NumericUpDown Grid.Column="1"
-                                                                   Value="{Binding LogoWidth}"
-                                                                   Minimum="50"
-                                                                   Maximum="300"
-                                                                   FormatString="0"
-                                                                   ShowButtonSpinner="False"
-                                                                   Classes="form-input" />
-                                                </Grid>
-                                                <TextBlock Text="{loc:Loc 'Range: 50-300 px'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                            </StackPanel>
-                                        </StackPanel>
-
-                                        <Border Height="1" Background="{DynamicResource BorderBrush}" />
-
-                                        <!-- Text Content Section -->
-                                        <StackPanel Spacing="10">
-                                            <TextBlock Text="{loc:Loc 'Text Content'}" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
-
-                                            <StackPanel Spacing="4">
-                                                <TextBlock Text="{loc:Loc 'Header Text'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                <TextBox Text="{Binding HeaderText, Mode=TwoWay}" Classes="form-input" />
-                                            </StackPanel>
-
-                                            <StackPanel Spacing="4">
-                                                <TextBlock Text="{loc:Loc 'Footer Text'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                <TextBox Text="{Binding FooterText, Mode=TwoWay}" Classes="form-input" />
-                                            </StackPanel>
-
-                                            <StackPanel Spacing="4">
-                                                <TextBlock Text="{loc:Loc 'Payment Instructions'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                <TextBox Text="{Binding PaymentInstructions, Mode=TwoWay}"
-                                                         Classes="form-input"
-                                                         AcceptsReturn="True"
-                                                         TextWrapping="Wrap"
-                                                         MinHeight="60"
-                                                         Watermark="{loc:Loc 'Bank details, payment methods, etc.'}" />
-                                            </StackPanel>
-                                        </StackPanel>
-
-                                        <Border Height="1" Background="{DynamicResource BorderBrush}" />
-
-                                        <!-- Display Options Section -->
-                                        <StackPanel Spacing="8">
-                                            <TextBlock Text="{loc:Loc 'Display Options'}" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
-
-                                            <CheckBox IsChecked="{Binding ShowCompanyAddress}"
-                                                      Content="{loc:Loc 'Show company address'}" />
-                                            <CheckBox IsChecked="{Binding ShowCompanyPhone}"
-                                                      Content="{loc:Loc 'Show company phone'}" />
-                                            <CheckBox IsChecked="{Binding ShowCompanyCity}"
-                                                      Content="{loc:Loc 'Show company city'}" />
-                                            <CheckBox IsChecked="{Binding ShowCompanyCountry}"
-                                                      Content="{loc:Loc 'Show company country'}" />
-                                            <CheckBox IsChecked="{Binding ShowTaxBreakdown}"
-                                                      Content="{loc:Loc 'Show tax breakdown'}" />
-                                            <CheckBox IsChecked="{Binding ShowItemDescriptions}"
-                                                      Content="{loc:Loc 'Show item descriptions'}" />
-                                            <CheckBox IsChecked="{Binding ShowNotes}"
-                                                      Content="{loc:Loc 'Show notes section'}" />
-                                            <CheckBox IsChecked="{Binding ShowPaymentInstructions}"
-                                                      Content="{loc:Loc 'Show payment instructions'}" />
-                                            <CheckBox IsChecked="{Binding ShowDueDateProminent}"
-                                                      Content="{loc:Loc 'Highlight due date'}" />
-                                        </StackPanel>
-
-                                        <Border Height="1" Background="{DynamicResource BorderBrush}" />
-
-                                        <!-- Font -->
-                                        <StackPanel Spacing="6">
-                                            <TextBlock Text="{loc:Loc 'Font Family'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                            <ComboBox ItemsSource="{Binding FontFamilyOptions}"
-                                                      SelectedItem="{Binding SelectedFontFamily}"
-                                                      Classes="form-combobox"
-                                                      HorizontalAlignment="Stretch" />
-                                        </StackPanel>
+                                        <!-- Tab Buttons -->
+                                        <Grid ColumnDefinitions="*,*,*,*">
+                                            <Button Grid.Column="0"
+                                                    Content="{loc:Loc 'Colors'}"
+                                                    Classes="property-tab-button"
+                                                    Classes.selected="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=0}"
+                                                    Command="{Binding SetPropertiesTabCommand}"
+                                                    CommandParameter="0" />
+                                            <Button Grid.Column="1"
+                                                    Content="{loc:Loc 'Logo'}"
+                                                    Classes="property-tab-button"
+                                                    Classes.selected="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=1}"
+                                                    Command="{Binding SetPropertiesTabCommand}"
+                                                    CommandParameter="1" />
+                                            <Button Grid.Column="2"
+                                                    Content="{loc:Loc 'Text'}"
+                                                    Classes="property-tab-button"
+                                                    Classes.selected="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=2}"
+                                                    Command="{Binding SetPropertiesTabCommand}"
+                                                    CommandParameter="2" />
+                                            <Button Grid.Column="3"
+                                                    Content="{loc:Loc 'Display'}"
+                                                    Classes="property-tab-button"
+                                                    Classes.selected="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=3}"
+                                                    Command="{Binding SetPropertiesTabCommand}"
+                                                    CommandParameter="3" />
+                                        </Grid>
                                     </StackPanel>
-                                </ScrollViewer>
+
+                                    <!-- Scrollable Tab Content -->
+                                    <ScrollViewer Grid.Row="1"
+                                                  VerticalScrollBarVisibility="Auto"
+                                                  HorizontalScrollBarVisibility="Disabled"
+                                                  Margin="0,12,0,0">
+                                        <StackPanel Margin="20,0,20,20">
+                                            <!-- Colors Tab (Index 0) -->
+                                            <StackPanel Spacing="10" IsVisible="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=0}">
+                                                <!-- Primary Color -->
+                                                <Grid ColumnDefinitions="*,150">
+                                                    <TextBlock Grid.Column="0" Text="{loc:Loc 'Primary Color'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
+                                                    <controls:ColorPickerInput Grid.Column="1" ColorValue="{Binding PrimaryColor, Mode=TwoWay}" />
+                                                </Grid>
+
+                                                <!-- Secondary Color -->
+                                                <Grid ColumnDefinitions="*,150">
+                                                    <TextBlock Grid.Column="0" Text="{loc:Loc 'Secondary Color'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
+                                                    <controls:ColorPickerInput Grid.Column="1" ColorValue="{Binding SecondaryColor, Mode=TwoWay}" />
+                                                </Grid>
+
+                                                <!-- Text Color -->
+                                                <Grid ColumnDefinitions="*,150">
+                                                    <TextBlock Grid.Column="0" Text="{loc:Loc 'Text Color'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
+                                                    <controls:ColorPickerInput Grid.Column="1" ColorValue="{Binding TextColor, Mode=TwoWay}" />
+                                                </Grid>
+                                            </StackPanel>
+
+                                            <!-- Logo Tab (Index 1) -->
+                                            <StackPanel Spacing="10" IsVisible="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=1}">
+                                                <CheckBox IsChecked="{Binding ShowLogo}"
+                                                          Content="{loc:Loc 'Show logo on invoice'}" />
+
+                                                <!-- No logo selected state -->
+                                                <Button Classes="secondary-button"
+                                                        Command="{Binding SelectLogoCommand}"
+                                                        IsVisible="{Binding !HasLogo}"
+                                                        HorizontalAlignment="Stretch"
+                                                        HorizontalContentAlignment="Center"
+                                                        Padding="12,10">
+                                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                                        <PathIcon Data="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"
+                                                                  Width="16" Height="16" />
+                                                        <TextBlock Text="{loc:Loc 'Select Logo...'}" />
+                                                    </StackPanel>
+                                                </Button>
+
+                                                <!-- Logo selected state -->
+                                                <StackPanel Spacing="8" IsVisible="{Binding HasLogo}">
+                                                    <Grid ColumnDefinitions="Auto,*">
+                                                        <PathIcon Grid.Column="0"
+                                                                  Data="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"
+                                                                  Width="16" Height="16"
+                                                                  Foreground="{DynamicResource TextSecondaryBrush}"
+                                                                  VerticalAlignment="Center"
+                                                                  Margin="0,0,8,0" />
+                                                        <TextBlock Grid.Column="1"
+                                                                   Text="{Binding LogoFileName}"
+                                                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                                                   TextTrimming="CharacterEllipsis"
+                                                                   VerticalAlignment="Center"
+                                                                   ToolTip.Tip="{Binding LogoPath}" />
+                                                    </Grid>
+                                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                                        <Button Classes="secondary-button"
+                                                                Content="{loc:Loc 'Change'}"
+                                                                Command="{Binding SelectLogoCommand}"
+                                                                Padding="12,6" />
+                                                        <Button Classes="secondary-button danger"
+                                                                Content="{loc:Loc 'Remove'}"
+                                                                Command="{Binding RemoveLogoCommand}"
+                                                                Padding="12,6" />
+                                                    </StackPanel>
+                                                </StackPanel>
+
+                                                <StackPanel Spacing="4" IsVisible="{Binding ShowLogo}">
+                                                    <Grid ColumnDefinitions="*,80">
+                                                        <TextBlock Grid.Column="0" Text="{loc:Loc 'Logo Width (px)'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" VerticalAlignment="Center" />
+                                                        <TextBox Grid.Column="1"
+                                                                 Text="{Binding LogoWidthText, Mode=TwoWay}"
+                                                                 Classes="form-input"
+                                                                 HorizontalContentAlignment="Center" />
+                                                    </Grid>
+                                                    <TextBlock Text="{loc:Loc 'Range: 20-300 px'}"
+                                                               FontSize="11"
+                                                               Foreground="{DynamicResource TextTertiaryBrush}"
+                                                               IsVisible="{Binding !HasLogoWidthWarning}" />
+                                                    <TextBlock Text="{Binding LogoWidthWarning}"
+                                                               FontSize="11"
+                                                               Foreground="#DC2626"
+                                                               IsVisible="{Binding HasLogoWidthWarning}" />
+                                                    <CheckBox IsChecked="{Binding LockAspectRatio}"
+                                                              Content="{loc:Loc 'Lock aspect ratio'}"
+                                                              Margin="0,4,0,0" />
+                                                </StackPanel>
+                                            </StackPanel>
+
+                                            <!-- Text Tab (Index 2) -->
+                                            <StackPanel Spacing="10" IsVisible="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=2}">
+                                                <StackPanel Spacing="4">
+                                                    <TextBlock Text="{loc:Loc 'Header Text'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                    <TextBox Text="{Binding HeaderText, Mode=TwoWay}" Classes="form-input" />
+                                                </StackPanel>
+
+                                                <StackPanel Spacing="4">
+                                                    <TextBlock Text="{loc:Loc 'Footer Text'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                    <TextBox Text="{Binding FooterText, Mode=TwoWay}" Classes="form-input" />
+                                                </StackPanel>
+
+                                                <StackPanel Spacing="4">
+                                                    <TextBlock Text="{loc:Loc 'Payment Instructions'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                    <TextBox Text="{Binding PaymentInstructions, Mode=TwoWay}"
+                                                             Classes="form-input"
+                                                             AcceptsReturn="True"
+                                                             TextWrapping="Wrap"
+                                                             MinHeight="60"
+                                                             Watermark="{loc:Loc 'Bank details, payment methods, etc.'}" />
+                                                </StackPanel>
+
+                                                <Border Height="1" Background="{DynamicResource BorderBrush}" Margin="0,6" />
+
+                                                <StackPanel Spacing="6">
+                                                    <TextBlock Text="{loc:Loc 'Font Family'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                    <ComboBox ItemsSource="{Binding FontFamilyOptions}"
+                                                              SelectedItem="{Binding SelectedFontFamily}"
+                                                              Classes="form-combobox"
+                                                              HorizontalAlignment="Stretch" />
+                                                </StackPanel>
+                                            </StackPanel>
+
+                                            <!-- Display Options Tab (Index 3) -->
+                                            <StackPanel Spacing="8" IsVisible="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=3}">
+                                                <CheckBox IsChecked="{Binding ShowCompanyAddress}"
+                                                          Content="{loc:Loc 'Show company address'}" />
+                                                <CheckBox IsChecked="{Binding ShowCompanyPhone}"
+                                                          Content="{loc:Loc 'Show company phone'}" />
+                                                <CheckBox IsChecked="{Binding ShowCompanyCity}"
+                                                          Content="{loc:Loc 'Show company city'}" />
+                                                <CheckBox IsChecked="{Binding ShowCompanyCountry}"
+                                                          Content="{loc:Loc 'Show company country'}" />
+                                                <CheckBox IsChecked="{Binding ShowTaxBreakdown}"
+                                                          Content="{loc:Loc 'Show tax breakdown'}" />
+                                                <CheckBox IsChecked="{Binding ShowNotes}"
+                                                          Content="{loc:Loc 'Show notes section'}" />
+                                                <CheckBox IsChecked="{Binding ShowPaymentInstructions}"
+                                                          Content="{loc:Loc 'Show payment instructions'}" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </ScrollViewer>
+                                </Grid>
                             </Border>
 
                             <!-- Right Panel: Preview -->

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -414,6 +414,8 @@ public partial class ReportsPageViewModel : ViewModelBase
         OnPropertyChanged(nameof(SelectedChartStyleOption));
         OnPropertyChanged(nameof(SelectedLabelElement));
         OnPropertyChanged(nameof(SelectedImageElement));
+        OnPropertyChanged(nameof(SelectedImageFileName));
+        OnPropertyChanged(nameof(HasSelectedImage));
         OnPropertyChanged(nameof(SelectedTableElement));
         OnPropertyChanged(nameof(SelectedDateRangeElement));
         OnPropertyChanged(nameof(SelectedSummaryElement));
@@ -458,6 +460,10 @@ public partial class ReportsPageViewModel : ViewModelBase
     public ChartReportElement? SelectedChartElement => SelectedElement as ChartReportElement;
     public LabelReportElement? SelectedLabelElement => SelectedElement as LabelReportElement;
     public ImageReportElement? SelectedImageElement => SelectedElement as ImageReportElement;
+    public string SelectedImageFileName => string.IsNullOrEmpty(SelectedImageElement?.ImagePath)
+        ? string.Empty
+        : Path.GetFileName(SelectedImageElement.ImagePath);
+    public bool HasSelectedImage => !string.IsNullOrEmpty(SelectedImageElement?.ImagePath);
     public TableReportElement? SelectedTableElement => SelectedElement as TableReportElement;
     public DateRangeReportElement? SelectedDateRangeElement => SelectedElement as DateRangeReportElement;
     public SummaryReportElement? SelectedSummaryElement => SelectedElement as SummaryReportElement;
@@ -1035,6 +1041,8 @@ public partial class ReportsPageViewModel : ViewModelBase
             {
                 SelectedImageElement.ImagePath = result[0].Path.LocalPath;
                 OnPropertyChanged(nameof(SelectedImageElement));
+                OnPropertyChanged(nameof(SelectedImageFileName));
+                OnPropertyChanged(nameof(HasSelectedImage));
                 OnPropertyChanged(nameof(Configuration));
             }
         }
@@ -1046,6 +1054,8 @@ public partial class ReportsPageViewModel : ViewModelBase
         if (SelectedImageElement == null) return;
         SelectedImageElement.ImagePath = string.Empty;
         OnPropertyChanged(nameof(SelectedImageElement));
+        OnPropertyChanged(nameof(SelectedImageFileName));
+        OnPropertyChanged(nameof(HasSelectedImage));
         OnPropertyChanged(nameof(Configuration));
     }
 

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -1044,22 +1044,48 @@
                                            FontSize="12"
                                            FontWeight="Medium"
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <StackPanel Spacing="4">
-                                    <TextBlock Text="{loc:Loc 'Image Path'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <Grid ColumnDefinitions="*,Auto" MaxWidth="220">
-                                        <TextBox Grid.Column="0" Text="{Binding SelectedImageElement.ImagePath}" Watermark="{loc:Loc 'Path to image...'}" IsReadOnly="True" TextWrapping="NoWrap" />
-                                        <Button Grid.Column="1" Margin="4,0,0,0" Padding="8,6" Command="{Binding BrowseImagePathCommand}" ToolTip.Tip="{loc:Loc 'Browse...'}">
-                                            <PathIcon Data="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"
-                                                      Width="14" Height="14"
-                                                      Foreground="{DynamicResource TextSecondaryBrush}" />
-                                        </Button>
+
+                                <!-- No image selected state -->
+                                <Button Classes="secondary-button"
+                                        Command="{Binding BrowseImagePathCommand}"
+                                        IsVisible="{Binding !HasSelectedImage}"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Center"
+                                        Padding="12,10">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <PathIcon Data="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"
+                                                  Width="16" Height="16" />
+                                        <TextBlock Text="{loc:Loc 'Select Image...'}" />
+                                    </StackPanel>
+                                </Button>
+
+                                <!-- Image selected state -->
+                                <StackPanel Spacing="8" IsVisible="{Binding HasSelectedImage}">
+                                    <Grid ColumnDefinitions="Auto,*">
+                                        <PathIcon Grid.Column="0"
+                                                  Data="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"
+                                                  Width="16" Height="16"
+                                                  Foreground="{DynamicResource TextSecondaryBrush}"
+                                                  VerticalAlignment="Center"
+                                                  Margin="0,0,8,0" />
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding SelectedImageFileName}"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   VerticalAlignment="Center"
+                                                   ToolTip.Tip="{Binding SelectedImageElement.ImagePath}" />
                                     </Grid>
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <Button Classes="secondary-button"
+                                                Content="{loc:Loc 'Change'}"
+                                                Command="{Binding BrowseImagePathCommand}"
+                                                Padding="12,6" />
+                                        <Button Classes="secondary-button danger"
+                                                Content="{loc:Loc 'Remove'}"
+                                                Command="{Binding RemoveImageCommand}"
+                                                Padding="12,6" />
+                                    </StackPanel>
                                 </StackPanel>
-                                <Button Classes="secondary-button danger"
-                                        Content="{loc:Loc 'Remove Image'}"
-                                        Command="{Binding RemoveImageCommand}"
-                                        IsVisible="{Binding SelectedImageElement.ImagePath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                        HorizontalAlignment="Left" />
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Scale Mode'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding ImageScaleModes}"


### PR DESCRIPTION
- Redesign logo/image selection UI in templates and reports
- Fix lock aspect ratio checkbox not resetting width
- Fix aspect ratio toggle, validation warnings, and image path display
- Fix logo width input and make aspect ratio checkbox functional
- Fix logo aspect ratio preservation and default lock to checked
- Improve invoice template modal and fix company address visibility
- Adjust fullscreen mode to only fill height, with slightly wider fixed width
- Improve invoice template modal with Bold design and fullscreen fixes