### PR TITLE
Add revenue transaction support to receipt scanning

### DIFF
--- a/ArgoBooks/Converters/BoolConverters.cs
+++ b/ArgoBooks/Converters/BoolConverters.cs
@@ -228,6 +228,12 @@ public static class BoolConverters
     /// </summary>
     public static readonly IValueConverter ToCircleBorderThickness =
         new FuncValueConverter<bool, Thickness>(value => value ? new Thickness(0) : new Thickness(2));
+
+    /// <summary>
+    /// Multi-value converter that returns one of two brushes based on a boolean condition.
+    /// Values[0] = bool condition, Values[1] = brush when true, Values[2] = brush when false.
+    /// </summary>
+    public static readonly IMultiValueConverter ToConditionalBrush = new ConditionalBrushMultiConverter();
 }
 
 /// <summary>
@@ -552,4 +558,23 @@ public class FullscreenMinMaxConverter : IValueConverter
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Multi-value converter that returns one of two brushes based on a boolean condition.
+/// Values[0] = bool condition, Values[1] = brush when true, Values[2] = brush when false.
+/// </summary>
+public class ConditionalBrushMultiConverter : IMultiValueConverter
+{
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Count < 3)
+            return Brushes.Transparent;
+
+        var condition = values[0] is bool b && b;
+        var trueBrush = values[1] as IBrush ?? Brushes.Transparent;
+        var falseBrush = values[2] as IBrush ?? Brushes.Transparent;
+
+        return condition ? trueBrush : falseBrush;
+    }
 }

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -620,53 +620,116 @@
                                             </StackPanel>
                                         </Border>
 
-                                        <!-- Transaction Type Toggle (Expense/Revenue) -->
-                                        <Border Background="{DynamicResource SurfaceAltBrush}"
-                                                CornerRadius="8"
-                                                Padding="16,12"
-                                                Margin="0,0,0,12">
-                                            <Grid ColumnDefinitions="*,Auto">
-                                                <StackPanel Grid.Column="0" Spacing="2">
-                                                    <TextBlock Text="{loc:Loc 'Transaction Type'}"
-                                                               FontSize="13"
-                                                               FontWeight="Medium"
-                                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                    <TextBlock Text="{loc:Loc 'Based on merchant matching your company name'}"
-                                                               FontSize="11"
-                                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                                </StackPanel>
-                                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                                                    <TextBlock Text="{loc:Loc 'Expense'}"
-                                                               FontSize="13"
-                                                               FontWeight="Medium"
-                                                               VerticalAlignment="Center">
-                                                        <TextBlock.Foreground>
-                                                            <MultiBinding Converter="{x:Static local:BoolConverters.ToConditionalBrush}">
-                                                                <Binding Path="IsRevenue" />
-                                                                <Binding Source="{DynamicResource TextTertiaryBrush}" />
-                                                                <Binding Source="{DynamicResource TextPrimaryBrush}" />
-                                                            </MultiBinding>
-                                                        </TextBlock.Foreground>
-                                                    </TextBlock>
-                                                    <ToggleSwitch IsChecked="{Binding IsRevenue}"
-                                                                  IsEnabled="{Binding !IsLoadingAiSuggestions}"
-                                                                  OffContent=""
-                                                                  OnContent="" />
-                                                    <TextBlock Text="{loc:Loc 'Revenue'}"
-                                                               FontSize="13"
-                                                               FontWeight="Medium"
-                                                               VerticalAlignment="Center">
-                                                        <TextBlock.Foreground>
-                                                            <MultiBinding Converter="{x:Static local:BoolConverters.ToConditionalBrush}">
-                                                                <Binding Path="IsRevenue" />
-                                                                <Binding Source="{DynamicResource TextPrimaryBrush}" />
-                                                                <Binding Source="{DynamicResource TextTertiaryBrush}" />
-                                                            </MultiBinding>
-                                                        </TextBlock.Foreground>
-                                                    </TextBlock>
-                                                </StackPanel>
-                                            </Grid>
-                                        </Border>
+                                        <!-- Transaction Type Tabs (Expense/Revenue) -->
+                                        <StackPanel Spacing="8" Margin="0,0,0,12">
+                                            <TextBlock Text="{loc:Loc 'Transaction Type'}"
+                                                       FontSize="13"
+                                                       FontWeight="Medium"
+                                                       Foreground="{DynamicResource TextSecondaryBrush}" />
+                                            <Border Background="{DynamicResource SurfaceAltBrush}"
+                                                    CornerRadius="8"
+                                                    Padding="4"
+                                                    IsEnabled="{Binding !IsLoadingAiSuggestions}">
+                                                <Grid ColumnDefinitions="*,*">
+                                                    <!-- Expense Tab -->
+                                                    <Button Grid.Column="0"
+                                                            Command="{Binding SetTransactionTypeCommand}"
+                                                            CommandParameter="Expense"
+                                                            HorizontalAlignment="Stretch"
+                                                            HorizontalContentAlignment="Center"
+                                                            Padding="12,10"
+                                                            CornerRadius="6"
+                                                            Cursor="Hand">
+                                                        <Button.Styles>
+                                                            <Style Selector="Button">
+                                                                <Setter Property="Background" Value="Transparent" />
+                                                                <Setter Property="BorderThickness" Value="0" />
+                                                                <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
+                                                            </Style>
+                                                            <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                                                                <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+                                                            </Style>
+                                                        </Button.Styles>
+                                                        <Panel>
+                                                            <!-- Selected state background -->
+                                                            <Border IsVisible="{Binding !IsRevenue}"
+                                                                    Background="{DynamicResource SurfaceBrush}"
+                                                                    CornerRadius="6"
+                                                                    BoxShadow="0 1 2 0 #0000000D" />
+                                                            <StackPanel Orientation="Horizontal"
+                                                                        Spacing="8"
+                                                                        HorizontalAlignment="Center"
+                                                                        Margin="0,1">
+                                                                <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                                                          Width="16" Height="16"
+                                                                          IsVisible="{Binding !IsRevenue}"
+                                                                          Foreground="{DynamicResource PrimaryBrush}" />
+                                                                <TextBlock Text="{loc:Loc 'Expense'}"
+                                                                           FontSize="13"
+                                                                           FontWeight="Medium"
+                                                                           VerticalAlignment="Center">
+                                                                    <TextBlock.Foreground>
+                                                                        <MultiBinding Converter="{x:Static local:BoolConverters.ToConditionalBrush}">
+                                                                            <Binding Path="IsRevenue" />
+                                                                            <Binding Source="{DynamicResource TextSecondaryBrush}" />
+                                                                            <Binding Source="{DynamicResource TextPrimaryBrush}" />
+                                                                        </MultiBinding>
+                                                                    </TextBlock.Foreground>
+                                                                </TextBlock>
+                                                            </StackPanel>
+                                                        </Panel>
+                                                    </Button>
+                                                    <!-- Revenue Tab -->
+                                                    <Button Grid.Column="1"
+                                                            Command="{Binding SetTransactionTypeCommand}"
+                                                            CommandParameter="Revenue"
+                                                            HorizontalAlignment="Stretch"
+                                                            HorizontalContentAlignment="Center"
+                                                            Padding="12,10"
+                                                            CornerRadius="6"
+                                                            Cursor="Hand">
+                                                        <Button.Styles>
+                                                            <Style Selector="Button">
+                                                                <Setter Property="Background" Value="Transparent" />
+                                                                <Setter Property="BorderThickness" Value="0" />
+                                                                <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
+                                                            </Style>
+                                                            <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                                                                <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+                                                            </Style>
+                                                        </Button.Styles>
+                                                        <Panel>
+                                                            <!-- Selected state background -->
+                                                            <Border IsVisible="{Binding IsRevenue}"
+                                                                    Background="{DynamicResource SurfaceBrush}"
+                                                                    CornerRadius="6"
+                                                                    BoxShadow="0 1 2 0 #0000000D" />
+                                                            <StackPanel Orientation="Horizontal"
+                                                                        Spacing="8"
+                                                                        HorizontalAlignment="Center"
+                                                                        Margin="0,1">
+                                                                <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                                                                          Width="16" Height="16"
+                                                                          IsVisible="{Binding IsRevenue}"
+                                                                          Foreground="{DynamicResource SuccessBrush}" />
+                                                                <TextBlock Text="{loc:Loc 'Revenue'}"
+                                                                           FontSize="13"
+                                                                           FontWeight="Medium"
+                                                                           VerticalAlignment="Center">
+                                                                    <TextBlock.Foreground>
+                                                                        <MultiBinding Converter="{x:Static local:BoolConverters.ToConditionalBrush}">
+                                                                            <Binding Path="IsRevenue" />
+                                                                            <Binding Source="{DynamicResource TextPrimaryBrush}" />
+                                                                            <Binding Source="{DynamicResource TextSecondaryBrush}" />
+                                                                        </MultiBinding>
+                                                                    </TextBlock.Foreground>
+                                                                </TextBlock>
+                                                            </StackPanel>
+                                                        </Panel>
+                                                    </Button>
+                                                </Grid>
+                                            </Border>
+                                        </StackPanel>
 
                                         <!-- Supplier and Category Row -->
                                         <Grid ColumnDefinitions="*,16,*">

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -620,9 +620,58 @@
                                             </StackPanel>
                                         </Border>
 
+                                        <!-- Transaction Type Toggle (Expense/Revenue) -->
+                                        <Border Background="{DynamicResource SurfaceAltBrush}"
+                                                CornerRadius="8"
+                                                Padding="16,12"
+                                                Margin="0,0,0,12">
+                                            <Grid ColumnDefinitions="*,Auto">
+                                                <StackPanel Grid.Column="0" Spacing="2">
+                                                    <TextBlock Text="{loc:Loc 'Transaction Type'}"
+                                                               FontSize="13"
+                                                               FontWeight="Medium"
+                                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                    <TextBlock Text="{loc:Loc 'Based on merchant matching your company name'}"
+                                                               FontSize="11"
+                                                               Foreground="{DynamicResource TextTertiaryBrush}" />
+                                                </StackPanel>
+                                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                                                    <TextBlock Text="{loc:Loc 'Expense'}"
+                                                               FontSize="13"
+                                                               FontWeight="Medium"
+                                                               VerticalAlignment="Center">
+                                                        <TextBlock.Foreground>
+                                                            <MultiBinding Converter="{x:Static local:BoolConverters.ToConditionalBrush}">
+                                                                <Binding Path="IsRevenue" />
+                                                                <Binding Source="{DynamicResource TextTertiaryBrush}" />
+                                                                <Binding Source="{DynamicResource TextPrimaryBrush}" />
+                                                            </MultiBinding>
+                                                        </TextBlock.Foreground>
+                                                    </TextBlock>
+                                                    <ToggleSwitch IsChecked="{Binding IsRevenue}"
+                                                                  IsEnabled="{Binding !IsLoadingAiSuggestions}"
+                                                                  OffContent=""
+                                                                  OnContent="" />
+                                                    <TextBlock Text="{loc:Loc 'Revenue'}"
+                                                               FontSize="13"
+                                                               FontWeight="Medium"
+                                                               VerticalAlignment="Center">
+                                                        <TextBlock.Foreground>
+                                                            <MultiBinding Converter="{x:Static local:BoolConverters.ToConditionalBrush}">
+                                                                <Binding Path="IsRevenue" />
+                                                                <Binding Source="{DynamicResource TextPrimaryBrush}" />
+                                                                <Binding Source="{DynamicResource TextTertiaryBrush}" />
+                                                            </MultiBinding>
+                                                        </TextBlock.Foreground>
+                                                    </TextBlock>
+                                                </StackPanel>
+                                            </Grid>
+                                        </Border>
+
                                         <!-- Supplier and Category Row -->
                                         <Grid ColumnDefinitions="*,16,*">
-                                            <StackPanel Grid.Column="0" Spacing="6">
+                                            <StackPanel Grid.Column="0" Spacing="6"
+                                                        IsVisible="{Binding !IsRevenue}">
                                                 <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                                     <Run Text="{loc:Loc 'Supplier'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
                                                 </TextBlock>
@@ -636,7 +685,8 @@
                                                     EmptyCreateLinkText="{loc:Loc 'Create one'}"
                                                     EmptyCreateCommand="{Binding NavigateToCreateSupplierCommand}"
                                                     HasError="{Binding HasSupplierError}"
-                                                    ErrorMessage="{Binding SupplierErrorMessage}" />
+                                                    ErrorMessage="{Binding SupplierErrorMessage}"
+                                                    IsEnabled="{Binding !IsLoadingAiSuggestions}" />
                                                 <!-- AI Create Supplier Suggestion -->
                                                 <Border IsVisible="{Binding ShowCreateSupplierSuggestion}"
                                                         Background="{DynamicResource WarningLightBrush}"
@@ -687,7 +737,8 @@
                                                     EmptyCreateLinkText="{loc:Loc 'Create one'}"
                                                     EmptyCreateCommand="{Binding NavigateToCreateCategoryCommand}"
                                                     HasError="{Binding HasCategoryError}"
-                                                    ErrorMessage="{Binding CategoryErrorMessage}" />
+                                                    ErrorMessage="{Binding CategoryErrorMessage}"
+                                                    IsEnabled="{Binding !IsLoadingAiSuggestions}" />
                                                 <!-- AI Create Category Suggestion -->
                                                 <Border IsVisible="{Binding ShowCreateCategorySuggestion}"
                                                         Background="{DynamicResource WarningLightBrush}"
@@ -775,7 +826,7 @@
                                 <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
                                           Width="16" Height="16"
                                           Foreground="{DynamicResource TextTertiaryBrush}" />
-                                <TextBlock Text="{loc:Loc 'Review the extracted data before creating the expense.'}"
+                                <TextBlock Text="{loc:Loc 'Review the extracted data before creating the transaction.'}"
                                            FontSize="13"
                                            Foreground="{DynamicResource TextTertiaryBrush}"
                                            VerticalAlignment="Center" />
@@ -787,11 +838,13 @@
                                     Command="{Binding RequestCloseScanReviewModalCommand}" />
                             <Button Grid.Column="2"
                                     Classes="primary-button"
-                                    Command="{Binding CreateExpenseCommand}">
+                                    Command="{Binding CreateTransactionCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <PathIcon Data="{x:Static icons:Icons.Check}"
                                               Width="16" Height="16" />
-                                    <TextBlock Text="{loc:Loc 'Create Expense'}" />
+                                    <!-- Show "Create Revenue" when IsRevenue, otherwise "Create Expense" -->
+                                    <TextBlock IsVisible="{Binding IsRevenue}" Text="{loc:Loc 'Create Revenue'}" />
+                                    <TextBlock IsVisible="{Binding !IsRevenue}" Text="{loc:Loc 'Create Expense'}" />
                                 </StackPanel>
                             </Button>
                         </Grid>

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -626,109 +626,55 @@
                                                        FontSize="13"
                                                        FontWeight="Medium"
                                                        Foreground="{DynamicResource TextSecondaryBrush}" />
-                                            <Border Background="{DynamicResource SurfaceAltBrush}"
-                                                    CornerRadius="8"
-                                                    Padding="4"
-                                                    IsEnabled="{Binding !IsLoadingAiSuggestions}">
-                                                <Grid ColumnDefinitions="*,*">
-                                                    <!-- Expense Tab -->
-                                                    <Button Grid.Column="0"
-                                                            Command="{Binding SetTransactionTypeCommand}"
-                                                            CommandParameter="Expense"
-                                                            HorizontalAlignment="Stretch"
-                                                            HorizontalContentAlignment="Center"
-                                                            Padding="12,10"
-                                                            CornerRadius="6"
-                                                            Cursor="Hand">
-                                                        <Button.Styles>
-                                                            <Style Selector="Button">
-                                                                <Setter Property="Background" Value="Transparent" />
-                                                                <Setter Property="BorderThickness" Value="0" />
-                                                                <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
-                                                            </Style>
-                                                            <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-                                                                <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
-                                                            </Style>
-                                                        </Button.Styles>
-                                                        <Panel>
-                                                            <!-- Selected state background -->
-                                                            <Border IsVisible="{Binding !IsRevenue}"
-                                                                    Background="{DynamicResource SurfaceBrush}"
-                                                                    CornerRadius="6"
-                                                                    BoxShadow="0 1 2 0 #0000000D" />
-                                                            <StackPanel Orientation="Horizontal"
-                                                                        Spacing="8"
-                                                                        HorizontalAlignment="Center"
-                                                                        Margin="0,1">
-                                                                <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                                                                          Width="16" Height="16"
-                                                                          IsVisible="{Binding !IsRevenue}"
-                                                                          Foreground="{DynamicResource PrimaryBrush}" />
-                                                                <TextBlock Text="{loc:Loc 'Expense'}"
-                                                                           FontSize="13"
-                                                                           FontWeight="Medium"
-                                                                           VerticalAlignment="Center">
-                                                                    <TextBlock.Foreground>
-                                                                        <MultiBinding Converter="{x:Static local:BoolConverters.ToConditionalBrush}">
-                                                                            <Binding Path="IsRevenue" />
-                                                                            <Binding Source="{DynamicResource TextSecondaryBrush}" />
-                                                                            <Binding Source="{DynamicResource TextPrimaryBrush}" />
-                                                                        </MultiBinding>
-                                                                    </TextBlock.Foreground>
-                                                                </TextBlock>
-                                                            </StackPanel>
-                                                        </Panel>
-                                                    </Button>
-                                                    <!-- Revenue Tab -->
-                                                    <Button Grid.Column="1"
-                                                            Command="{Binding SetTransactionTypeCommand}"
-                                                            CommandParameter="Revenue"
-                                                            HorizontalAlignment="Stretch"
-                                                            HorizontalContentAlignment="Center"
-                                                            Padding="12,10"
-                                                            CornerRadius="6"
-                                                            Cursor="Hand">
-                                                        <Button.Styles>
-                                                            <Style Selector="Button">
-                                                                <Setter Property="Background" Value="Transparent" />
-                                                                <Setter Property="BorderThickness" Value="0" />
-                                                                <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
-                                                            </Style>
-                                                            <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-                                                                <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
-                                                            </Style>
-                                                        </Button.Styles>
-                                                        <Panel>
-                                                            <!-- Selected state background -->
-                                                            <Border IsVisible="{Binding IsRevenue}"
-                                                                    Background="{DynamicResource SurfaceBrush}"
-                                                                    CornerRadius="6"
-                                                                    BoxShadow="0 1 2 0 #0000000D" />
-                                                            <StackPanel Orientation="Horizontal"
-                                                                        Spacing="8"
-                                                                        HorizontalAlignment="Center"
-                                                                        Margin="0,1">
-                                                                <PathIcon Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                                                                          Width="16" Height="16"
-                                                                          IsVisible="{Binding IsRevenue}"
-                                                                          Foreground="{DynamicResource SuccessBrush}" />
-                                                                <TextBlock Text="{loc:Loc 'Revenue'}"
-                                                                           FontSize="13"
-                                                                           FontWeight="Medium"
-                                                                           VerticalAlignment="Center">
-                                                                    <TextBlock.Foreground>
-                                                                        <MultiBinding Converter="{x:Static local:BoolConverters.ToConditionalBrush}">
-                                                                            <Binding Path="IsRevenue" />
-                                                                            <Binding Source="{DynamicResource TextPrimaryBrush}" />
-                                                                            <Binding Source="{DynamicResource TextSecondaryBrush}" />
-                                                                        </MultiBinding>
-                                                                    </TextBlock.Foreground>
-                                                                </TextBlock>
-                                                            </StackPanel>
-                                                        </Panel>
-                                                    </Button>
-                                                </Grid>
-                                            </Border>
+                                            <Grid ColumnDefinitions="*,*">
+                                                <Grid.Styles>
+                                                    <Style Selector="Button.transaction-type-tab">
+                                                        <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+                                                        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
+                                                        <Setter Property="BorderThickness" Value="1" />
+                                                        <Setter Property="Padding" Value="16,12" />
+                                                        <Setter Property="Cursor" Value="Hand" />
+                                                        <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                                                        <Setter Property="FontSize" Value="13" />
+                                                        <Setter Property="FontWeight" Value="Medium" />
+                                                        <Setter Property="CornerRadius" Value="8,0,0,8" />
+                                                    </Style>
+                                                    <Style Selector="Button.transaction-type-tab /template/ ContentPresenter#PART_ContentPresenter">
+                                                        <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+                                                    </Style>
+                                                    <Style Selector="Button.transaction-type-tab:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                                                        <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
+                                                    </Style>
+                                                    <Style Selector="Button.transaction-type-tab.selected">
+                                                        <Setter Property="Background" Value="{DynamicResource PrimaryBrush}" />
+                                                        <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
+                                                        <Setter Property="Foreground" Value="White" />
+                                                    </Style>
+                                                    <Style Selector="Button.transaction-type-tab.selected /template/ ContentPresenter#PART_ContentPresenter">
+                                                        <Setter Property="Background" Value="{DynamicResource PrimaryBrush}" />
+                                                    </Style>
+                                                    <Style Selector="Button.transaction-type-tab.right">
+                                                        <Setter Property="CornerRadius" Value="0,8,8,0" />
+                                                    </Style>
+                                                </Grid.Styles>
+                                                <!-- Expense Tab -->
+                                                <Button Grid.Column="0"
+                                                        Content="{loc:Loc 'Expense'}"
+                                                        Classes="transaction-type-tab"
+                                                        Classes.selected="{Binding !IsRevenue}"
+                                                        Command="{Binding SetTransactionTypeCommand}"
+                                                        CommandParameter="Expense"
+                                                        IsEnabled="{Binding !IsLoadingAiSuggestions}" />
+                                                <!-- Revenue Tab -->
+                                                <Button Grid.Column="1"
+                                                        Content="{loc:Loc 'Revenue'}"
+                                                        Classes="transaction-type-tab right"
+                                                        Classes.selected="{Binding IsRevenue}"
+                                                        Command="{Binding SetTransactionTypeCommand}"
+                                                        CommandParameter="Revenue"
+                                                        IsEnabled="{Binding !IsLoadingAiSuggestions}" />
+                                            </Grid>
                                         </StackPanel>
 
                                         <!-- Supplier and Category Row -->

--- a/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
@@ -309,6 +309,15 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
         SelectedCategory = null;
     }
 
+    /// <summary>
+    /// Sets the transaction type (expense or revenue).
+    /// </summary>
+    [RelayCommand]
+    private void SetTransactionType(string type)
+    {
+        IsRevenue = type == "Revenue";
+    }
+
     public ObservableCollection<SupplierOption> SupplierOptions { get; } = [];
     public ObservableCollection<CategoryOption> CategoryOptions { get; } = [];
     public ObservableCollection<ProductOption> ProductOptions { get; } = [];


### PR DESCRIPTION
## Summary
This PR adds support for revenue transactions alongside expense transactions in the receipt scanning workflow. The system now automatically detects whether a scanned receipt represents revenue or an expense by comparing the extracted merchant name against the user's company name.

## Key Changes

### Core Functionality
- **Transaction Type Detection**: Implemented `DetectTransactionType()` method that intelligently compares merchant names against company name using multiple matching strategies (exact match, substring match, word-level similarity)
- **Revenue Transaction Creation**: Added `CreateRevenueTransaction()` method to handle revenue transaction creation with proper ID generation and undo/redo support
- **Refactored Expense Creation**: Extracted expense logic into `CreateExpenseTransaction()` method for better code organization
- **UI Transaction Type Selector**: Added toggle buttons to manually switch between Expense and Revenue transaction types

### UI Updates
- Added transaction type tab selector (Expense/Revenue) in the receipt review modal
- Made supplier field conditional - only visible and required for expense transactions
- Updated button labels to dynamically show "Create Expense" or "Create Revenue" based on selected type
- Updated help text from "expense" to "transaction" for clarity
- Disabled supplier and category inputs while AI suggestions are loading

### Data Model Changes
- Added `IsRevenue` observable property to track transaction type
- Added `TransactionTypeLabel` computed property for UI display
- Added `SetTransactionType()` relay command for manual type switching
- Category options now load based on transaction type (Revenue vs Expense categories)

### New Converter
- Added `ConditionalBrushMultiConverter` - a multi-value converter that returns one of two brushes based on a boolean condition, useful for dynamic styling based on transaction type

## Implementation Details
- Transaction type detection uses normalized string comparison to handle variations like "ACME Inc" vs "ACME"
- Common business suffixes (Inc, LLC, Ltd, Corp, etc.) are stripped during comparison
- Word-level matching requires 50% similarity threshold for positive match
- Both revenue and receipt records are created together with proper ID generation
- Full undo/redo support for both transaction types with appropriate action descriptions

https://claude.ai/code/session_01PwYsCmLijkrvF37bDgfnCT