### PR TITLE
Add backdrop close confirmation to modals and filter improvements

### DIFF
--- a/ArgoBooks/Modals/CategoryModals.axaml
+++ b/ArgoBooks/Modals/CategoryModals.axaml
@@ -12,7 +12,8 @@
 
     <Panel>
         <!-- Add Category Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -87,7 +88,8 @@
         </controls:ModalOverlay>
 
         <!-- Edit Category Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"

--- a/ArgoBooks/Modals/CustomerModals.axaml
+++ b/ArgoBooks/Modals/CustomerModals.axaml
@@ -19,7 +19,8 @@
     <!-- All modals in one UserControl for full-screen coverage -->
     <Panel>
         <!-- Add Customer Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -165,7 +166,8 @@
         </controls:ModalOverlay>
 
         <!-- Edit Customer Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -293,7 +295,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -478,7 +481,8 @@
         </controls:ModalOverlay>
 
         <!-- History Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsHistoryFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsHistoryFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseHistoryFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"

--- a/ArgoBooks/Modals/DepartmentModals.axaml
+++ b/ArgoBooks/Modals/DepartmentModals.axaml
@@ -8,7 +8,8 @@
              x:DataType="vm:DepartmentModalsViewModel">
     <Panel>
         <!-- Add Department Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -48,7 +49,8 @@
         </controls:ModalOverlay>
 
         <!-- Edit Department Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"

--- a/ArgoBooks/Modals/EditCompanyModal.axaml
+++ b/ArgoBooks/Modals/EditCompanyModal.axaml
@@ -10,7 +10,8 @@
              x:Class="ArgoBooks.Modals.EditCompanyModal"
              x:DataType="vm:EditCompanyModalViewModel">
 
-    <controls:ModalOverlay IsOpen="{Binding IsOpen}">
+    <controls:ModalOverlay IsOpen="{Binding IsOpen}"
+                           ClosingCommand="{Binding CloseCommand}">
         <controls:ModalOverlay.ModalContent>
             <!-- Modal -->
             <Border HorizontalAlignment="Center"

--- a/ArgoBooks/Modals/ExpenseModals.axaml
+++ b/ArgoBooks/Modals/ExpenseModals.axaml
@@ -19,7 +19,8 @@
 
     <Panel>
         <!-- ======================= ADD / EDIT EXPENSE MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                     VerticalAlignment="Center"
@@ -358,7 +359,8 @@
         <modals:SaveErrorModal />
 
         <!-- ======================= FILTER MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                     VerticalAlignment="Center"

--- a/ArgoBooks/Modals/InvoiceModals.axaml
+++ b/ArgoBooks/Modals/InvoiceModals.axaml
@@ -18,7 +18,8 @@
 
     <Panel>
         <!-- ======================= CREATE / EDIT INVOICE MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsCreateEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsCreateEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseCreateEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                     VerticalAlignment="Center"
@@ -450,7 +451,8 @@
         </controls:ModalOverlay>
 
         <!-- ======================= FILTER MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                         VerticalAlignment="Center"

--- a/ArgoBooks/Modals/LocationsModals.axaml
+++ b/ArgoBooks/Modals/LocationsModals.axaml
@@ -12,7 +12,8 @@
 
     <Panel>
         <!-- Add Location Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -146,7 +147,8 @@
         </controls:ModalOverlay>
 
         <!-- Edit Location Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -281,7 +283,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"

--- a/ArgoBooks/Modals/LostDamagedModals.axaml
+++ b/ArgoBooks/Modals/LostDamagedModals.axaml
@@ -12,7 +12,8 @@
 
     <Panel>
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                         VerticalAlignment="Center"

--- a/ArgoBooks/Modals/PaymentModals.axaml
+++ b/ArgoBooks/Modals/PaymentModals.axaml
@@ -18,7 +18,8 @@
     <!-- All modals in one UserControl for full-screen coverage -->
     <Panel>
         <!-- Add Payment Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                         BorderBrush="{DynamicResource BorderBrush}"
@@ -143,7 +144,8 @@
         </controls:ModalOverlay>
 
         <!-- Edit Payment Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                         BorderBrush="{DynamicResource BorderBrush}"
@@ -254,7 +256,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                         BorderBrush="{DynamicResource BorderBrush}"

--- a/ArgoBooks/Modals/ProductModals.axaml
+++ b/ArgoBooks/Modals/ProductModals.axaml
@@ -16,7 +16,8 @@
 
     <Panel>
         <!-- Add Product Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -127,7 +128,8 @@
         </controls:ModalOverlay>
 
         <!-- Edit Product Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -238,7 +240,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -268,23 +271,17 @@
                         </StackPanel>
                         <StackPanel Spacing="6">
                             <TextBlock Text="{loc:Loc Category}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <ComboBox ItemsSource="{Binding AvailableCategories}" SelectedItem="{Binding FilterCategory}" Classes="form-combobox" PlaceholderText="{loc:Loc 'All Categories'}">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate DataType="vm:CategoryOption">
-                                        <TextBlock Text="{Binding Name}" />
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
+                            <controls:SearchableDropdown ItemsSource="{Binding AvailableCategories}"
+                                                         SelectedItem="{Binding FilterCategory}"
+                                                         DisplayMemberPath="Name"
+                                                         Placeholder="{loc:Loc 'Search categories...'}" />
                         </StackPanel>
                         <StackPanel Spacing="6">
                             <TextBlock Text="{loc:Loc Supplier}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <ComboBox ItemsSource="{Binding AvailableSuppliers}" SelectedItem="{Binding FilterSupplier}" Classes="form-combobox" PlaceholderText="{loc:Loc 'All Suppliers'}">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate DataType="vm:SupplierOption">
-                                        <TextBlock Text="{Binding Name}" />
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
+                            <controls:SearchableDropdown ItemsSource="{Binding AvailableSuppliers}"
+                                                         SelectedItem="{Binding FilterSupplier}"
+                                                         DisplayMemberPath="Name"
+                                                         Placeholder="{loc:Loc 'Search suppliers...'}" />
                         </StackPanel>
                     </StackPanel>
 

--- a/ArgoBooks/Modals/PurchaseOrdersModals.axaml
+++ b/ArgoBooks/Modals/PurchaseOrdersModals.axaml
@@ -14,7 +14,8 @@
 
     <Panel>
         <!-- Add/Edit Order Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -470,7 +471,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -524,10 +526,9 @@
                                        FontSize="13"
                                        FontWeight="Medium"
                                        Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <ComboBox ItemsSource="{Binding FilterSupplierOptions}"
-                                      SelectedItem="{Binding FilterSupplier}"
-                                      Classes="form-combobox"
-                                      HorizontalAlignment="Stretch" />
+                            <controls:SearchableDropdown ItemsSource="{Binding FilterSupplierOptions}"
+                                                         SelectedItem="{Binding FilterSupplier}"
+                                                         Placeholder="{loc:Loc 'Search suppliers...'}" />
                         </StackPanel>
 
                         <!-- Status -->

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -14,7 +14,8 @@
 
     <Panel>
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                         VerticalAlignment="Center"

--- a/ArgoBooks/Modals/RentalInventoryModals.axaml
+++ b/ArgoBooks/Modals/RentalInventoryModals.axaml
@@ -17,7 +17,8 @@
 
     <Panel>
         <!-- Add Rental Item Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -134,7 +135,8 @@
         </controls:ModalOverlay>
 
         <!-- Edit Rental Item Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -263,7 +265,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"

--- a/ArgoBooks/Modals/RentalRecordsModals.axaml
+++ b/ArgoBooks/Modals/RentalRecordsModals.axaml
@@ -14,7 +14,8 @@
 
     <Panel>
         <!-- Add Record Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -155,7 +156,8 @@
         </controls:ModalOverlay>
 
         <!-- Edit Record Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -296,7 +298,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"

--- a/ArgoBooks/Modals/ReturnsModals.axaml
+++ b/ArgoBooks/Modals/ReturnsModals.axaml
@@ -12,7 +12,8 @@
 
     <Panel>
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                         VerticalAlignment="Center"

--- a/ArgoBooks/Modals/RevenueModals.axaml
+++ b/ArgoBooks/Modals/RevenueModals.axaml
@@ -19,7 +19,8 @@
 
     <Panel>
         <!-- ======================= ADD / EDIT REVENUE MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddEditModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddEditModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddEditModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                     VerticalAlignment="Center"
@@ -374,7 +375,8 @@
         <modals:SaveErrorModal />
 
         <!-- ======================= FILTER MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                         VerticalAlignment="Center"

--- a/ArgoBooks/Modals/SettingsModal.axaml
+++ b/ArgoBooks/Modals/SettingsModal.axaml
@@ -17,7 +17,8 @@
     </Design.DataContext>
 
     <Panel>
-        <controls:ModalOverlay IsOpen="{Binding IsOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsOpen}"
+                               ClosingCommand="{Binding CloseCommand}">
             <controls:ModalOverlay.ModalContent>
                 <!-- Modal Container -->
                 <Border Background="{DynamicResource SurfaceBrush}"

--- a/ArgoBooks/Modals/StockAdjustmentsModals.axaml
+++ b/ArgoBooks/Modals/StockAdjustmentsModals.axaml
@@ -13,7 +13,8 @@
 
     <Panel>
         <!-- Add Adjustment Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -287,7 +288,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     CornerRadius="12"
@@ -339,16 +341,9 @@
                                        FontSize="13"
                                        FontWeight="Medium"
                                        Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <ComboBox ItemsSource="{Binding FilterProducts}"
-                                      SelectedItem="{Binding FilterProduct}"
-                                      Classes="form-combobox"
-                                      HorizontalAlignment="Stretch">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Converter={StaticResource TranslateConverter}}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
+                            <controls:SearchableDropdown ItemsSource="{Binding FilterProducts}"
+                                                         SelectedItem="{Binding FilterProduct}"
+                                                         Placeholder="{loc:Loc 'Search products...'}" />
                         </StackPanel>
 
                         <!-- Adjustment Type -->

--- a/ArgoBooks/Modals/StockLevelsModals.axaml
+++ b/ArgoBooks/Modals/StockLevelsModals.axaml
@@ -13,7 +13,8 @@
 
     <Panel>
         <!-- Adjust Stock Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAdjustStockModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAdjustStockModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAdjustStockModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -134,7 +135,8 @@
         </controls:ModalOverlay>
 
         <!-- Add Item Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsAddItemModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsAddItemModalOpen}"
+                               ClosingCommand="{Binding RequestCloseAddItemModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -254,7 +256,8 @@
         </controls:ModalOverlay>
 
         <!-- Filter Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+        <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                               ClosingCommand="{Binding RequestCloseFilterModalCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     CornerRadius="12"
@@ -288,16 +291,9 @@
                                        FontSize="13"
                                        FontWeight="Medium"
                                        Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <ComboBox ItemsSource="{Binding FilterCategories}"
-                                      SelectedItem="{Binding FilterCategory}"
-                                      Classes="form-combobox"
-                                      HorizontalAlignment="Stretch">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding Converter={StaticResource TranslateConverter}}" />
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
+                            <controls:SearchableDropdown ItemsSource="{Binding FilterCategories}"
+                                                         SelectedItem="{Binding FilterCategory}"
+                                                         Placeholder="{loc:Loc 'Search categories...'}" />
                         </StackPanel>
 
                         <!-- Location -->
@@ -306,16 +302,9 @@
                                        FontSize="13"
                                        FontWeight="Medium"
                                        Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <ComboBox ItemsSource="{Binding FilterLocations}"
-                                      SelectedItem="{Binding FilterLocation}"
-                                      Classes="form-combobox"
-                                      HorizontalAlignment="Stretch">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding Converter={StaticResource TranslateConverter}}" />
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
+                            <controls:SearchableDropdown ItemsSource="{Binding FilterLocations}"
+                                                         SelectedItem="{Binding FilterLocation}"
+                                                         Placeholder="{loc:Loc 'Search locations...'}" />
                         </StackPanel>
 
                         <!-- Stock Status -->

--- a/ArgoBooks/Modals/SupplierModals.axaml
+++ b/ArgoBooks/Modals/SupplierModals.axaml
@@ -8,7 +8,8 @@
              x:DataType="vm:SupplierModalsViewModel">
   <Panel>
        <!-- Add Supplier Modal -->
-       <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}">
+       <controls:ModalOverlay IsOpen="{Binding IsAddModalOpen}"
+                              ClosingCommand="{Binding RequestCloseAddModalCommand}">
            <controls:ModalOverlay.ModalContent>
                <Border Background="{DynamicResource SurfaceBrush}"
                    BorderBrush="{DynamicResource BorderBrush}"
@@ -99,7 +100,8 @@
        </controls:ModalOverlay>
 
        <!-- Edit Supplier Modal -->
-       <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}">
+       <controls:ModalOverlay IsOpen="{Binding IsEditModalOpen}"
+                              ClosingCommand="{Binding RequestCloseEditModalCommand}">
            <controls:ModalOverlay.ModalContent>
                <Border Background="{DynamicResource SurfaceBrush}"
                    BorderBrush="{DynamicResource BorderBrush}"
@@ -190,7 +192,8 @@
        </controls:ModalOverlay>
 
        <!-- Filter Modal -->
-       <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}">
+       <controls:ModalOverlay IsOpen="{Binding IsFilterModalOpen}"
+                              ClosingCommand="{Binding RequestCloseFilterModalCommand}">
            <controls:ModalOverlay.ModalContent>
                <Border Background="{DynamicResource SurfaceBrush}"
                    BorderBrush="{DynamicResource BorderBrush}"
@@ -208,13 +211,9 @@
                    <StackPanel Grid.Row="1" Margin="24" Spacing="20">
                        <StackPanel Spacing="6">
                            <TextBlock Text="{loc:Loc 'Country'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                           <ComboBox ItemsSource="{Binding CountryOptions}" SelectedItem="{Binding FilterCountry}" Classes="form-combobox">
-                               <ComboBox.ItemTemplate>
-                                   <DataTemplate>
-                                       <TextBlock Text="{Binding Converter={StaticResource TranslateConverter}}" />
-                                   </DataTemplate>
-                               </ComboBox.ItemTemplate>
-                           </ComboBox>
+                           <controls:SearchableDropdown ItemsSource="{Binding CountryOptions}"
+                                                        SelectedItem="{Binding FilterCountry}"
+                                                        Placeholder="{loc:Loc 'Search countries...'}" />
                        </StackPanel>
                        <StackPanel Spacing="6">
                            <TextBlock Text="{loc:Loc 'Status'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />

--- a/ArgoBooks/ViewModels/DepartmentModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/DepartmentModalsViewModel.cs
@@ -41,6 +41,24 @@ public partial class DepartmentModalsViewModel : ObservableObject
 
     private Department? _editingDepartment;
 
+    // Original values for change detection in edit mode
+    private string _originalDepartmentName = string.Empty;
+    private string _originalDescription = string.Empty;
+
+    /// <summary>
+    /// Returns true if any data has been entered in the Add modal.
+    /// </summary>
+    public bool HasAddModalEnteredData =>
+        !string.IsNullOrWhiteSpace(ModalDepartmentName) ||
+        !string.IsNullOrWhiteSpace(ModalDescription);
+
+    /// <summary>
+    /// Returns true if any changes have been made in the Edit modal.
+    /// </summary>
+    public bool HasEditModalChanges =>
+        ModalDepartmentName != _originalDepartmentName ||
+        ModalDescription != _originalDescription;
+
     #endregion
 
     #region Events
@@ -65,6 +83,29 @@ public partial class DepartmentModalsViewModel : ObservableObject
     {
         IsAddModalOpen = false;
         ClearModalFields();
+    }
+
+    [RelayCommand]
+    public async Task RequestCloseAddModalAsync()
+    {
+        if (HasAddModalEnteredData)
+        {
+            var dialog = App.ConfirmationDialog;
+            if (dialog != null)
+            {
+                var result = await dialog.ShowAsync(new ConfirmationDialogOptions
+                {
+                    Title = "Discard Changes?".Translate(),
+                    Message = "You have entered data that will be lost. Are you sure you want to close?".Translate(),
+                    PrimaryButtonText = "Discard".Translate(),
+                    CancelButtonText = "Cancel".Translate(),
+                    IsPrimaryDestructive = true
+                });
+                if (result != ConfirmationResult.Primary)
+                    return;
+            }
+        }
+        CloseAddModal();
     }
 
     [RelayCommand]
@@ -114,6 +155,8 @@ public partial class DepartmentModalsViewModel : ObservableObject
         _editingDepartment = department;
         ModalDepartmentName = department.Name;
         ModalDescription = department.Description ?? string.Empty;
+        _originalDepartmentName = ModalDepartmentName;
+        _originalDescription = ModalDescription;
         ModalError = null;
         IsEditModalOpen = true;
     }
@@ -124,6 +167,29 @@ public partial class DepartmentModalsViewModel : ObservableObject
         IsEditModalOpen = false;
         _editingDepartment = null;
         ClearModalFields();
+    }
+
+    [RelayCommand]
+    public async Task RequestCloseEditModalAsync()
+    {
+        if (HasEditModalChanges)
+        {
+            var dialog = App.ConfirmationDialog;
+            if (dialog != null)
+            {
+                var result = await dialog.ShowAsync(new ConfirmationDialogOptions
+                {
+                    Title = "Discard Changes?".Translate(),
+                    Message = "You have unsaved changes that will be lost. Are you sure you want to close?".Translate(),
+                    PrimaryButtonText = "Discard".Translate(),
+                    CancelButtonText = "Cancel".Translate(),
+                    IsPrimaryDestructive = true
+                });
+                if (result != ConfirmationResult.Primary)
+                    return;
+            }
+        }
+        CloseEditModal();
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/StockAdjustmentsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/StockAdjustmentsModalsViewModel.cs
@@ -62,6 +62,16 @@ public partial class StockAdjustmentsModalsViewModel : ViewModelBase
     private bool _hasQuantityError;
 
     /// <summary>
+    /// Returns true if any data has been entered in the Add modal.
+    /// </summary>
+    public bool HasAddModalEnteredData =>
+        SelectedInventoryOption != null ||
+        AdjustmentType != "Add" ||
+        !string.IsNullOrWhiteSpace(AdjustmentQuantity) ||
+        !string.IsNullOrWhiteSpace(AdjustmentReason) ||
+        !string.IsNullOrWhiteSpace(ReferenceNumber);
+
+    /// <summary>
     /// Adjustment type options for dropdown.
     /// </summary>
     public ObservableCollection<string> AdjustmentTypes { get; } = ["Add", "Remove", "Set"];
@@ -161,6 +171,34 @@ public partial class StockAdjustmentsModalsViewModel : ViewModelBase
     {
         IsAddModalOpen = false;
         ClearAddModalFields();
+    }
+
+    /// <summary>
+    /// Requests to close the Add modal, showing confirmation if data was entered.
+    /// </summary>
+    [RelayCommand]
+    public async Task RequestCloseAddModalAsync()
+    {
+        if (HasAddModalEnteredData)
+        {
+            var dialog = App.ConfirmationDialog;
+            if (dialog != null)
+            {
+                var result = await dialog.ShowAsync(new ConfirmationDialogOptions
+                {
+                    Title = "Discard Changes?".Translate(),
+                    Message = "You have entered data that will be lost. Are you sure you want to close?".Translate(),
+                    PrimaryButtonText = "Discard".Translate(),
+                    CancelButtonText = "Cancel".Translate(),
+                    IsPrimaryDestructive = true
+                });
+
+                if (result != ConfirmationResult.Primary)
+                    return;
+            }
+        }
+
+        CloseAddModal();
     }
 
     /// <summary>
@@ -499,15 +537,63 @@ public partial class StockAdjustmentsModalsViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Clears all filters.
+    /// Resets filter values to their defaults.
     /// </summary>
-    [RelayCommand]
-    private void ClearFilters()
+    private void ResetFilterDefaults()
     {
         FilterStartDate = null;
         FilterEndDate = null;
         FilterProduct = "All";
         FilterType = "All";
+    }
+
+    /// <summary>
+    /// Clears all filters.
+    /// </summary>
+    [RelayCommand]
+    private void ClearFilters()
+    {
+        ResetFilterDefaults();
+        CloseFilterModal();
+    }
+
+    /// <summary>
+    /// Returns true if any filter has been changed from default values.
+    /// </summary>
+    public bool HasFilterChanges =>
+        FilterStartDate != null ||
+        FilterEndDate != null ||
+        FilterProduct != "All" ||
+        FilterType != "All";
+
+    /// <summary>
+    /// Requests to close the filter modal, showing confirmation if changes were made.
+    /// </summary>
+    [RelayCommand]
+    public async Task RequestCloseFilterModalAsync()
+    {
+        if (HasFilterChanges)
+        {
+            var dialog = App.ConfirmationDialog;
+            if (dialog != null)
+            {
+                var result = await dialog.ShowAsync(new ConfirmationDialogOptions
+                {
+                    Title = "Discard Changes?".Translate(),
+                    Message = "You have unapplied filter changes. Are you sure you want to close?".Translate(),
+                    PrimaryButtonText = "Discard".Translate(),
+                    CancelButtonText = "Cancel".Translate(),
+                    IsPrimaryDestructive = true
+                });
+
+                if (result != ConfirmationResult.Primary)
+                    return;
+            }
+
+            ResetFilterDefaults();
+        }
+
+        CloseFilterModal();
     }
 
     #endregion


### PR DESCRIPTION
- Add backdrop close confirmation to all data entry modals
- Add backdrop close confirmation to all filter modals
- Refactor filter reset logic to use shared ResetFilterDefaults method
- Fix filter modals to reset values when discarding changes
- Fix filter modals to reset dropdown values to 'All' instead of null
- Fix Suppliers filter modal country input
- Change filter modal dropdowns to SearchableDropdown
- Fix ClearFilters to close modal in StockAdjustments and StockLevels