### PR TITLE
Fix chart accent colors and add MaxLength to TextBox inputs

### DIFF
--- a/ArgoBooks/Controls/ArgoNumericUpDown.axaml
+++ b/ArgoBooks/Controls/ArgoNumericUpDown.axaml
@@ -30,7 +30,8 @@
                      Padding="8,4"
                      VerticalAlignment="Center"
                      VerticalContentAlignment="Center"
-                     behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                     behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                     MaxLength="20" />
 
             <!-- Vertically Stacked Up/Down Buttons -->
             <Grid Grid.Column="1" RowDefinitions="*,*" Width="20">

--- a/ArgoBooks/Controls/ArgoTable/ArgoTable.axaml
+++ b/ArgoBooks/Controls/ArgoTable/ArgoTable.axaml
@@ -61,7 +61,8 @@
                                          Text="{Binding #Root.SearchQuery, Mode=TwoWay}"
                                          Watermark="{Binding #Root.SearchPlaceholder}"
                                          Classes="search-input"
-                                         VerticalAlignment="Center" />
+                                         VerticalAlignment="Center"
+                                         MaxLength="100" />
                                 <Button Grid.Column="2"
                                         Classes="icon-button"
                                         Width="24" Height="24"

--- a/ArgoBooks/Controls/CategoryInput.axaml
+++ b/ArgoBooks/Controls/CategoryInput.axaml
@@ -57,7 +57,8 @@
                          BorderThickness="0"
                          Padding="12,10"
                          FontSize="14"
-                         VerticalAlignment="Center" />
+                         VerticalAlignment="Center"
+                         MaxLength="100" />
 
                 <!-- Dropdown Arrow -->
                 <Button Grid.Column="1"

--- a/ArgoBooks/Controls/ColorPickerInput.axaml
+++ b/ArgoBooks/Controls/ColorPickerInput.axaml
@@ -53,7 +53,8 @@
                  Text="{Binding #Root.ColorValue, Mode=TwoWay}"
                  Watermark="#000000"
                  VerticalAlignment="Center"
-                 Padding="8,6" />
+                 Padding="8,6"
+                 MaxLength="9" />
 
         <!-- Color Picker Popup -->
         <Popup Grid.Column="0"
@@ -88,7 +89,8 @@
                                  Margin="8,0,0,0"
                                  FontFamily="Consolas,Menlo,monospace"
                                  FontSize="13"
-                                 Padding="6,4" />
+                                 Padding="6,4"
+                                 MaxLength="9" />
                     </Grid>
 
                     <!-- Action Buttons Row -->

--- a/ArgoBooks/Controls/CountryInput.axaml
+++ b/ArgoBooks/Controls/CountryInput.axaml
@@ -46,7 +46,8 @@
                          BorderThickness="0"
                          Padding="12,10"
                          FontSize="14"
-                         VerticalAlignment="Center" />
+                         VerticalAlignment="Center"
+                         MaxLength="100" />
 
                 <!-- Dropdown Arrow -->
                 <Button Grid.Column="2"

--- a/ArgoBooks/Controls/Header.axaml
+++ b/ArgoBooks/Controls/Header.axaml
@@ -50,7 +50,8 @@
                              Classes="header-search"
                              GotFocus="SearchInput_GotFocus"
                              KeyDown="SearchInput_KeyDown"
-                             VerticalAlignment="Center" />
+                             VerticalAlignment="Center"
+                             MaxLength="100" />
 
                     <!-- Keyboard Shortcut Hint -->
                     <Border Grid.Column="2"

--- a/ArgoBooks/Controls/PhoneInput.axaml
+++ b/ArgoBooks/Controls/PhoneInput.axaml
@@ -40,7 +40,8 @@
                          Padding="8,8"
                          FontSize="14"
                          MinWidth="50"
-                         VerticalAlignment="Center" />
+                         VerticalAlignment="Center"
+                         MaxLength="10" />
 
                 <!-- Dropdown Arrow -->
                 <Button Grid.Column="1"
@@ -157,6 +158,7 @@
                  BorderThickness="1"
                  CornerRadius="6"
                  Padding="12,10"
-                 FontSize="14" />
+                 FontSize="14"
+                 MaxLength="20" />
     </Grid>
 </UserControl>

--- a/ArgoBooks/Controls/PieChartLegend.axaml.cs
+++ b/ArgoBooks/Controls/PieChartLegend.axaml.cs
@@ -33,7 +33,7 @@ public class PieLegendItem
     /// <summary>
     /// The hex color string.
     /// </summary>
-    public string ColorHex { get; set; } = "#6495ED";
+    public string ColorHex { get; set; } = "#3B82F6";
 
     /// <summary>
     /// Formatted value display string.

--- a/ArgoBooks/Controls/SearchableDropdown.axaml
+++ b/ArgoBooks/Controls/SearchableDropdown.axaml
@@ -84,7 +84,8 @@
                          Background="Transparent"
                          BorderThickness="0"
                          Padding="8,6"
-                         VerticalAlignment="Center" />
+                         VerticalAlignment="Center"
+                         MaxLength="100" />
 
                 <!-- Dropdown Arrow -->
                 <Button Grid.Column="1"

--- a/ArgoBooks/Modals/CategoryModals.axaml
+++ b/ArgoBooks/Modals/CategoryModals.axaml
@@ -41,14 +41,14 @@
                                 <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                     <Run Text="{loc:Loc 'Category Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                 </TextBlock>
-                                <TextBox Text="{Binding ModalCategoryName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter category name'}" />
+                                <TextBox Text="{Binding ModalCategoryName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter category name'}" MaxLength="100" />
                                 <TextBlock Text="{Binding ModalCategoryNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                            IsVisible="{Binding ModalCategoryNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             </StackPanel>
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Description}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalDescription, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter description'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                             </StackPanel>
                             <Grid ColumnDefinitions="*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6">
@@ -109,14 +109,14 @@
                                 <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                     <Run Text="{loc:Loc 'Category Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                 </TextBlock>
-                                <TextBox Text="{Binding ModalCategoryName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter category name'}" />
+                                <TextBox Text="{Binding ModalCategoryName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter category name'}" MaxLength="100" />
                                 <TextBlock Text="{Binding ModalCategoryNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                            IsVisible="{Binding ModalCategoryNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             </StackPanel>
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Description}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalDescription, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter description'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                             </StackPanel>
                             <Grid ColumnDefinitions="*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6">

--- a/ArgoBooks/Modals/CreateCompanyWizard.axaml
+++ b/ArgoBooks/Modals/CreateCompanyWizard.axaml
@@ -113,7 +113,8 @@
                                 </TextBlock>
                                 <TextBox Text="{Binding CompanyName, Mode=TwoWay}"
                                          Classes="form-input"
-                                         Watermark="{loc:Loc 'Enter company name'}" />
+                                         Watermark="{loc:Loc 'Enter company name'}"
+                                         MaxLength="100" />
                             </StackPanel>
 
                             <!-- Two column layout for other fields -->
@@ -171,7 +172,8 @@
                                                Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Classes="form-input"
                                              Text="{Binding City, Mode=TwoWay}"
-                                             Watermark="{loc:Loc 'Enter city'}" />
+                                             Watermark="{loc:Loc 'Enter city'}"
+                                             MaxLength="100" />
                                 </StackPanel>
 
                                 <!-- Address -->
@@ -185,7 +187,8 @@
                                              Watermark="{loc:Loc 'Enter address'}"
                                              AcceptsReturn="True"
                                              TextWrapping="Wrap"
-                                             MinHeight="60" />
+                                             MinHeight="60"
+                                             MaxLength="200" />
                                 </StackPanel>
                             </Grid>
                         </StackPanel>
@@ -269,7 +272,8 @@
                                             <TextBox Text="{Binding Password, Mode=TwoWay}"
                                                      Classes="form-input"
                                                      PasswordChar="*"
-                                                     Watermark="{loc:Loc 'Enter password'}" />
+                                                     Watermark="{loc:Loc 'Enter password'}"
+                                                     MaxLength="128" />
                                         </StackPanel>
 
                                         <StackPanel Spacing="6">
@@ -280,7 +284,8 @@
                                             <TextBox Text="{Binding ConfirmPassword, Mode=TwoWay}"
                                                      Classes="form-input"
                                                      PasswordChar="*"
-                                                     Watermark="{loc:Loc 'Confirm password'}" />
+                                                     Watermark="{loc:Loc 'Confirm password'}"
+                                                     MaxLength="128" />
                                             <TextBlock Text="{loc:Loc 'Passwords do not match'}"
                                                        FontSize="12"
                                                        Foreground="{DynamicResource DangerBrush}"

--- a/ArgoBooks/Modals/CustomerModals.axaml
+++ b/ArgoBooks/Modals/CustomerModals.axaml
@@ -59,7 +59,7 @@
                             <Grid ColumnDefinitions="Auto,16,*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6" Width="100">
                                     <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'CUS-xxx'}" />
+                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'CUS-xxx'}" MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
@@ -67,7 +67,8 @@
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalFirstName, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter first name'}" />
+                                             Watermark="{loc:Loc 'Enter first name'}"
+                                             MaxLength="50" />
                                     <TextBlock Text="{Binding ModalFirstNameError}"
                                                FontSize="12"
                                                Foreground="{DynamicResource ErrorBrush}"
@@ -79,7 +80,8 @@
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalLastName, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter last name'}" />
+                                             Watermark="{loc:Loc 'Enter last name'}"
+                                             MaxLength="50" />
                                     <TextBlock Text="{Binding ModalLastNameError}"
                                                FontSize="12"
                                                Foreground="{DynamicResource ErrorBrush}"
@@ -90,14 +92,14 @@
                             <!-- Company Name -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Company'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <TextBox Text="{Binding ModalCompanyName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter company name'}" />
+                                <TextBox Text="{Binding ModalCompanyName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter company name'}" MaxLength="100" />
                             </StackPanel>
 
                             <!-- Email and Phone Row -->
                             <Grid ColumnDefinitions="*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Email'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalEmail, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter email address'}" />
+                                    <TextBox Text="{Binding ModalEmail, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter email address'}" MaxLength="254" />
                                     <TextBlock Text="{Binding ModalEmailError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalEmailError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -113,18 +115,18 @@
                             <!-- Street Address -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Street Address'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter street address'}" />
+                                <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter street address'}" MaxLength="200" />
                             </StackPanel>
 
                             <!-- City and State Row -->
                             <Grid ColumnDefinitions="*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'City'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalCity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter city'}" />
+                                    <TextBox Text="{Binding ModalCity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter city'}" MaxLength="100" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'State/Province'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter state'}" />
+                                    <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter state'}" MaxLength="100" />
                                 </StackPanel>
                             </Grid>
 
@@ -132,7 +134,7 @@
                             <Grid ColumnDefinitions="*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Postal Code'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalZipCode, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter postal code'}" />
+                                    <TextBox Text="{Binding ModalZipCode, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter postal code'}" MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Country'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
@@ -144,7 +146,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Notes'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -200,13 +202,13 @@
                             <Grid ColumnDefinitions="Auto,16,*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6" Width="100">
                                     <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" />
+                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                         <Run Text="{loc:Loc 'First Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
-                                    <TextBox Text="{Binding ModalFirstName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter first name'}" />
+                                    <TextBox Text="{Binding ModalFirstName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter first name'}" MaxLength="50" />
                                     <TextBlock Text="{Binding ModalFirstNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalFirstNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -214,7 +216,7 @@
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                         <Run Text="{loc:Loc 'Last Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
-                                    <TextBox Text="{Binding ModalLastName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter last name'}" />
+                                    <TextBox Text="{Binding ModalLastName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter last name'}" MaxLength="50" />
                                     <TextBlock Text="{Binding ModalLastNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalLastNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -223,14 +225,14 @@
                             <!-- Company Name -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Company'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <TextBox Text="{Binding ModalCompanyName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter company name'}" />
+                                <TextBox Text="{Binding ModalCompanyName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter company name'}" MaxLength="100" />
                             </StackPanel>
 
                             <!-- Email and Phone Row -->
                             <Grid ColumnDefinitions="*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Email'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalEmail, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter email address'}" />
+                                    <TextBox Text="{Binding ModalEmail, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter email address'}" MaxLength="254" />
                                     <TextBlock Text="{Binding ModalEmailError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalEmailError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -246,18 +248,18 @@
                             <!-- Street Address -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Street Address'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter street address'}" />
+                                <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter street address'}" MaxLength="200" />
                             </StackPanel>
 
                             <!-- City and State Row -->
                             <Grid ColumnDefinitions="*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'City'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalCity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter city'}" />
+                                    <TextBox Text="{Binding ModalCity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter city'}" MaxLength="100" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'State/Province'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter state'}" />
+                                    <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter state'}" MaxLength="100" />
                                 </StackPanel>
                             </Grid>
 
@@ -265,7 +267,7 @@
                             <Grid ColumnDefinitions="*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Postal Code'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalZipCode, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter postal code'}" />
+                                    <TextBox Text="{Binding ModalZipCode, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter postal code'}" MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Country'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
@@ -277,7 +279,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Notes'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -368,9 +370,9 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Outstanding Amount'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <Grid ColumnDefinitions="*,Auto,*">
-                                    <TextBox Grid.Column="0" Text="{Binding FilterOutstandingMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Min'}" />
+                                    <TextBox Grid.Column="0" Text="{Binding FilterOutstandingMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Min'}" MaxLength="20" />
                                     <TextBlock Grid.Column="1" Text="{loc:Loc 'to'}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="12,0" />
-                                    <TextBox Grid.Column="2" Text="{Binding FilterOutstandingMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Max'}" />
+                                    <TextBox Grid.Column="2" Text="{Binding FilterOutstandingMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Max'}" MaxLength="20" />
                                 </Grid>
                             </StackPanel>
 
@@ -568,9 +570,9 @@
                         <StackPanel Spacing="6">
                             <TextBlock Text="{loc:Loc 'Amount Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                             <Grid ColumnDefinitions="*,Auto,*">
-                                <TextBox Grid.Column="0" Text="{Binding HistoryFilterAmountMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Min'}" behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                <TextBox Grid.Column="0" Text="{Binding HistoryFilterAmountMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Min'}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 <TextBlock Grid.Column="1" Text="{loc:Loc 'to'}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="12,0" />
-                                <TextBox Grid.Column="2" Text="{Binding HistoryFilterAmountMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Max'}" behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                <TextBox Grid.Column="2" Text="{Binding HistoryFilterAmountMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Max'}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                             </Grid>
                         </StackPanel>
                     </StackPanel>

--- a/ArgoBooks/Modals/DepartmentModals.axaml
+++ b/ArgoBooks/Modals/DepartmentModals.axaml
@@ -29,12 +29,12 @@
                             <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                 <Run Text="{loc:Loc 'Department Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                             </TextBlock>
-                            <TextBox Text="{Binding ModalDepartmentName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter department name'}" />
+                            <TextBox Text="{Binding ModalDepartmentName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter department name'}" MaxLength="100" />
                             <TextBlock Text="{Binding ModalDepartmentNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" IsVisible="{Binding ModalDepartmentNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                         </StackPanel>
                         <StackPanel Spacing="6">
                             <TextBlock Text="{loc:Loc Description}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <TextBox Text="{Binding ModalDescription, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter description'}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                            <TextBox Text="{Binding ModalDescription, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter description'}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                         </StackPanel>
                     </StackPanel>
                     <Border Grid.Row="2" Padding="24,16" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">
@@ -70,12 +70,12 @@
                             <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                 <Run Text="{loc:Loc 'Department Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                             </TextBlock>
-                            <TextBox Text="{Binding ModalDepartmentName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter department name'}" />
+                            <TextBox Text="{Binding ModalDepartmentName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter department name'}" MaxLength="100" />
                             <TextBlock Text="{Binding ModalDepartmentNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" IsVisible="{Binding ModalDepartmentNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                         </StackPanel>
                         <StackPanel Spacing="6">
                             <TextBlock Text="{loc:Loc Description}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <TextBox Text="{Binding ModalDescription, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter description'}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                            <TextBox Text="{Binding ModalDescription, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter description'}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                         </StackPanel>
                     </StackPanel>
                     <Border Grid.Row="2" Padding="24,16" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">

--- a/ArgoBooks/Modals/EditCompanyModal.axaml
+++ b/ArgoBooks/Modals/EditCompanyModal.axaml
@@ -61,7 +61,8 @@
                             </TextBlock>
                             <TextBox Classes="form-input"
                                      Text="{Binding CompanyName, Mode=TwoWay}"
-                                     Watermark="{loc:Loc 'Enter company name'}" />
+                                     Watermark="{loc:Loc 'Enter company name'}"
+                                     MaxLength="100" />
                         </StackPanel>
 
                         <!-- Two column layout for fields -->
@@ -119,7 +120,8 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Classes="form-input"
                                          Text="{Binding City, Mode=TwoWay}"
-                                         Watermark="{loc:Loc 'Enter city'}" />
+                                         Watermark="{loc:Loc 'Enter city'}"
+                                         MaxLength="100" />
                             </StackPanel>
 
                             <!-- Address -->
@@ -130,7 +132,8 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Classes="form-input"
                                          Text="{Binding Address, Mode=TwoWay}"
-                                         Watermark="{loc:Loc 'Enter address'}" />
+                                         Watermark="{loc:Loc 'Enter address'}"
+                                         MaxLength="200" />
                             </StackPanel>
                         </Grid>
 

--- a/ArgoBooks/Modals/EmojiPickerModal.axaml
+++ b/ArgoBooks/Modals/EmojiPickerModal.axaml
@@ -33,7 +33,8 @@
                     <Border Grid.Row="1" Padding="16,12">
                         <TextBox Text="{Binding SearchText, Mode=TwoWay}"
                                  Classes="form-input"
-                                 Watermark="{loc:Loc 'Search emojis...'}">
+                                 Watermark="{loc:Loc 'Search emojis...'}"
+                                 MaxLength="50">
                             <TextBox.InnerRightContent>
                                 <Button Classes="icon-button"
                                         Command="{Binding ClearSearchCommand}"

--- a/ArgoBooks/Modals/ExpenseModals.axaml
+++ b/ArgoBooks/Modals/ExpenseModals.axaml
@@ -213,7 +213,8 @@
                                     <TextBox Text="{Binding ModalTaxRate, Mode=TwoWay, Converter={x:Static local:NullableDecimalConverter.Instance}}"
                                              Classes="form-input"
                                              HorizontalAlignment="Stretch"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </StackPanel>
 
                                 <!-- Shipping -->
@@ -223,7 +224,8 @@
                                     <TextBox Text="{Binding ModalShipping, Mode=TwoWay, Converter={x:Static local:NullableDecimalConverter.Instance}}"
                                              Classes="form-input"
                                              HorizontalAlignment="Stretch"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </StackPanel>
 
                                 <!-- Discount -->
@@ -233,7 +235,8 @@
                                     <TextBox Text="{Binding ModalDiscount, Mode=TwoWay, Converter={x:Static local:NullableDecimalConverter.Instance}}"
                                              Classes="form-input"
                                              HorizontalAlignment="Stretch"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -275,7 +278,8 @@
                                          AcceptsReturn="True"
                                          TextWrapping="Wrap"
                                          Height="80"
-                                         Watermark="{loc:Loc 'Additional notes...'}" />
+                                         Watermark="{loc:Loc 'Additional notes...'}"
+                                         MaxLength="500" />
                             </StackPanel>
 
                             <!-- Totals Summary -->
@@ -452,7 +456,8 @@
                                                  Classes="form-input"
                                                  Watermark="$0.00"
                                                  HorizontalAlignment="Stretch"
-                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                 MaxLength="20" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -460,7 +465,8 @@
                                                  Classes="form-input"
                                                  Watermark="$0.00"
                                                  HorizontalAlignment="Stretch"
-                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                 MaxLength="20" />
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>
@@ -589,7 +595,8 @@
                                      AcceptsReturn="True"
                                      TextWrapping="Wrap"
                                      Height="80"
-                                     Watermark="{loc:Loc 'Additional notes about this status change...'}" />
+                                     Watermark="{loc:Loc 'Additional notes about this status change...'}"
+                                     MaxLength="500" />
                         </StackPanel>
                     </StackPanel>
 

--- a/ArgoBooks/Modals/InvoiceModals.axaml
+++ b/ArgoBooks/Modals/InvoiceModals.axaml
@@ -336,7 +336,8 @@
                                          TextWrapping="Wrap"
                                          MinHeight="80"
                                          MaxHeight="120"
-                                         Watermark="{loc:Loc 'Additional notes for this invoice...'}" />
+                                         Watermark="{loc:Loc 'Additional notes for this invoice...'}"
+                                         MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -557,7 +558,8 @@
                                              Text="{Binding FilterAmountMin, Mode=TwoWay}"
                                              Classes="form-input"
                                              Watermark="{loc:Loc Min}"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                     <TextBlock Grid.Column="1" Text="{loc:Loc to}" FontSize="13"
                                                Foreground="{DynamicResource TextTertiaryBrush}"
                                                VerticalAlignment="Center" Margin="12,0" />
@@ -565,7 +567,8 @@
                                              Text="{Binding FilterAmountMax, Mode=TwoWay}"
                                              Classes="form-input"
                                              Watermark="{loc:Loc Max}"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </Grid>
                             </StackPanel>
                         </StackPanel>

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
@@ -101,7 +101,8 @@
                                             <TextBox Text="{Binding TemplateName, Mode=TwoWay}"
                                                      Classes="form-input"
                                                      BorderBrush="{Binding HasValidationMessage, Converter={x:Static local:BoolConverters.ToErrorBorderBrush}}"
-                                                     Watermark="{loc:Loc 'Enter template name...'}" />
+                                                     Watermark="{loc:Loc 'Enter template name...'}"
+                                                     MaxLength="100" />
                                             <TextBlock Text="{Binding ValidationMessage}"
                                                        FontSize="13"
                                                        Foreground="{DynamicResource ErrorBrush}"
@@ -232,7 +233,8 @@
                                                         <TextBox Grid.Column="1"
                                                                  Text="{Binding LogoWidthText, Mode=TwoWay}"
                                                                  Classes="form-input"
-                                                                 HorizontalContentAlignment="Center" />
+                                                                 HorizontalContentAlignment="Center"
+                                                                 MaxLength="5" />
                                                     </Grid>
                                                     <TextBlock Text="{loc:Loc 'Range: 20-300 px'}"
                                                                FontSize="11"
@@ -252,12 +254,12 @@
                                             <StackPanel Spacing="10" IsVisible="{Binding PropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=2}">
                                                 <StackPanel Spacing="4">
                                                     <TextBlock Text="{loc:Loc 'Header Text'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                    <TextBox Text="{Binding HeaderText, Mode=TwoWay}" Classes="form-input" />
+                                                    <TextBox Text="{Binding HeaderText, Mode=TwoWay}" Classes="form-input" MaxLength="200" />
                                                 </StackPanel>
 
                                                 <StackPanel Spacing="4">
                                                     <TextBlock Text="{loc:Loc 'Footer Text'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                    <TextBox Text="{Binding FooterText, Mode=TwoWay}" Classes="form-input" />
+                                                    <TextBox Text="{Binding FooterText, Mode=TwoWay}" Classes="form-input" MaxLength="500" />
                                                 </StackPanel>
 
                                                 <StackPanel Spacing="4">
@@ -267,7 +269,8 @@
                                                              AcceptsReturn="True"
                                                              TextWrapping="Wrap"
                                                              MinHeight="60"
-                                                             Watermark="{loc:Loc 'Bank details, payment methods, etc.'}" />
+                                                             Watermark="{loc:Loc 'Bank details, payment methods, etc.'}"
+                                                             MaxLength="1000" />
                                                 </StackPanel>
 
                                                 <Border Height="1" Background="{DynamicResource BorderBrush}" Margin="0,6" />

--- a/ArgoBooks/Modals/LocationsModals.axaml
+++ b/ArgoBooks/Modals/LocationsModals.axaml
@@ -44,7 +44,8 @@
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalName, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter location name'}" />
+                                             Watermark="{loc:Loc 'Enter location name'}"
+                                             MaxLength="100" />
                                     <TextBlock Text="{Binding ModalNameError}"
                                                FontSize="12"
                                                Foreground="{DynamicResource ErrorBrush}"
@@ -54,7 +55,8 @@
                                     <TextBlock Text="{loc:Loc Code}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalCode, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Auto-generated if empty'}" />
+                                             Watermark="{loc:Loc 'Auto-generated if empty'}"
+                                             MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -88,13 +90,15 @@
                                     <TextBlock Text="{loc:Loc 'State/Province'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter state/province'}" />
+                                             Watermark="{loc:Loc 'Enter state/province'}"
+                                             MaxLength="100" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc City}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalCity, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter city'}" />
+                                             Watermark="{loc:Loc 'Enter city'}"
+                                             MaxLength="100" />
                                 </StackPanel>
                             </Grid>
 
@@ -104,13 +108,15 @@
                                     <TextBlock Text="{loc:Loc 'Postal Code'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalPostalCode, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter postal code'}" />
+                                             Watermark="{loc:Loc 'Enter postal code'}"
+                                             MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Street Address'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter street address'}" />
+                                             Watermark="{loc:Loc 'Enter street address'}"
+                                             MaxLength="200" />
                                 </StackPanel>
                             </Grid>
 
@@ -123,7 +129,8 @@
                                          TextWrapping="Wrap"
                                          MinHeight="80"
                                          MaxHeight="120"
-                                         Watermark="{loc:Loc 'Enter notes...'}" />
+                                         Watermark="{loc:Loc 'Enter notes...'}"
+                                         MaxLength="500" />
                             </StackPanel>
 
                             <!-- Error Message -->
@@ -179,7 +186,8 @@
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalName, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter location name'}" />
+                                             Watermark="{loc:Loc 'Enter location name'}"
+                                             MaxLength="100" />
                                     <TextBlock Text="{Binding ModalNameError}"
                                                FontSize="12"
                                                Foreground="{DynamicResource ErrorBrush}"
@@ -190,7 +198,8 @@
                                     <TextBox Text="{Binding ModalCode}"
                                              Classes="form-input"
                                              IsReadOnly="True"
-                                             Background="{DynamicResource SurfaceAltBrush}" />
+                                             Background="{DynamicResource SurfaceAltBrush}"
+                                             MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -224,13 +233,15 @@
                                     <TextBlock Text="{loc:Loc 'State/Province'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter state/province'}" />
+                                             Watermark="{loc:Loc 'Enter state/province'}"
+                                             MaxLength="100" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc City}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalCity, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter city'}" />
+                                             Watermark="{loc:Loc 'Enter city'}"
+                                             MaxLength="100" />
                                 </StackPanel>
                             </Grid>
 
@@ -240,13 +251,15 @@
                                     <TextBlock Text="{loc:Loc 'Postal Code'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalPostalCode, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter postal code'}" />
+                                             Watermark="{loc:Loc 'Enter postal code'}"
+                                             MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Street Address'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter street address'}" />
+                                             Watermark="{loc:Loc 'Enter street address'}"
+                                             MaxLength="200" />
                                 </StackPanel>
                             </Grid>
 
@@ -259,7 +272,8 @@
                                          TextWrapping="Wrap"
                                          MinHeight="80"
                                          MaxHeight="120"
-                                         Watermark="{loc:Loc 'Enter notes...'}" />
+                                         Watermark="{loc:Loc 'Enter notes...'}"
+                                         MaxLength="500" />
                             </StackPanel>
 
                             <!-- Error Message -->

--- a/ArgoBooks/Modals/LoginModal.axaml
+++ b/ArgoBooks/Modals/LoginModal.axaml
@@ -74,7 +74,8 @@
                                      PasswordChar="•"
                                      Watermark="{loc:Loc 'Enter your password'}"
                                      Classes="password-input"
-                                     x:Name="PasswordBox" />
+                                     x:Name="PasswordBox"
+                                     MaxLength="128" />
                             <Button Grid.Column="1"
                                     Classes="icon-button-small"
                                     Command="{Binding TogglePasswordVisibilityCommand}">

--- a/ArgoBooks/Modals/LostDamagedModals.axaml
+++ b/ArgoBooks/Modals/LostDamagedModals.axaml
@@ -354,7 +354,8 @@
                                          AcceptsReturn="True"
                                          TextWrapping="Wrap"
                                          MinHeight="80"
-                                         MaxHeight="120" />
+                                         MaxHeight="120"
+                                         MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
 

--- a/ArgoBooks/Modals/PasswordPromptModal.axaml
+++ b/ArgoBooks/Modals/PasswordPromptModal.axaml
@@ -119,7 +119,8 @@
                                          RevealPassword="{Binding IsPasswordVisible}"
                                          Classes="password-input"
                                          IsEnabled="{Binding !IsLoading}"
-                                         KeyDown="PasswordTextBox_KeyDown" />
+                                         KeyDown="PasswordTextBox_KeyDown"
+                                         MaxLength="128" />
                                 <Button Grid.Column="1"
                                         Classes="eye-button"
                                         Command="{Binding TogglePasswordVisibilityCommand}"

--- a/ArgoBooks/Modals/PaymentModals.axaml
+++ b/ArgoBooks/Modals/PaymentModals.axaml
@@ -78,7 +78,8 @@
                                 <TextBox Text="{Binding ModalAmount, Mode=TwoWay}"
                                          Classes="form-input"
                                          Watermark="0.00"
-                                         behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                         behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                         MaxLength="20" />
                                 <TextBlock Text="{Binding ModalAmountError}"
                                            FontSize="12"
                                            Foreground="{DynamicResource ErrorBrush}"
@@ -114,7 +115,8 @@
                                 <TextBlock Text="{loc:Loc 'Reference Number'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalReferenceNumber, Mode=TwoWay}"
                                          Classes="form-input"
-                                         Watermark="{loc:Loc 'Check number, transaction ID, etc.'}" />
+                                         Watermark="{loc:Loc 'Check number, transaction ID, etc.'}"
+                                         MaxLength="50" />
                             </StackPanel>
 
                             <!-- Notes -->
@@ -126,7 +128,8 @@
                                          AcceptsReturn="True"
                                          TextWrapping="Wrap"
                                          MinHeight="80"
-                                         MaxHeight="120" />
+                                         MaxHeight="120"
+                                         MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -190,7 +193,8 @@
                                 <TextBox Text="{Binding ModalAmount, Mode=TwoWay}"
                                          Classes="form-input"
                                          Watermark="0.00"
-                                         behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                         behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                         MaxLength="20" />
                                 <TextBlock Text="{Binding ModalAmountError}"
                                            FontSize="12"
                                            Foreground="{DynamicResource ErrorBrush}"
@@ -226,7 +230,8 @@
                                 <TextBlock Text="{loc:Loc 'Reference Number'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalReferenceNumber, Mode=TwoWay}"
                                          Classes="form-input"
-                                         Watermark="{loc:Loc 'Check number, transaction ID, etc.'}" />
+                                         Watermark="{loc:Loc 'Check number, transaction ID, etc.'}"
+                                         MaxLength="50" />
                             </StackPanel>
 
                             <!-- Notes -->
@@ -238,7 +243,8 @@
                                          AcceptsReturn="True"
                                          TextWrapping="Wrap"
                                          MinHeight="80"
-                                         MaxHeight="120" />
+                                         MaxHeight="120"
+                                         MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -337,9 +343,9 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Amount Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <Grid ColumnDefinitions="*,Auto,*">
-                                    <TextBox Grid.Column="0" Text="{Binding FilterAmountMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Min}" behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                    <TextBox Grid.Column="0" Text="{Binding FilterAmountMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Min}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                     <TextBlock Grid.Column="1" Text="{loc:Loc to}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="12,0" />
-                                    <TextBox Grid.Column="2" Text="{Binding FilterAmountMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Max}" behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                    <TextBox Grid.Column="2" Text="{Binding FilterAmountMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Max}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </Grid>
                             </StackPanel>
                         </StackPanel>

--- a/ArgoBooks/Modals/ProductModals.axaml
+++ b/ArgoBooks/Modals/ProductModals.axaml
@@ -48,13 +48,13 @@
                             <Grid ColumnDefinitions="Auto,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                     <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'PRD-xxx'}" />
+                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'PRD-xxx'}" MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                         <Run Text="{loc:Loc 'Product Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
-                                    <TextBox Text="{Binding ModalProductName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter product name'}" />
+                                    <TextBox Text="{Binding ModalProductName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter product name'}" MaxLength="100" />
                                     <TextBlock Text="{Binding ModalProductNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalProductNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -63,7 +63,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Description}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalDescription, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter description'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                             </StackPanel>
 
                             <Grid ColumnDefinitions="*,16,*">
@@ -107,14 +107,14 @@
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Reorder Point'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <Grid ColumnDefinitions="*,Auto">
-                                        <TextBox Grid.Column="0" Text="{Binding ModalReorderPoint, Mode=TwoWay}" Classes="form-input" Watermark="0" />
+                                        <TextBox Grid.Column="0" Text="{Binding ModalReorderPoint, Mode=TwoWay}" Classes="form-input" Watermark="0" MaxLength="10" />
                                         <TextBlock Grid.Column="1" Text="{loc:Loc units}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="8,0,0,0" />
                                     </Grid>
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Overstock Threshold'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <Grid ColumnDefinitions="*,Auto">
-                                        <TextBox Grid.Column="0" Text="{Binding ModalOverstockThreshold, Mode=TwoWay}" Classes="form-input" Watermark="0" />
+                                        <TextBox Grid.Column="0" Text="{Binding ModalOverstockThreshold, Mode=TwoWay}" Classes="form-input" Watermark="0" MaxLength="10" />
                                         <TextBlock Grid.Column="1" Text="{loc:Loc units}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="8,0,0,0" />
                                     </Grid>
                                 </StackPanel>
@@ -166,13 +166,13 @@
                             <Grid ColumnDefinitions="Auto,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                     <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" />
+                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                         <Run Text="{loc:Loc 'Product Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
-                                    <TextBox Text="{Binding ModalProductName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter product name'}" />
+                                    <TextBox Text="{Binding ModalProductName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter product name'}" MaxLength="100" />
                                     <TextBlock Text="{Binding ModalProductNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalProductNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -181,7 +181,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Description}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalDescription, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter description'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                             </StackPanel>
 
                             <Grid ColumnDefinitions="*,16,*">
@@ -225,14 +225,14 @@
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Reorder Point'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <Grid ColumnDefinitions="*,Auto">
-                                        <TextBox Grid.Column="0" Text="{Binding ModalReorderPoint, Mode=TwoWay}" Classes="form-input" Watermark="0" />
+                                        <TextBox Grid.Column="0" Text="{Binding ModalReorderPoint, Mode=TwoWay}" Classes="form-input" Watermark="0" MaxLength="10" />
                                         <TextBlock Grid.Column="1" Text="{loc:Loc units}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="8,0,0,0" />
                                     </Grid>
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Overstock Threshold'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <Grid ColumnDefinitions="*,Auto">
-                                        <TextBox Grid.Column="0" Text="{Binding ModalOverstockThreshold, Mode=TwoWay}" Classes="form-input" Watermark="0" />
+                                        <TextBox Grid.Column="0" Text="{Binding ModalOverstockThreshold, Mode=TwoWay}" Classes="form-input" Watermark="0" MaxLength="10" />
                                         <TextBlock Grid.Column="1" Text="{loc:Loc units}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="8,0,0,0" />
                                     </Grid>
                                 </StackPanel>

--- a/ArgoBooks/Modals/PurchaseOrdersModals.axaml
+++ b/ArgoBooks/Modals/PurchaseOrdersModals.axaml
@@ -151,13 +151,15 @@
                                                              Classes="form-input-compact"
                                                              HorizontalContentAlignment="Center"
                                                              VerticalAlignment="Top"
-                                                             Margin="0,0,8,0" />
+                                                             Margin="0,0,8,0"
+                                                             MaxLength="10" />
                                                     <TextBox Grid.Column="2"
                                                              Text="{Binding UnitCost, Mode=TwoWay}"
                                                              Classes="form-input-compact"
                                                              HorizontalContentAlignment="Center"
                                                              VerticalAlignment="Top"
-                                                             Margin="0,0,8,0" />
+                                                             Margin="0,0,8,0"
+                                                             MaxLength="20" />
                                                     <TextBlock Grid.Column="3"
                                                                Text="{Binding TotalDisplay}"
                                                                FontSize="14"
@@ -207,7 +209,8 @@
                                         <TextBox Grid.Column="1"
                                                  Text="{Binding ShippingCost, Mode=TwoWay}"
                                                  Classes="form-input-compact"
-                                                 HorizontalAlignment="Right" />
+                                                 HorizontalAlignment="Right"
+                                                 MaxLength="20" />
                                     </Grid>
                                     <Border Height="1" Background="{DynamicResource BorderBrush}" Margin="0,4" />
                                     <Grid ColumnDefinitions="*,Auto">
@@ -226,7 +229,8 @@
                                          TextWrapping="Wrap"
                                          MinHeight="60"
                                          MaxHeight="100"
-                                         Watermark="{loc:Loc 'Additional notes for this order...'}" />
+                                         Watermark="{loc:Loc 'Additional notes for this order...'}"
+                                         MaxLength="500" />
                             </StackPanel>
 
                             <!-- Error Message -->
@@ -440,7 +444,8 @@
                                                                  Text="{Binding ReceivingQuantity, Mode=TwoWay}"
                                                                  Classes="form-input-compact"
                                                                  HorizontalAlignment="Stretch"
-                                                                 HorizontalContentAlignment="Center" />
+                                                                 HorizontalContentAlignment="Center"
+                                                                 MaxLength="10" />
                                                     </Grid>
                                                 </Border>
                                             </DataTemplate>

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -95,7 +95,8 @@
                                                Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding FilterAmountMin}"
                                              Watermark="{loc:Loc '$0.00'}"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="8">
                                     <TextBlock Text="{loc:Loc 'Max Amount'}"
@@ -104,7 +105,8 @@
                                                Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding FilterAmountMax}"
                                              Watermark="{loc:Loc '$0.00'}"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -412,7 +414,8 @@
                                                          Watermark="0.00"
                                                          Classes="form-input"
                                                          BorderBrush="{Binding HasTotalError, Converter={x:Static local:BoolConverters.ToErrorBorderBrush}}"
-                                                         behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                                         behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                         MaxLength="20" />
                                                 <TextBlock Text="{Binding TotalErrorMessage}"
                                                            FontSize="12"
                                                            Foreground="{DynamicResource ErrorBrush}"
@@ -430,7 +433,8 @@
                                                 <TextBox Text="{Binding ExtractedSubtotal}"
                                                          Watermark="0.00"
                                                          Classes="form-input"
-                                                         behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                                         behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                         MaxLength="20" />
                                             </StackPanel>
                                             <StackPanel Grid.Column="2" Spacing="6">
                                                 <TextBlock Text="{loc:Loc 'Tax'}"
@@ -440,7 +444,8 @@
                                                 <TextBox Text="{Binding ExtractedTax}"
                                                          Watermark="0.00"
                                                          Classes="form-input"
-                                                         behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                                         behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                         MaxLength="20" />
                                             </StackPanel>
                                         </Grid>
                                     </StackPanel>
@@ -548,13 +553,15 @@
                                                                      HorizontalContentAlignment="Center"
                                                                      VerticalAlignment="Top"
                                                                      Margin="0,0,8,0"
-                                                                     behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                                                     behaviors:NumericInputBehavior.IsIntegerOnly="True"
+                                                                     MaxLength="10" />
                                                             <TextBox Grid.Column="2" Grid.Row="0"
                                                                      Text="{Binding UnitPrice}"
                                                                      HorizontalContentAlignment="Center"
                                                                      VerticalAlignment="Top"
                                                                      Margin="0,0,8,0"
-                                                                     behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                                                     behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                                     MaxLength="20" />
                                                             <TextBlock Grid.Column="3" Grid.Row="0"
                                                                        Text="{Binding TotalPrice, StringFormat='${0}'}"
                                                                        FontSize="14"
@@ -747,7 +754,8 @@
                                                      Classes="form-input"
                                                      AcceptsReturn="True"
                                                      TextWrapping="Wrap"
-                                                     Height="60" />
+                                                     Height="60"
+                                                     MaxLength="500" />
                                         </StackPanel>
                                     </StackPanel>
                                 </StackPanel>

--- a/ArgoBooks/Modals/RentalInventoryModals.axaml
+++ b/ArgoBooks/Modals/RentalInventoryModals.axaml
@@ -63,7 +63,7 @@
                                     <Run Text="{loc:Loc 'Total Quantity'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                 </TextBlock>
                                 <TextBox Text="{Binding ModalTotalQuantity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter quantity'}"
-                                         behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                         behaviors:NumericInputBehavior.IsIntegerOnly="True" MaxLength="10" />
                                 <TextBlock Text="{Binding ModalQuantityError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                            IsVisible="{Binding ModalQuantityError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             </StackPanel>
@@ -78,14 +78,14 @@
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Daily Rate'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalDailyRate, Mode=TwoWay}" Classes="form-input" Watermark="0.00"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                     <TextBlock Text="{Binding ModalDailyRateError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalDailyRateError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Weekly Rate'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalWeeklyRate, Mode=TwoWay}" Classes="form-input" Watermark="0.00"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -94,12 +94,12 @@
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Monthly Rate'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalMonthlyRate, Mode=TwoWay}" Classes="form-input" Watermark="0.00"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Security Deposit'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalSecurityDeposit, Mode=TwoWay}" Classes="form-input" Watermark="0.00"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -107,7 +107,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Notes}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -172,7 +172,7 @@
                                         <Run Text="{loc:Loc 'Total Quantity'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalTotalQuantity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter quantity'}"
-                                         behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                         behaviors:NumericInputBehavior.IsIntegerOnly="True" MaxLength="10" />
                                     <TextBlock Text="{Binding ModalQuantityError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalQuantityError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -198,14 +198,14 @@
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Daily Rate'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalDailyRate, Mode=TwoWay}" Classes="form-input" Watermark="0.00"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                     <TextBlock Text="{Binding ModalDailyRateError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding ModalDailyRateError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Weekly Rate'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalWeeklyRate, Mode=TwoWay}" Classes="form-input" Watermark="0.00"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -214,12 +214,12 @@
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Monthly Rate'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalMonthlyRate, Mode=TwoWay}" Classes="form-input" Watermark="0.00"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Security Deposit'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalSecurityDeposit, Mode=TwoWay}" Classes="form-input" Watermark="0.00"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -227,7 +227,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Notes}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80" MaxHeight="120" MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -297,9 +297,9 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Daily Rate'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <Grid ColumnDefinitions="*,Auto,*">
-                                    <TextBox Grid.Column="0" Text="{Binding FilterDailyRateMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Min}" behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                    <TextBox Grid.Column="0" Text="{Binding FilterDailyRateMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Min}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                     <TextBlock Grid.Column="1" Text="{loc:Loc to}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="12,0" />
-                                    <TextBox Grid.Column="2" Text="{Binding FilterDailyRateMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Max}" behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                    <TextBox Grid.Column="2" Text="{Binding FilterDailyRateMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Max}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </Grid>
                             </StackPanel>
                         </StackPanel>
@@ -372,7 +372,7 @@
                                         <Run Text="{loc:Loc Quantity}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
                                     <TextBox Text="{Binding RentOutQuantity, Mode=TwoWay}" Classes="form-input"
-                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" MaxLength="10" />
                                     <TextBlock Text="{Binding RentOutQuantityError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}"
                                                IsVisible="{Binding RentOutQuantityError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -428,7 +428,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Notes}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding RentOutNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}"
-                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="60" MaxHeight="100" />
+                                         AcceptsReturn="True" TextWrapping="Wrap" MinHeight="60" MaxHeight="100" MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>

--- a/ArgoBooks/Modals/RentalRecordsModals.axaml
+++ b/ArgoBooks/Modals/RentalRecordsModals.axaml
@@ -80,14 +80,14 @@
                                         <Run Text="{loc:Loc Quantity}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalQuantity}" Watermark="1" Classes="form-input"
-                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" MaxLength="10" />
                                     <TextBlock Text="{Binding ModalQuantityError}" Foreground="{DynamicResource ErrorBrush}" FontSize="12"
                                                IsVisible="{Binding ModalQuantityError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Security Deposit'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalSecurityDeposit}" Watermark="0.00" Classes="form-input"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -112,7 +112,7 @@
                                         <Run Text="{loc:Loc 'Rate Amount'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalRateAmount}" Watermark="0.00" Classes="form-input"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                     <TextBlock Text="{Binding ModalRateError}" Foreground="{DynamicResource ErrorBrush}" FontSize="12"
                                                IsVisible="{Binding ModalRateError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -138,7 +138,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Notes}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalNotes}" Watermark="{loc:Loc 'Optional notes'}" TextWrapping="Wrap" Classes="form-input"
-                                         AcceptsReturn="True" MinHeight="80" />
+                                         AcceptsReturn="True" MinHeight="80" MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -222,14 +222,14 @@
                                         <Run Text="{loc:Loc Quantity}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalQuantity}" Watermark="1" Classes="form-input"
-                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" MaxLength="10" />
                                     <TextBlock Text="{Binding ModalQuantityError}" Foreground="{DynamicResource ErrorBrush}" FontSize="12"
                                                IsVisible="{Binding ModalQuantityError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Security Deposit'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalSecurityDeposit}" Watermark="0.00" Classes="form-input"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -254,7 +254,7 @@
                                         <Run Text="{loc:Loc 'Rate Amount'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                     </TextBlock>
                                     <TextBox Text="{Binding ModalRateAmount}" Watermark="0.00" Classes="form-input"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
                                     <TextBlock Text="{Binding ModalRateError}" Foreground="{DynamicResource ErrorBrush}" FontSize="12"
                                                IsVisible="{Binding ModalRateError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
@@ -280,7 +280,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Notes}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ModalNotes}" Watermark="{loc:Loc 'Optional notes'}" TextWrapping="Wrap" Classes="form-input"
-                                         AcceptsReturn="True" MinHeight="80" />
+                                         AcceptsReturn="True" MinHeight="80" MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -340,13 +340,13 @@
                             <!-- Customer -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Customer}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <TextBox Text="{Binding FilterCustomer}" Watermark="{loc:Loc 'Search by customer name'}" Classes="form-input" />
+                                <TextBox Text="{Binding FilterCustomer}" Watermark="{loc:Loc 'Search by customer name'}" Classes="form-input" MaxLength="100" />
                             </StackPanel>
 
                             <!-- Item -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Rental Item'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <TextBox Text="{Binding FilterItem}" Watermark="{loc:Loc 'Search by item name'}" Classes="form-input" />
+                                <TextBox Text="{Binding FilterItem}" Watermark="{loc:Loc 'Search by item name'}" Classes="form-input" MaxLength="100" />
                             </StackPanel>
 
                             <!-- Start Date Range -->
@@ -475,7 +475,7 @@
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Return Notes'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ReturnNotes}" Watermark="{loc:Loc 'Optional notes about the return'}" TextWrapping="Wrap" Classes="form-input"
-                                         AcceptsReturn="True" MinHeight="60" />
+                                         AcceptsReturn="True" MinHeight="60" MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
                     </Border>

--- a/ArgoBooks/Modals/ReportModals.axaml
+++ b/ArgoBooks/Modals/ReportModals.axaml
@@ -138,7 +138,8 @@
                                  Watermark="{loc:Loc 'Template name...'}"
                                  Padding="12,10"
                                  x:Name="RenameTemplateTextBox"
-                                 KeyDown="OnRenameTemplateKeyDown" />
+                                 KeyDown="OnRenameTemplateKeyDown"
+                                 MaxLength="100" />
                     </StackPanel>
 
                     <!-- Footer -->

--- a/ArgoBooks/Modals/ReportSaveTemplateModal.axaml
+++ b/ArgoBooks/Modals/ReportSaveTemplateModal.axaml
@@ -53,7 +53,8 @@
                                Foreground="{DynamicResource TextSecondaryBrush}" />
                     <TextBox Text="{Binding SaveTemplateName}"
                              Watermark="{loc:Loc 'Enter template name...'}"
-                             Padding="12,10" />
+                             Padding="12,10"
+                             MaxLength="100" />
                 </StackPanel>
 
                 <!-- Error Message (only shown for validation errors) -->

--- a/ArgoBooks/Modals/ReturnsModals.axaml
+++ b/ArgoBooks/Modals/ReturnsModals.axaml
@@ -316,7 +316,8 @@
                                          AcceptsReturn="True"
                                          TextWrapping="Wrap"
                                          MinHeight="80"
-                                         MaxHeight="120" />
+                                         MaxHeight="120"
+                                         MaxLength="500" />
                             </StackPanel>
                         </StackPanel>
 

--- a/ArgoBooks/Modals/RevenueModals.axaml
+++ b/ArgoBooks/Modals/RevenueModals.axaml
@@ -229,7 +229,8 @@
                                     <TextBox Text="{Binding ModalTaxRate, Mode=TwoWay, Converter={x:Static local:NullableDecimalConverter.Instance}}"
                                              Classes="form-input"
                                              HorizontalAlignment="Stretch"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </StackPanel>
 
                                 <!-- Shipping -->
@@ -239,7 +240,8 @@
                                     <TextBox Text="{Binding ModalShipping, Mode=TwoWay, Converter={x:Static local:NullableDecimalConverter.Instance}}"
                                              Classes="form-input"
                                              HorizontalAlignment="Stretch"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </StackPanel>
 
                                 <!-- Discount -->
@@ -249,7 +251,8 @@
                                     <TextBox Text="{Binding ModalDiscount, Mode=TwoWay, Converter={x:Static local:NullableDecimalConverter.Instance}}"
                                              Classes="form-input"
                                              HorizontalAlignment="Stretch"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                             MaxLength="20" />
                                 </StackPanel>
                             </Grid>
 
@@ -291,7 +294,8 @@
                                          AcceptsReturn="True"
                                          TextWrapping="Wrap"
                                          Height="80"
-                                         Watermark="{loc:Loc 'Additional notes...'}" />
+                                         Watermark="{loc:Loc 'Additional notes...'}"
+                                         MaxLength="500" />
                             </StackPanel>
 
                             <!-- Totals Summary -->
@@ -479,7 +483,8 @@
                                                  Classes="form-input"
                                                  Watermark="$0.00"
                                                  HorizontalAlignment="Stretch"
-                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                 MaxLength="20" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -487,7 +492,8 @@
                                                  Classes="form-input"
                                                  Watermark="$0.00"
                                                  HorizontalAlignment="Stretch"
-                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True" />
+                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                 MaxLength="20" />
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>
@@ -600,7 +606,8 @@
                                      AcceptsReturn="True"
                                      TextWrapping="Wrap"
                                      Height="80"
-                                     Watermark="{loc:Loc 'Additional notes about this status change...'}" />
+                                     Watermark="{loc:Loc 'Additional notes about this status change...'}"
+                                     MaxLength="500" />
                         </StackPanel>
                     </StackPanel>
 

--- a/ArgoBooks/Modals/SettingsModal.axaml
+++ b/ArgoBooks/Modals/SettingsModal.axaml
@@ -466,7 +466,7 @@
                                                 Command="{Binding SelectAccentColorCommand}"
                                                 CommandParameter="Blue">
                                             <Grid>
-                                                <Border Width="48" Height="48" CornerRadius="24" Background="{DynamicResource PrimaryBrush}">
+                                                <Border Width="48" Height="48" CornerRadius="24" Background="#3B82F6">
                                                     <PathIcon Data="{x:Static icons:Icons.Check}"
                                                               Width="20" Height="20" Foreground="White">
                                                         <PathIcon.IsVisible>
@@ -779,7 +779,8 @@
                                     <TextBox Grid.Column="0"
                                              Text="{Binding NewPassword}"
                                              RevealPassword="{Binding IsNewPasswordVisible}"
-                                             Classes="password-field" />
+                                             Classes="password-field"
+                                             MaxLength="128" />
                                     <Button Grid.Column="1"
                                             Classes="eye-toggle"
                                             Command="{Binding ToggleNewPasswordVisibilityCommand}">
@@ -798,7 +799,8 @@
                                     <TextBox Grid.Column="0"
                                              Text="{Binding ConfirmPassword}"
                                              RevealPassword="{Binding IsConfirmPasswordVisible}"
-                                             Classes="password-field" />
+                                             Classes="password-field"
+                                             MaxLength="128" />
                                     <Button Grid.Column="1"
                                             Classes="eye-toggle"
                                             Command="{Binding ToggleConfirmPasswordVisibilityCommand}">
@@ -848,7 +850,8 @@
                                              x:Name="ChangeCurrentPasswordTextBox"
                                              Text="{Binding CurrentPassword}"
                                              RevealPassword="{Binding IsCurrentPasswordVisible}"
-                                             Classes="password-field" />
+                                             Classes="password-field"
+                                             MaxLength="128" />
                                     <Button Grid.Column="1"
                                             Classes="eye-toggle"
                                             Command="{Binding ToggleCurrentPasswordVisibilityCommand}">
@@ -867,7 +870,8 @@
                                     <TextBox Grid.Column="0"
                                              Text="{Binding NewPassword}"
                                              RevealPassword="{Binding IsNewPasswordVisible}"
-                                             Classes="password-field" />
+                                             Classes="password-field"
+                                             MaxLength="128" />
                                     <Button Grid.Column="1"
                                             Classes="eye-toggle"
                                             Command="{Binding ToggleNewPasswordVisibilityCommand}">
@@ -886,7 +890,8 @@
                                     <TextBox Grid.Column="0"
                                              Text="{Binding ConfirmPassword}"
                                              RevealPassword="{Binding IsConfirmPasswordVisible}"
-                                             Classes="password-field" />
+                                             Classes="password-field"
+                                             MaxLength="128" />
                                     <Button Grid.Column="1"
                                             Classes="eye-toggle"
                                             Command="{Binding ToggleConfirmPasswordVisibilityCommand}">
@@ -938,7 +943,8 @@
                                              x:Name="RemoveCurrentPasswordTextBox"
                                              Text="{Binding CurrentPassword}"
                                              RevealPassword="{Binding IsCurrentPasswordVisible}"
-                                             Classes="password-field" />
+                                             Classes="password-field"
+                                             MaxLength="128" />
                                     <Button Grid.Column="1"
                                             Classes="eye-toggle"
                                             Command="{Binding ToggleCurrentPasswordVisibilityCommand}">

--- a/ArgoBooks/Modals/StockAdjustmentsModals.axaml
+++ b/ArgoBooks/Modals/StockAdjustmentsModals.axaml
@@ -99,7 +99,8 @@
                                     <TextBox Text="{Binding AdjustmentQuantity, Mode=TwoWay}"
                                              Classes="form-input"
                                              Watermark="{loc:Loc 'Enter quantity'}"
-                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                             behaviors:NumericInputBehavior.IsIntegerOnly="True"
+                                             MaxLength="10" />
                                     <TextBlock Text="{loc:Loc 'Please enter a valid quantity'}"
                                                FontSize="12"
                                                Foreground="{DynamicResource ErrorBrush}"
@@ -125,7 +126,8 @@
                                 <TextBlock Text="{loc:Loc 'Reference Number'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ReferenceNumber, Mode=TwoWay}"
                                          Classes="form-input"
-                                         Watermark="{loc:Loc 'e.g., PO-12345 or RMA-67890'}" />
+                                         Watermark="{loc:Loc 'e.g., PO-12345 or RMA-67890'}"
+                                         MaxLength="50" />
                             </StackPanel>
 
                             <!-- Reason/Notes -->
@@ -137,7 +139,8 @@
                                          TextWrapping="Wrap"
                                          MinHeight="80"
                                          MaxHeight="120"
-                                         Watermark="{loc:Loc 'Enter reason for adjustment...'}" />
+                                         Watermark="{loc:Loc 'Enter reason for adjustment...'}"
+                                         MaxLength="500" />
                             </StackPanel>
 
                             <!-- Error Message -->

--- a/ArgoBooks/Modals/StockLevelsModals.axaml
+++ b/ArgoBooks/Modals/StockLevelsModals.axaml
@@ -81,7 +81,8 @@
                                     <TextBox Text="{Binding AdjustmentQuantity, Mode=TwoWay}"
                                              Classes="form-input"
                                              Watermark="{loc:Loc 'Enter quantity'}"
-                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                             behaviors:NumericInputBehavior.IsIntegerOnly="True"
+                                             MaxLength="10" />
                                     <TextBlock Text="{loc:Loc 'Please enter a valid quantity'}"
                                                FontSize="12"
                                                Foreground="{DynamicResource ErrorBrush}"
@@ -111,7 +112,8 @@
                                          TextWrapping="Wrap"
                                          MinHeight="80"
                                          MaxHeight="120"
-                                         Watermark="{loc:Loc 'Enter reason for adjustment...'}" />
+                                         Watermark="{loc:Loc 'Enter reason for adjustment...'}"
+                                         MaxLength="500" />
                             </StackPanel>
 
                             <!-- Error Message -->
@@ -181,7 +183,8 @@
                                     <TextBlock Text="{loc:Loc SKU}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding AddItemSku, Mode=TwoWay}"
                                              Classes="form-input"
-                                             Watermark="{loc:Loc 'Enter SKU (optional)'}" />
+                                             Watermark="{loc:Loc 'Enter SKU (optional)'}"
+                                             MaxLength="50" />
                                 </StackPanel>
 
                                 <StackPanel Grid.Column="2" Spacing="6">
@@ -210,7 +213,8 @@
                                     <TextBox Text="{Binding AddItemQuantity, Mode=TwoWay}"
                                              Classes="form-input"
                                              Watermark="0"
-                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                             behaviors:NumericInputBehavior.IsIntegerOnly="True"
+                                             MaxLength="10" />
                                     <TextBlock Text="{loc:Loc 'Please enter a valid quantity'}"
                                                FontSize="12"
                                                Foreground="{DynamicResource ErrorBrush}"
@@ -222,7 +226,8 @@
                                     <TextBox Text="{Binding AddItemReorderPoint, Mode=TwoWay}"
                                              Classes="form-input"
                                              Watermark="10"
-                                             behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                             behaviors:NumericInputBehavior.IsIntegerOnly="True"
+                                             MaxLength="10" />
                                 </StackPanel>
                             </Grid>
 
@@ -232,7 +237,8 @@
                                 <TextBox Text="{Binding AddItemOverstockThreshold, Mode=TwoWay}"
                                          Classes="form-input"
                                          Watermark="100"
-                                         behaviors:NumericInputBehavior.IsIntegerOnly="True" />
+                                         behaviors:NumericInputBehavior.IsIntegerOnly="True"
+                                         MaxLength="10" />
                             </StackPanel>
 
                             <!-- Error Message -->

--- a/ArgoBooks/Modals/SupplierModals.axaml
+++ b/ArgoBooks/Modals/SupplierModals.axaml
@@ -29,20 +29,20 @@
                            <Grid ColumnDefinitions="Auto,16,*">
                                <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                    <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'SUP-xxx'}" />
+                                   <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'SUP-xxx'}" MaxLength="20" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
                                    <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                        <Run Text="{loc:Loc 'Supplier Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                    </TextBlock>
-                                   <TextBox Text="{Binding ModalSupplierName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter supplier name'}" />
+                                   <TextBox Text="{Binding ModalSupplierName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter supplier name'}" MaxLength="100" />
                                    <TextBlock Text="{Binding ModalSupplierNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" IsVisible="{Binding ModalSupplierNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                </StackPanel>
                            </Grid>
                            <Grid ColumnDefinitions="*,16,*">
                                <StackPanel Grid.Column="0" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'Email'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalEmail, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'supplier@email.com'}" />
+                                   <TextBox Text="{Binding ModalEmail, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'supplier@email.com'}" MaxLength="254" />
                                    <TextBlock Text="{Binding ModalEmailError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" IsVisible="{Binding ModalEmailError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
@@ -53,27 +53,27 @@
                            </Grid>
                            <StackPanel Spacing="6">
                                <TextBlock Text="{loc:Loc 'Website'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                               <TextBox Text="{Binding ModalWebsite, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'https://www.example.com'}" />
+                               <TextBox Text="{Binding ModalWebsite, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'https://www.example.com'}" MaxLength="500" />
                            </StackPanel>
                            <TextBlock Text="{loc:Loc 'Address'}" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,8,0,0" />
                            <StackPanel Spacing="6">
                                <TextBlock Text="{loc:Loc 'Street Address'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                               <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Street address'}" />
+                               <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Street address'}" MaxLength="200" />
                            </StackPanel>
                            <Grid ColumnDefinitions="*,16,*">
                                <StackPanel Grid.Column="0" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'City'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalCity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'City'}" />
+                                   <TextBox Text="{Binding ModalCity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'City'}" MaxLength="100" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'State/Province'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'State'}" />
+                                   <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'State'}" MaxLength="100" />
                                </StackPanel>
                            </Grid>
                            <Grid ColumnDefinitions="*,16,*">
                                <StackPanel Grid.Column="0" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'Postal Code'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalZipCode, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Postal code'}" />
+                                   <TextBox Text="{Binding ModalZipCode, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Postal code'}" MaxLength="20" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'Country'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
@@ -82,7 +82,7 @@
                            </Grid>
                            <StackPanel Spacing="6">
                                <TextBlock Text="{loc:Loc 'Notes'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                               <TextBox Text="{Binding ModalNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="60" />
+                               <TextBox Text="{Binding ModalNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="60" MaxLength="500" />
                            </StackPanel>
                        </StackPanel>
                    </ScrollViewer>
@@ -127,20 +127,20 @@
                            <Grid ColumnDefinitions="Auto,16,*">
                                <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                    <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" />
+                                   <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" MaxLength="20" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
                                    <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                        <Run Text="{loc:Loc 'Supplier Name'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                    </TextBlock>
-                                   <TextBox Text="{Binding ModalSupplierName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter supplier name'}" />
+                                   <TextBox Text="{Binding ModalSupplierName, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter supplier name'}" MaxLength="100" />
                                    <TextBlock Text="{Binding ModalSupplierNameError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" IsVisible="{Binding ModalSupplierNameError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                </StackPanel>
                            </Grid>
                            <Grid ColumnDefinitions="*,16,*">
                                <StackPanel Grid.Column="0" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'Email'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalEmail, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'supplier@email.com'}" />
+                                   <TextBox Text="{Binding ModalEmail, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'supplier@email.com'}" MaxLength="254" />
                                    <TextBlock Text="{Binding ModalEmailError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" IsVisible="{Binding ModalEmailError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
@@ -151,27 +151,27 @@
                            </Grid>
                            <StackPanel Spacing="6">
                                <TextBlock Text="{loc:Loc 'Website'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                               <TextBox Text="{Binding ModalWebsite, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'https://www.example.com'}" />
+                               <TextBox Text="{Binding ModalWebsite, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'https://www.example.com'}" MaxLength="500" />
                            </StackPanel>
                            <TextBlock Text="{loc:Loc 'Address'}" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" Margin="0,8,0,0" />
                            <StackPanel Spacing="6">
                                <TextBlock Text="{loc:Loc 'Street Address'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                               <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Street address'}" />
+                               <TextBox Text="{Binding ModalStreetAddress, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Street address'}" MaxLength="200" />
                            </StackPanel>
                            <Grid ColumnDefinitions="*,16,*">
                                <StackPanel Grid.Column="0" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'City'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalCity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'City'}" />
+                                   <TextBox Text="{Binding ModalCity, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'City'}" MaxLength="100" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'State/Province'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'State'}" />
+                                   <TextBox Text="{Binding ModalStateProvince, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'State'}" MaxLength="100" />
                                </StackPanel>
                            </Grid>
                            <Grid ColumnDefinitions="*,16,*">
                                <StackPanel Grid.Column="0" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'Postal Code'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                   <TextBox Text="{Binding ModalZipCode, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Postal code'}" />
+                                   <TextBox Text="{Binding ModalZipCode, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Postal code'}" MaxLength="20" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
                                    <TextBlock Text="{loc:Loc 'Country'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
@@ -180,7 +180,7 @@
                            </Grid>
                            <StackPanel Spacing="6">
                                <TextBlock Text="{loc:Loc 'Notes'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                               <TextBox Text="{Binding ModalNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="60" />
+                               <TextBox Text="{Binding ModalNotes, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Enter notes'}" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="60" MaxLength="500" />
                            </StackPanel>
                        </StackPanel>
                    </ScrollViewer>

--- a/ArgoBooks/Modals/SwitchAccountModal.axaml
+++ b/ArgoBooks/Modals/SwitchAccountModal.axaml
@@ -73,7 +73,8 @@
                                      Text="{Binding SearchQuery, Mode=TwoWay}"
                                      Watermark="{loc:Loc 'Search accounts...'}"
                                      Classes="search-input"
-                                     VerticalAlignment="Center" />
+                                     VerticalAlignment="Center"
+                                     MaxLength="100" />
                         </Grid>
                     </Border>
                 </Border>

--- a/ArgoBooks/Panels/QuickActionsPanel.axaml
+++ b/ArgoBooks/Panels/QuickActionsPanel.axaml
@@ -40,7 +40,8 @@
                                  BorderThickness="0"
                                  Background="Transparent"
                                  FontSize="16"
-                                 VerticalAlignment="Center" />
+                                 VerticalAlignment="Center"
+                                 MaxLength="100" />
 
                         <!-- Close hint -->
                         <Border Grid.Column="2"

--- a/ArgoBooks/Services/ChartLoaderService.cs
+++ b/ArgoBooks/Services/ChartLoaderService.cs
@@ -25,7 +25,7 @@ public class ChartLoaderService
     private const float AxisTextSize = 14f;
 
     // Chart colors
-    private static readonly SKColor RevenueColor = SKColor.Parse("#6495ED"); // Cornflower Blue (matches WinForms)
+    private static readonly SKColor RevenueColor = SKColor.Parse("#3B82F6"); // Blue (matches accent theme)
     private static readonly SKColor ExpenseColor = SKColor.Parse("#EF4444"); // Red
     private static readonly SKColor ProfitColor = SKColor.Parse("#22C55E"); // Green
 
@@ -2027,7 +2027,7 @@ public class ChartLoaderService
     {
         string[] colors =
         [
-            "#6495ED", // Cornflower Blue
+            "#3B82F6", // Blue
             "#EF4444", // Red
             "#22C55E", // Green
             "#F59E0B", // Amber

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -509,7 +509,8 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <TextBox Text="{Binding ReportName}"
                                          Watermark="{loc:Loc 'Enter report name...'}"
-                                         Padding="12,10" />
+                                         Padding="12,10"
+                                         MaxLength="100" />
                             </StackPanel>
 
                             <!-- Date Range -->
@@ -1001,7 +1002,7 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Text'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <TextBox Text="{Binding SelectedLabelElement.Text}" />
+                                    <TextBox Text="{Binding SelectedLabelElement.Text}" MaxLength="500" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Font Family'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -1587,7 +1588,8 @@
                                 <TextBox Grid.Column="0"
                                          Text="{Binding ExportFilePath}"
                                          Watermark="{loc:Loc 'Select file path...'}"
-                                         Padding="12,10" />
+                                         Padding="12,10"
+                                         MaxLength="500" />
                                 <Button Grid.Column="1"
                                         Content="{loc:Loc 'Browse'}"
                                         Margin="8,0,0,0"


### PR DESCRIPTION
- Fix chart accent colors in ChartLoaderService and PieChartLegend
- Add MaxLength limits to all TextBox inputs across modals and controls
- Update ColorPickerInput and other input controls with proper constraints