### PR TITLE
Fix sample company message, consolidate AppInfo, and various UI fixes

### DIFF
--- a/ArgoBooks.Core/Models/Reports/ReportTemplateFactory.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportTemplateFactory.cs
@@ -507,55 +507,43 @@ public static class ReportTemplateFactory
     {
         var context = new LayoutContext(config);
 
-        // Mixed layout: full-width chart at top, then 2x2 grid below the date range
-        var topStack = CreateVerticalStack(context, 0.33, 0.67);
-
-        config.AddElement(new ChartReportElement
-        {
-            ChartType = ChartDataType.ReturnsOverTime,
-            X = topStack[0].X,
-            Y = topStack[0].Y,
-            Width = topStack[0].Width,
-            Height = topStack[0].Height
-        });
-
-        // Create a 2x2 grid in the bottom portion
-        var bottomGrid = SplitIntoGrid(topStack[1], 2, 2, context.ElementSpacing);
+        // 2x2 grid layout for 4 charts
+        var grid = CreateGrid(context, 2, 2);
 
         config.AddElement(new ChartReportElement
         {
             ChartType = ChartDataType.ReturnReasons,
-            X = bottomGrid[0, 0].X,
-            Y = bottomGrid[0, 0].Y,
-            Width = bottomGrid[0, 0].Width,
-            Height = bottomGrid[0, 0].Height
+            X = grid[0, 0].X,
+            Y = grid[0, 0].Y,
+            Width = grid[0, 0].Width,
+            Height = grid[0, 0].Height
         });
 
         config.AddElement(new ChartReportElement
         {
             ChartType = ChartDataType.ReturnFinancialImpact,
-            X = bottomGrid[0, 1].X,
-            Y = bottomGrid[0, 1].Y,
-            Width = bottomGrid[0, 1].Width,
-            Height = bottomGrid[0, 1].Height
+            X = grid[0, 1].X,
+            Y = grid[0, 1].Y,
+            Width = grid[0, 1].Width,
+            Height = grid[0, 1].Height
         });
 
         config.AddElement(new ChartReportElement
         {
             ChartType = ChartDataType.ReturnsByCategory,
-            X = bottomGrid[1, 0].X,
-            Y = bottomGrid[1, 0].Y,
-            Width = bottomGrid[1, 0].Width,
-            Height = bottomGrid[1, 0].Height
+            X = grid[1, 0].X,
+            Y = grid[1, 0].Y,
+            Width = grid[1, 0].Width,
+            Height = grid[1, 0].Height
         });
 
         config.AddElement(new ChartReportElement
         {
             ChartType = ChartDataType.ReturnsByProduct,
-            X = bottomGrid[1, 1].X,
-            Y = bottomGrid[1, 1].Y,
-            Width = bottomGrid[1, 1].Width,
-            Height = bottomGrid[1, 1].Height
+            X = grid[1, 1].X,
+            Y = grid[1, 1].Y,
+            Width = grid[1, 1].Width,
+            Height = grid[1, 1].Height
         });
 
         // Date range element - added last so it renders on top (highest ZOrder)
@@ -572,55 +560,43 @@ public static class ReportTemplateFactory
     {
         var context = new LayoutContext(config);
 
-        // Mixed layout: full-width chart at top, then 2x2 grid below the date range
-        var topStack = CreateVerticalStack(context, 0.33, 0.67);
-
-        config.AddElement(new ChartReportElement
-        {
-            ChartType = ChartDataType.LossesOverTime,
-            X = topStack[0].X,
-            Y = topStack[0].Y,
-            Width = topStack[0].Width,
-            Height = topStack[0].Height
-        });
-
-        // Create a 2x2 grid in the bottom portion
-        var bottomGrid = SplitIntoGrid(topStack[1], 2, 2, context.ElementSpacing);
+        // 2x2 grid layout for 4 charts
+        var grid = CreateGrid(context, 2, 2);
 
         config.AddElement(new ChartReportElement
         {
             ChartType = ChartDataType.LossReasons,
-            X = bottomGrid[0, 0].X,
-            Y = bottomGrid[0, 0].Y,
-            Width = bottomGrid[0, 0].Width,
-            Height = bottomGrid[0, 0].Height
+            X = grid[0, 0].X,
+            Y = grid[0, 0].Y,
+            Width = grid[0, 0].Width,
+            Height = grid[0, 0].Height
         });
 
         config.AddElement(new ChartReportElement
         {
             ChartType = ChartDataType.LossFinancialImpact,
-            X = bottomGrid[0, 1].X,
-            Y = bottomGrid[0, 1].Y,
-            Width = bottomGrid[0, 1].Width,
-            Height = bottomGrid[0, 1].Height
+            X = grid[0, 1].X,
+            Y = grid[0, 1].Y,
+            Width = grid[0, 1].Width,
+            Height = grid[0, 1].Height
         });
 
         config.AddElement(new ChartReportElement
         {
             ChartType = ChartDataType.LossesByCategory,
-            X = bottomGrid[1, 0].X,
-            Y = bottomGrid[1, 0].Y,
-            Width = bottomGrid[1, 0].Width,
-            Height = bottomGrid[1, 0].Height
+            X = grid[1, 0].X,
+            Y = grid[1, 0].Y,
+            Width = grid[1, 0].Width,
+            Height = grid[1, 0].Height
         });
 
         config.AddElement(new ChartReportElement
         {
             ChartType = ChartDataType.LossesByProduct,
-            X = bottomGrid[1, 1].X,
-            Y = bottomGrid[1, 1].Y,
-            Width = bottomGrid[1, 1].Width,
-            Height = bottomGrid[1, 1].Height
+            X = grid[1, 1].X,
+            Y = grid[1, 1].Y,
+            Width = grid[1, 1].Width,
+            Height = grid[1, 1].Height
         });
 
         // Date range element - added last so it renders on top (highest ZOrder)

--- a/ArgoBooks.Core/Services/AppInfo.cs
+++ b/ArgoBooks.Core/Services/AppInfo.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Provides application version information.
+/// </summary>
+public static class AppInfo
+{
+    private static string? _versionNumber;
+    private static Version? _assemblyVersion;
+
+    /// <summary>
+    /// Gets the application version in "X.X.X" format.
+    /// </summary>
+    public static string VersionNumber
+    {
+        get
+        {
+            if (_versionNumber == null)
+            {
+                var version = AssemblyVersion;
+                _versionNumber = version != null
+                    ? $"{version.Major}.{version.Minor}.{version.Build}"
+                    : "1.0.0";
+            }
+            return _versionNumber;
+        }
+    }
+
+    /// <summary>
+    /// Gets the raw version object from the entry assembly.
+    /// </summary>
+    public static Version? AssemblyVersion
+    {
+        get
+        {
+            if (_assemblyVersion == null)
+            {
+                try
+                {
+                    _assemblyVersion = Assembly.GetEntryAssembly()?.GetName().Version;
+                }
+                catch
+                {
+                    // Ignore errors accessing assembly
+                }
+            }
+            return _assemblyVersion;
+        }
+    }
+}

--- a/ArgoBooks.Core/Services/SampleCompanyService.cs
+++ b/ArgoBooks.Core/Services/SampleCompanyService.cs
@@ -189,7 +189,7 @@ public class SampleCompanyService
             Phone = "555-100-0000"
         };
 
-        companyData.Settings.AppVersion = "2.2.3";
+        companyData.Settings.AppVersion = AppInfo.VersionNumber;
 
         // Set localization defaults
         companyData.Settings.Localization = new LocalizationSettings
@@ -255,22 +255,10 @@ public class SampleCompanyService
     {
         var dates = new List<DateTime>();
 
+        // Only consider Revenue and Expense dates for time-shifting
+        // This ensures the dashboard "This Month" view shows meaningful data
         dates.AddRange(data.Revenues.Select(s => s.Date));
         dates.AddRange(data.Expenses.Select(p => p.Date));
-        dates.AddRange(data.Invoices.Select(i => i.IssueDate));
-        dates.AddRange(data.Payments.Select(p => p.Date));
-        dates.AddRange(data.Rentals.Select(r => r.StartDate));
-        dates.AddRange(data.Rentals.Where(r => r.ReturnDate.HasValue).Select(r => r.ReturnDate!.Value));
-        dates.AddRange(data.Returns.Select(r => r.ReturnDate));
-        dates.AddRange(data.Receipts.Select(r => r.Date));
-        dates.AddRange(data.LostDamaged.Select(ld => ld.DateDiscovered));
-        dates.AddRange(data.StockAdjustments.Select(sa => sa.Timestamp));
-        dates.AddRange(data.StockTransfers.Select(st => st.TransferDate));
-        dates.AddRange(data.StockTransfers.Where(st => st.CompletedAt.HasValue).Select(st => st.CompletedAt!.Value));
-        dates.AddRange(data.PurchaseOrders.Select(po => po.OrderDate));
-        dates.AddRange(data.RecurringInvoices.Select(ri => ri.StartDate));
-        dates.AddRange(data.RecurringInvoices.Where(ri => ri.LastGeneratedAt.HasValue).Select(ri => ri.LastGeneratedAt!.Value));
-        dates.AddRange(data.Customers.Where(c => c.LastTransactionDate.HasValue).Select(c => c.LastTransactionDate!.Value));
 
         return dates.Count > 0 ? dates.Max() : DateTime.MinValue;
     }

--- a/ArgoBooks.Core/Services/TelemetryManager.cs
+++ b/ArgoBooks.Core/Services/TelemetryManager.cs
@@ -40,7 +40,7 @@ public class TelemetryManager : ITelemetryManager
         _settingsService = settingsService;
         _errorLogger = errorLogger;
 
-        _appVersion = appVersion ?? GetAppVersion();
+        _appVersion = appVersion ?? AppInfo.VersionNumber;
         _platform = GetPlatform();
         _userAgent = GetUserAgent();
 
@@ -282,20 +282,6 @@ public class TelemetryManager : ITelemetryManager
         }
 
         return telemetryEvent;
-    }
-
-    private static string GetAppVersion()
-    {
-        try
-        {
-            var assembly = System.Reflection.Assembly.GetEntryAssembly();
-            var version = assembly?.GetName().Version;
-            return version?.ToString(3) ?? "1.0.0";
-        }
-        catch
-        {
-            return "1.0.0";
-        }
     }
 
     private static string GetPlatform()

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -609,7 +609,7 @@ public class App : Application
             var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
             var geoLocationService = new GeoLocationService(httpClient, errorLogger);
             var telemetryStorageService = new TelemetryStorageService(errorLogger: errorLogger);
-            var appVersion = AppInfo.VersionNumber;
+            var appVersion = Services.AppInfo.VersionNumber;
             var telemetryUploadService = new TelemetryUploadService(telemetryStorageService, httpClient, errorLogger, appVersion);
             TelemetryManager = new TelemetryManager(
                 telemetryStorageService,
@@ -1554,7 +1554,11 @@ public class App : Application
                 if (CompanyManager.CompanyData != null)
                 {
                     if (SampleCompanyService.TimeShiftSampleData(CompanyManager.CompanyData))
+                    {
                         CompanyManager.NotifyDataChanged();
+                        // Save the shifted data so it persists for next open
+                        await CompanyManager.SaveCompanyAsync();
+                    }
                     CompanyManager.CompanyData.MarkAsSaved();
 
                     // Reset unsaved changes since time-shift is automatic and shouldn't count as a user change
@@ -1595,7 +1599,7 @@ public class App : Application
         if (!Version.TryParse(sampleVersion, out var sampleVer))
             return false;
 
-        var appVersion = AppInfo.AssemblyVersion;
+        var appVersion = Services.AppInfo.AssemblyVersion;
         if (appVersion == null)
             return false;
 
@@ -2304,7 +2308,7 @@ public class App : Application
                 }
                 successMessage += "\n\n" + "Please save to persist changes.".Translate();
 
-                _appShellViewModel.AddNotification("Import Complete".Translate(), successMessage, NotificationType.Success);
+                _appShellViewModel?.AddNotification("Import Complete".Translate(), successMessage, NotificationType.Success);
             }
             catch (Exception ex)
             {

--- a/ArgoBooks/Services/AppInfo.cs
+++ b/ArgoBooks/Services/AppInfo.cs
@@ -1,12 +1,15 @@
-using System.Reflection;
+using CoreAppInfo = ArgoBooks.Core.Services.AppInfo;
 
 namespace ArgoBooks.Services;
 
 /// <summary>
 /// Provides application information such as version.
+/// Delegates to ArgoBooks.Core.Services.AppInfo for consistency.
 /// </summary>
 public static class AppInfo
 {
+    private static string? _version;
+
     /// <summary>
     /// Gets the application version in "V.X.X.X" format for display.
     /// </summary>
@@ -14,40 +17,18 @@ public static class AppInfo
     {
         get
         {
-            if (field == null)
-            {
-                var assembly = Assembly.GetExecutingAssembly();
-                var version = assembly.GetName().Version;
-                field = version != null
-                    ? $"V.{version.Major}.{version.Minor}.{version.Build}"
-                    : "V.1.0.0";
-            }
-            return field;
+            _version ??= $"V.{VersionNumber}";
+            return _version;
         }
     }
 
     /// <summary>
     /// Gets the application version in "X.X.X" format (without "V." prefix).
     /// </summary>
-    public static string VersionNumber
-    {
-        get
-        {
-            if (field == null)
-            {
-                var assembly = Assembly.GetExecutingAssembly();
-                var version = assembly.GetName().Version;
-                field = version != null
-                    ? $"{version.Major}.{version.Minor}.{version.Build}"
-                    : "1.0.0";
-            }
-            return field;
-        }
-    }
+    public static string VersionNumber => CoreAppInfo.VersionNumber;
 
     /// <summary>
     /// Gets the raw version object.
     /// </summary>
-    public static Version? AssemblyVersion =>
-        Assembly.GetExecutingAssembly().GetName().Version;
+    public static Version? AssemblyVersion => CoreAppInfo.AssemblyVersion;
 }

--- a/ArgoBooks/Services/ChartLoaderService.cs
+++ b/ArgoBooks/Services/ChartLoaderService.cs
@@ -28,7 +28,7 @@ public class ChartLoaderService
     private static readonly SKColor RevenueColor = SKColor.Parse("#3B82F6"); // Blue (matches accent theme)
     private static readonly SKColor ExpenseColor = SKColor.Parse("#EF4444"); // Red
     private static readonly SKColor ProfitColor = SKColor.Parse("#22C55E"); // Green
-    private static readonly SKColor CustomerColor = SKColor.Parse("#8B5CF6"); // Purple
+    private static readonly SKColor CustomerColor = SKColor.Parse("#3B82F6"); // Blue (matches accent theme)
 
     // Theme colors (will be updated based on current theme)
     private SKColor _textColor = SKColor.Parse("#F9FAFB"); // Light text for dark theme
@@ -1428,7 +1428,39 @@ public class ChartLoaderService
             Values = dataPoints.Select(p => p.Value).ToArray(),
             SeriesName = "Count"        };
         _chartExportDataByTitle["Return Reasons"] = exportData;
-        _chartExportDataByTitle["Returns by Category"] = exportData;
+
+        return (series, legend);
+    }
+
+    /// <summary>
+    /// Loads returns by category as a pie chart.
+    /// Uses ReportChartDataService for data fetching.
+    /// </summary>
+    public (ObservableCollection<ISeries> Series, ObservableCollection<PieLegendItem> Legend) LoadReturnsByCategoryChart(
+        CompanyData? companyData,
+        DateTime? startDate = null,
+        DateTime? endDate = null)
+    {
+        var filters = CreateFilters(startDate, endDate);
+        filters.IncludeReturns = true;
+        var dataService = new ReportChartDataService(companyData, filters);
+
+        var dataPoints = dataService.GetReturnsByCategory().ToList();
+
+        if (dataPoints.Count == 0)
+            return ([], []);
+
+        var (series, legend) = CreatePieSeriesWithLegend(dataPoints);
+
+        // Store export data
+        _chartExportDataByTitle["Returns by Category"] = new ChartExportData
+        {
+            ChartTitle = "Returns by Category",
+            ChartType = ChartType.Distribution,
+            Labels = dataPoints.Select(p => p.Label).ToArray(),
+            Values = dataPoints.Select(p => p.Value).ToArray(),
+            SeriesName = "Count"
+        };
 
         return (series, legend);
     }

--- a/ArgoBooks/Services/LanguageService.cs
+++ b/ArgoBooks/Services/LanguageService.cs
@@ -306,7 +306,7 @@ public partial class LanguageService
             TranslationProgress?.Invoke(this, new TranslationProgressEventArgs(languageName, true, "Downloading translations..."));
 
             // Get app version for download URL
-            var version = GetAppVersion();
+            var version = ArgoBooks.Core.Services.AppInfo.VersionNumber;
             var downloadUrl = string.Format(DownloadUrlTemplate, version, isoCode);
 
             System.Diagnostics.Debug.WriteLine($"LanguageService: Downloading from {downloadUrl}");
@@ -558,27 +558,6 @@ public partial class LanguageService
         }
 
         return $"str_{cleanText}";
-    }
-
-    /// <summary>
-    /// Gets the current app version for download URL.
-    /// </summary>
-    private static string GetAppVersion()
-    {
-        try
-        {
-            var version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
-            if (version != null)
-            {
-                return $"{version.Major}.{version.Minor}.{version.Build}";
-            }
-        }
-        catch
-        {
-            // Ignore errors getting version
-        }
-
-        return "1.0.0";
     }
 
     /// <summary>

--- a/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
@@ -875,6 +875,15 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
     private bool _hasReturnReasonsData;
 
     [ObservableProperty]
+    private ObservableCollection<ISeries> _returnsByCategorySeries = [];
+
+    [ObservableProperty]
+    private ObservableCollection<PieLegendItem> _returnsByCategoryLegend = [];
+
+    [ObservableProperty]
+    private bool _hasReturnsByCategoryData;
+
+    [ObservableProperty]
     private ObservableCollection<ISeries> _returnFinancialImpactSeries = [];
 
     [ObservableProperty]
@@ -1491,6 +1500,7 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
         // Returns charts
         LoadReturnsOverTimeChart(data);
         LoadReturnReasonsChart(data);
+        LoadReturnsByCategoryChart(data);
         LoadReturnFinancialImpactChart(data);
         LoadReturnsByProductChart(data);
         LoadExpenseVsRevenueReturnsChart(data);
@@ -1684,6 +1694,14 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
         ReturnReasonsSeries = series;
         ReturnReasonsLegend = legend;
         HasReturnReasonsData = series.Count > 0;
+    }
+
+    private void LoadReturnsByCategoryChart(CompanyData data)
+    {
+        var (series, legend) = _chartLoaderService.LoadReturnsByCategoryChart(data, StartDate, EndDate);
+        ReturnsByCategorySeries = series;
+        ReturnsByCategoryLegend = legend;
+        HasReturnsByCategoryData = series.Count > 0;
     }
 
     private void LoadReturnFinancialImpactChart(CompanyData data)

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -1346,6 +1346,17 @@ public partial class ReportsPageViewModel : ViewModelBase
             {
                 ExportMessage = "Export completed successfully!";
 
+                // Auto-dismiss success message after 5 seconds
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(5000);
+                    Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                    {
+                        if (ExportMessage == "Export completed successfully!")
+                            ExportMessage = string.Empty;
+                    });
+                });
+
                 // Save export settings for next time
                 await SaveExportSettingsAsync();
 

--- a/ArgoBooks/Views/AnalyticsPage.axaml
+++ b/ArgoBooks/Views/AnalyticsPage.axaml
@@ -1303,8 +1303,8 @@
                                 Padding="10"
                                 Margin="12,0,0,0">
                             <Panel>
-                                <!-- Pie Chart with custom legend - reusing Return Reasons -->
-                                <Grid RowDefinitions="Auto,*" IsVisible="{Binding HasReturnReasonsData}">
+                                <!-- Pie Chart with custom legend -->
+                                <Grid RowDefinitions="Auto,*" IsVisible="{Binding HasReturnsByCategoryData}">
                                     <TextBlock Grid.Row="0"
                                                Text="{loc:Loc 'Returns by Category'}"
                                                HorizontalAlignment="Center"
@@ -1316,12 +1316,12 @@
                                         <lvc:PieChart Grid.Column="0"
                                                       PointerPressed="OnChartPointerPressed"
                                                     PointerReleased="OnChartPointerReleased"
-                                                      Series="{Binding ReturnReasonsSeries}"
+                                                      Series="{Binding ReturnsByCategorySeries}"
                                                       LegendPosition="Hidden" />
                                         <controls:PieChartLegend Grid.Column="1"
                                                                  PointerPressed="OnChartPointerPressed"
                                                     PointerReleased="OnChartPointerReleased"
-                                                                 Items="{Binding ReturnReasonsLegend}"
+                                                                 Items="{Binding ReturnsByCategoryLegend}"
                                                                  MaxHeightOverride="240"
                                                                  Width="200"
                                                                  Margin="8,0,0,0"
@@ -1331,7 +1331,7 @@
                                 <!-- No data placeholder -->
                                 <Border Background="{DynamicResource SurfaceAltBrush}"
                                         CornerRadius="8"
-                                        IsVisible="{Binding !HasReturnReasonsData}">
+                                        IsVisible="{Binding !HasReturnsByCategoryData}">
                                     <TextBlock Text="{loc:Loc 'No category data available'}"
                                                HorizontalAlignment="Center"
                                                VerticalAlignment="Center"

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -1099,12 +1099,11 @@
                                                 Value="{Binding SelectedImageElement.Opacity}"
                                                 Minimum="0" Maximum="100"
                                                 VerticalAlignment="Center" />
-                                        <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="8,0,0,0">
-                                            <controls:ArgoNumericUpDown Value="{Binding SelectedImageElement.Opacity}"
-                                                           Minimum="0" Maximum="100"
-                                                           Width="70"
-                                                           Increment="1" />
-                                        </StackPanel>
+                                        <TextBox Grid.Column="1"
+                                                 Text="{Binding SelectedImageElement.Opacity}"
+                                                 Width="50"
+                                                 Margin="8,0,0,0"
+                                                 VerticalAlignment="Center" />
                                     </Grid>
                                 </StackPanel>
                                 <StackPanel Spacing="4">


### PR DESCRIPTION
- Fix sample company showing 'Creating' message when opening
- Consolidate version-getting methods into common AppInfo class in Core
- Fix sample company time-shift not persisting by saving after shift
- Time-shift now only uses revenue/expense dates for dashboard view
- Change Customer Growth chart color from purple to blue
- Fix Returns by Category chart showing wrong data (separate loader)
- Fix opacity control text overflow in image element properties
- Auto-dismiss export success message after 5 seconds
- Limit report templates to maximum 4 charts (2x2 grid layout)
- Fix null reference warning in import notification