### PR TITLE
Persist column visibility settings across app restarts

### DIFF
--- a/ArgoBooks.Core/Models/GlobalSettings.cs
+++ b/ArgoBooks.Core/Models/GlobalSettings.cs
@@ -49,6 +49,12 @@ public class UiSettings
     public ChartSettings Chart { get; set; } = new();
     public QuickActionsSettings QuickActions { get; set; } = new();
     public EmojiPickerSettings EmojiPicker { get; set; } = new();
+
+    /// <summary>
+    /// Persisted column visibility settings per page.
+    /// Key is the page name (e.g., "Expenses"), value is a dictionary of column name to visibility.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, bool>> ColumnVisibility { get; set; } = new();
 }
 
 public class EmojiPickerSettings

--- a/ArgoBooks/Controls/ArgoTable/ArgoTable.axaml
+++ b/ArgoBooks/Controls/ArgoTable/ArgoTable.axaml
@@ -92,8 +92,14 @@
                         </Button>
 
                         <!-- Extra Buttons Content (slot for additional buttons) -->
-                        <ContentPresenter Content="{Binding #Root.ExtraButtonsContent}"
-                                          IsVisible="{Binding #Root.ExtraButtonsContent, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                        <ContentPresenter Content="{Binding #Root.ExtraButtonsContent}">
+                            <ContentPresenter.IsVisible>
+                                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                    <Binding Path="#Root.ExtraButtonsContent" Converter="{x:Static ObjectConverters.IsNotNull}" />
+                                    <Binding Path="#Root.ShowExtraButtons" />
+                                </MultiBinding>
+                            </ContentPresenter.IsVisible>
+                        </ContentPresenter>
 
                         <!-- Add Button -->
                         <Button Classes="primary-button"

--- a/ArgoBooks/Controls/ArgoTable/ArgoTable.axaml.cs
+++ b/ArgoBooks/Controls/ArgoTable/ArgoTable.axaml.cs
@@ -83,6 +83,9 @@ public partial class ArgoTable : UserControl, INotifyPropertyChanged
     public static readonly StyledProperty<object?> ExtraButtonsContentProperty =
         AvaloniaProperty.Register<ArgoTable, object?>(nameof(ExtraButtonsContent));
 
+    public static readonly StyledProperty<bool> ShowExtraButtonsProperty =
+        AvaloniaProperty.Register<ArgoTable, bool>(nameof(ShowExtraButtons), true);
+
     // Add Button
     public static readonly StyledProperty<bool> ShowAddButtonProperty =
         AvaloniaProperty.Register<ArgoTable, bool>(nameof(ShowAddButton), true);
@@ -267,6 +270,12 @@ public partial class ArgoTable : UserControl, INotifyPropertyChanged
     {
         get => GetValue(ExtraButtonsContentProperty);
         set => SetValue(ExtraButtonsContentProperty, value);
+    }
+
+    public bool ShowExtraButtons
+    {
+        get => GetValue(ShowExtraButtonsProperty);
+        set => SetValue(ShowExtraButtonsProperty, value);
     }
 
     public bool ShowAddButton

--- a/ArgoBooks/Helpers/ColumnVisibilityHelper.cs
+++ b/ArgoBooks/Helpers/ColumnVisibilityHelper.cs
@@ -1,0 +1,48 @@
+namespace ArgoBooks.Helpers;
+
+/// <summary>
+/// Helper for persisting column visibility settings across app restarts.
+/// </summary>
+public static class ColumnVisibilityHelper
+{
+    /// <summary>
+    /// Loads a saved column visibility value, or returns the default if not found.
+    /// </summary>
+    public static bool Load(string pageName, string columnName, bool defaultValue)
+    {
+        var settings = App.SettingsService?.GlobalSettings?.Ui;
+        if (settings == null)
+            return defaultValue;
+
+        if (settings.ColumnVisibility.TryGetValue(pageName, out var pageColumns) &&
+            pageColumns.TryGetValue(columnName, out var isVisible))
+        {
+            return isVisible;
+        }
+
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Saves a column visibility value and persists to disk.
+    /// </summary>
+    public static void Save(string pageName, string columnName, bool isVisible)
+    {
+        var settings = App.SettingsService?.GlobalSettings?.Ui;
+        if (settings == null)
+            return;
+
+        if (!settings.ColumnVisibility.TryGetValue(pageName, out var pageColumns))
+        {
+            pageColumns = new Dictionary<string, bool>();
+            settings.ColumnVisibility[pageName] = pageColumns;
+        }
+
+        // Only save to disk if value actually changed
+        if (pageColumns.TryGetValue(columnName, out var existing) && existing == isVisible)
+            return;
+
+        pageColumns[columnName] = isVisible;
+        _ = App.SettingsService!.SaveGlobalSettingsAsync();
+    }
+}

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -180,7 +180,7 @@
                 <Border HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Width="{Binding ModalWidth}"
-                    MaxHeight="750"
+                    MaxHeight="850"
                     Background="{DynamicResource SurfaceBrush}"
                     CornerRadius="12"
                     BoxShadow="0 8 32 0 #40000000">
@@ -306,7 +306,7 @@
 
                             <!-- Results State -->
                             <Grid IsVisible="{Binding HasScanResult}"
-                                  ColumnDefinitions="320,*"
+                                  ColumnDefinitions="2*,3*"
                                   Margin="24">
                                 <!-- Left: Receipt Preview -->
                                 <Border Grid.Column="0"
@@ -326,8 +326,7 @@
                                                 Margin="8,0,8,8"
                                                 CornerRadius="4">
                                             <Image Source="{Binding ReceiptImagePath, Converter={x:Static local:BoolConverters.ToImageSource}}"
-                                                   Stretch="Uniform"
-                                                   MaxHeight="400" />
+                                                   Stretch="Uniform" />
                                         </Border>
                                     </Grid>
                                 </Border>
@@ -478,7 +477,7 @@
                                             <Grid ColumnDefinitions="*,70,80,80,32">
                                                 <TextBlock Grid.Column="0" Text="{loc:Loc 'Product'}" FontSize="12" FontWeight="Medium"
                                                            Foreground="{DynamicResource TextTertiaryBrush}" />
-                                                <TextBlock Grid.Column="1" Text="{loc:Loc 'Qty'}" FontSize="12" FontWeight="Medium"
+                                                <TextBlock Grid.Column="1" Text="{loc:Loc 'Quantity'}" FontSize="12" FontWeight="Medium"
                                                            Foreground="{DynamicResource TextTertiaryBrush}"
                                                            HorizontalAlignment="Center" />
                                                 <TextBlock Grid.Column="2" Text="{loc:Loc 'Unit Price'}" FontSize="12" FontWeight="Medium"
@@ -677,9 +676,9 @@
                                             </Grid>
                                         </StackPanel>
 
-                                        <!-- Supplier and Category Row -->
-                                        <Grid ColumnDefinitions="*,16,*">
-                                            <StackPanel Grid.Column="0" Spacing="6"
+                                        <!-- Supplier Row -->
+                                        <Grid>
+                                            <StackPanel Spacing="6"
                                                         IsVisible="{Binding !IsRevenue}">
                                                 <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
                                                     <Run Text="{loc:Loc 'Supplier'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
@@ -720,58 +719,6 @@
                                                                 FontSize="11" />
                                                         <Button Grid.Column="2"
                                                                 Command="{Binding DismissSupplierSuggestionCommand}"
-                                                                Background="Transparent"
-                                                                BorderThickness="0"
-                                                                Padding="8,4"
-                                                                Margin="4,0,0,0"
-                                                                Cursor="Hand">
-                                                            <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                                                      Width="14" Height="14"
-                                                                      Foreground="#92400E" />
-                                                        </Button>
-                                                    </Grid>
-                                                </Border>
-                                            </StackPanel>
-                                            <StackPanel Grid.Column="2" Spacing="6">
-                                                <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
-                                                    <Run Text="{loc:Loc 'Category'}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
-                                                </TextBlock>
-                                                <controls:SearchableDropdown
-                                                    ItemsSource="{Binding CategoryOptions}"
-                                                    SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"
-                                                    DisplayMemberPath="Name"
-                                                    Placeholder="{loc:Loc 'Search for a category...'}"
-                                                    ShowAddNew="False"
-                                                    EmptyMessage="{loc:Loc 'No categories found.'}"
-                                                    EmptyCreateLinkText="{loc:Loc 'Create one'}"
-                                                    EmptyCreateCommand="{Binding NavigateToCreateCategoryCommand}"
-                                                    HasError="{Binding HasCategoryError}"
-                                                    ErrorMessage="{Binding CategoryErrorMessage}"
-                                                    IsEnabled="{Binding !IsLoadingAiSuggestions}" />
-                                                <!-- AI Create Category Suggestion -->
-                                                <Border IsVisible="{Binding ShowCreateCategorySuggestion}"
-                                                        Background="{DynamicResource WarningLightBrush}"
-                                                        CornerRadius="6"
-                                                        Padding="10">
-                                                    <Grid ColumnDefinitions="*,Auto,Auto">
-                                                        <StackPanel Grid.Column="0" Spacing="2">
-                                                            <TextBlock Text="{loc:Loc 'Suggested category:'}"
-                                                                       FontSize="11"
-                                                                       Foreground="#92400E" />
-                                                            <TextBlock Text="{Binding SuggestedCategoryName}"
-                                                                       FontSize="12"
-                                                                       FontWeight="SemiBold"
-                                                                       Foreground="#78350F" />
-                                                        </StackPanel>
-                                                        <Button Grid.Column="1"
-                                                                Content="{loc:Loc 'Create'}"
-                                                                Command="{Binding CreateSuggestedCategoryCommand}"
-                                                                Classes="primary-button"
-                                                                Padding="10,4"
-                                                                Margin="8,0,0,0"
-                                                                FontSize="11" />
-                                                        <Button Grid.Column="2"
-                                                                Command="{Binding DismissCategorySuggestionCommand}"
                                                                 Background="Transparent"
                                                                 BorderThickness="0"
                                                                 Padding="8,4"

--- a/ArgoBooks/ViewModels/AppShellViewModel.cs
+++ b/ArgoBooks/ViewModels/AppShellViewModel.cs
@@ -1,7 +1,9 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Reflection;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Localization;
+using Avalonia.Controls;
 using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -844,6 +846,30 @@ public partial class AppShellViewModel : ViewModelBase
         HelpPanelViewModel.CloseCommand.Execute(null);
         QuickActionsViewModel.CloseCommand.Execute(null);
         CompanySwitcherPanelViewModel.CloseCommand.Execute(null);
+        ClosePageContextMenus();
+    }
+
+    /// <summary>
+    /// Closes any open context menus on the current page (column visibility, chart context, reports context).
+    /// </summary>
+    public void ClosePageContextMenus()
+    {
+        if (CurrentPage is not Control { DataContext: { } vm })
+            return;
+
+        var type = vm.GetType();
+
+        // Close column visibility menu
+        type.GetProperty("IsColumnMenuOpen", BindingFlags.Public | BindingFlags.Instance)?
+            .SetValue(vm, false);
+
+        // Close chart context menu
+        type.GetProperty("IsChartContextMenuOpen", BindingFlags.Public | BindingFlags.Instance)?
+            .SetValue(vm, false);
+
+        // Close reports context menu
+        type.GetProperty("IsContextMenuOpen", BindingFlags.Public | BindingFlags.Instance)?
+            .SetValue(vm, false);
     }
 
     /// <summary>

--- a/ArgoBooks/ViewModels/CategoriesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/CategoriesPageViewModel.cs
@@ -3,6 +3,7 @@ using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
+using ArgoBooks.Helpers;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
 using ArgoBooks.Localization;
@@ -143,21 +144,21 @@ public partial class CategoriesPageViewModel : SortablePageViewModelBase
     public CategoriesTableColumnWidths ColumnWidths => App.CategoriesColumnWidths;
 
     [ObservableProperty]
-    private bool _showNameColumn = true;
+    private bool _showNameColumn = ColumnVisibilityHelper.Load("Categories", "Name", true);
 
     [ObservableProperty]
-    private bool _showDescriptionColumn = true;
+    private bool _showDescriptionColumn = ColumnVisibilityHelper.Load("Categories", "Description", true);
 
     [ObservableProperty]
-    private bool _showTypeColumn = true;
+    private bool _showTypeColumn = ColumnVisibilityHelper.Load("Categories", "Type", true);
 
     [ObservableProperty]
-    private bool _showProductCountColumn = true;
+    private bool _showProductCountColumn = ColumnVisibilityHelper.Load("Categories", "ProductCount", true);
 
-    partial void OnShowNameColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Name", value);
-    partial void OnShowDescriptionColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Description", value);
-    partial void OnShowTypeColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Type", value);
-    partial void OnShowProductCountColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("ProductCount", value);
+    partial void OnShowNameColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Name", value); ColumnVisibilityHelper.Save("Categories", "Name", value); }
+    partial void OnShowDescriptionColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Description", value); ColumnVisibilityHelper.Save("Categories", "Description", value); }
+    partial void OnShowTypeColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Type", value); ColumnVisibilityHelper.Save("Categories", "Type", value); }
+    partial void OnShowProductCountColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("ProductCount", value); ColumnVisibilityHelper.Save("Categories", "ProductCount", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/CustomersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomersPageViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Entities;
@@ -60,29 +61,29 @@ public partial class CustomersPageViewModel : SortablePageViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showCustomerColumn = true;
+    private bool _showCustomerColumn = ColumnVisibilityHelper.Load("Customers", "Customer", true);
 
     [ObservableProperty]
-    private bool _showEmailColumn = true;
+    private bool _showEmailColumn = ColumnVisibilityHelper.Load("Customers", "Email", true);
 
     [ObservableProperty]
-    private bool _showPhoneColumn = true;
+    private bool _showPhoneColumn = ColumnVisibilityHelper.Load("Customers", "Phone", true);
 
     [ObservableProperty]
-    private bool _showAddressColumn = true;
+    private bool _showAddressColumn = ColumnVisibilityHelper.Load("Customers", "Address", true);
 
     [ObservableProperty]
-    private bool _showCountryColumn = true;
+    private bool _showCountryColumn = ColumnVisibilityHelper.Load("Customers", "Country", true);
 
     [ObservableProperty]
-    private bool _showLastRentalColumn = true;
+    private bool _showLastRentalColumn = ColumnVisibilityHelper.Load("Customers", "LastRental", true);
 
-    partial void OnShowCustomerColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Customer", value);
-    partial void OnShowEmailColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Email", value);
-    partial void OnShowPhoneColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Phone", value);
-    partial void OnShowAddressColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Address", value);
-    partial void OnShowCountryColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Country", value);
-    partial void OnShowLastRentalColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("LastRental", value);
+    partial void OnShowCustomerColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Customer", value); ColumnVisibilityHelper.Save("Customers", "Customer", value); }
+    partial void OnShowEmailColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Email", value); ColumnVisibilityHelper.Save("Customers", "Email", value); }
+    partial void OnShowPhoneColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Phone", value); ColumnVisibilityHelper.Save("Customers", "Phone", value); }
+    partial void OnShowAddressColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Address", value); ColumnVisibilityHelper.Save("Customers", "Address", value); }
+    partial void OnShowCountryColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Country", value); ColumnVisibilityHelper.Save("Customers", "Country", value); }
+    partial void OnShowLastRentalColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("LastRental", value); ColumnVisibilityHelper.Save("Customers", "LastRental", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/DepartmentsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DepartmentsPageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Data;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Localization;
 using ArgoBooks.Services;
@@ -86,17 +87,17 @@ public partial class DepartmentsPageViewModel : SortablePageViewModelBase
     public DepartmentsTableColumnWidths ColumnWidths => App.DepartmentsColumnWidths;
 
     [ObservableProperty]
-    private bool _showDepartmentColumn = true;
+    private bool _showDepartmentColumn = ColumnVisibilityHelper.Load("Departments", "Department", true);
 
     [ObservableProperty]
-    private bool _showDescriptionColumn = true;
+    private bool _showDescriptionColumn = ColumnVisibilityHelper.Load("Departments", "Description", true);
 
     [ObservableProperty]
-    private bool _showEmployeesColumn = true;
+    private bool _showEmployeesColumn = ColumnVisibilityHelper.Load("Departments", "Employees", true);
 
-    partial void OnShowDepartmentColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Department", value);
-    partial void OnShowDescriptionColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Description", value);
-    partial void OnShowEmployeesColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Employees", value);
+    partial void OnShowDepartmentColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Department", value); ColumnVisibilityHelper.Save("Departments", "Department", value); }
+    partial void OnShowDescriptionColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Description", value); ColumnVisibilityHelper.Save("Departments", "Description", value); }
+    partial void OnShowEmployeesColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Employees", value); ColumnVisibilityHelper.Save("Departments", "Employees", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/ExpensesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ExpensesPageViewModel.cs
@@ -5,6 +5,7 @@ using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Transactions;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
+using ArgoBooks.Helpers;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -85,57 +86,57 @@ public partial class ExpensesPageViewModel : SortablePageViewModelBase
     public TableColumnWidths ColumnWidths => App.ExpensesColumnWidths;
 
     [ObservableProperty]
-    private bool _showIdColumn = true;
+    private bool _showIdColumn = ColumnVisibilityHelper.Load("Expenses", "Id", true);
 
     [ObservableProperty]
-    private bool _showAccountantColumn; // No Accountant column in Expenses UI
+    private bool _showAccountantColumn = ColumnVisibilityHelper.Load("Expenses", "Accountant", false); // No Accountant column in Expenses UI
 
     [ObservableProperty]
-    private bool _showProductColumn = true;
+    private bool _showProductColumn = ColumnVisibilityHelper.Load("Expenses", "Product", true);
 
     [ObservableProperty]
-    private bool _showSupplierColumn = true;
+    private bool _showSupplierColumn = ColumnVisibilityHelper.Load("Expenses", "Supplier", true);
 
     [ObservableProperty]
-    private bool _showDateColumn = true;
+    private bool _showDateColumn = ColumnVisibilityHelper.Load("Expenses", "Date", true);
 
     [ObservableProperty]
-    private bool _showQuantityColumn;
+    private bool _showQuantityColumn = ColumnVisibilityHelper.Load("Expenses", "Quantity", false);
 
     [ObservableProperty]
-    private bool _showAmountColumn;
+    private bool _showAmountColumn = ColumnVisibilityHelper.Load("Expenses", "Amount", false);
 
     [ObservableProperty]
-    private bool _showTaxColumn;
+    private bool _showTaxColumn = ColumnVisibilityHelper.Load("Expenses", "Tax", false);
 
     [ObservableProperty]
-    private bool _showShippingColumn;
+    private bool _showShippingColumn = ColumnVisibilityHelper.Load("Expenses", "Shipping", false);
 
     [ObservableProperty]
-    private bool _showDiscountColumn;
+    private bool _showDiscountColumn = ColumnVisibilityHelper.Load("Expenses", "Discount", false);
 
     [ObservableProperty]
-    private bool _showTotalColumn = true;
+    private bool _showTotalColumn = ColumnVisibilityHelper.Load("Expenses", "Total", true);
 
     [ObservableProperty]
-    private bool _showReceiptColumn = true;
+    private bool _showReceiptColumn = ColumnVisibilityHelper.Load("Expenses", "Receipt", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("Expenses", "Status", true);
 
-    partial void OnShowIdColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Id", value);
-    partial void OnShowAccountantColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Accountant", value);
-    partial void OnShowProductColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Product", value);
-    partial void OnShowSupplierColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Supplier", value);
-    partial void OnShowDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Date", value);
-    partial void OnShowQuantityColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Quantity", value);
-    partial void OnShowAmountColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Amount", value);
-    partial void OnShowTaxColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Tax", value);
-    partial void OnShowShippingColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Shipping", value);
-    partial void OnShowDiscountColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Discount", value);
-    partial void OnShowTotalColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Total", value);
-    partial void OnShowReceiptColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Receipt", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
+    partial void OnShowIdColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Id", value); ColumnVisibilityHelper.Save("Expenses", "Id", value); }
+    partial void OnShowAccountantColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Accountant", value); ColumnVisibilityHelper.Save("Expenses", "Accountant", value); }
+    partial void OnShowProductColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Product", value); ColumnVisibilityHelper.Save("Expenses", "Product", value); }
+    partial void OnShowSupplierColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Supplier", value); ColumnVisibilityHelper.Save("Expenses", "Supplier", value); }
+    partial void OnShowDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Date", value); ColumnVisibilityHelper.Save("Expenses", "Date", value); }
+    partial void OnShowQuantityColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Quantity", value); ColumnVisibilityHelper.Save("Expenses", "Quantity", value); }
+    partial void OnShowAmountColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Amount", value); ColumnVisibilityHelper.Save("Expenses", "Amount", value); }
+    partial void OnShowTaxColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Tax", value); ColumnVisibilityHelper.Save("Expenses", "Tax", value); }
+    partial void OnShowShippingColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Shipping", value); ColumnVisibilityHelper.Save("Expenses", "Shipping", value); }
+    partial void OnShowDiscountColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Discount", value); ColumnVisibilityHelper.Save("Expenses", "Discount", value); }
+    partial void OnShowTotalColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Total", value); ColumnVisibilityHelper.Save("Expenses", "Total", value); }
+    partial void OnShowReceiptColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Receipt", value); ColumnVisibilityHelper.Save("Expenses", "Receipt", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("Expenses", "Status", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
@@ -7,6 +7,7 @@ using ArgoBooks.Services;
 using ArgoBooks.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using ArgoBooks.Helpers;
 
 namespace ArgoBooks.ViewModels;
 
@@ -164,33 +165,33 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
     public InvoicesTableColumnWidths ColumnWidths => App.InvoicesColumnWidths;
 
     [ObservableProperty]
-    private bool _showIdColumn = true;
+    private bool _showIdColumn = ColumnVisibilityHelper.Load("Invoices", "Id", true);
 
     [ObservableProperty]
-    private bool _showAccountantColumn = true;
+    private bool _showAccountantColumn = ColumnVisibilityHelper.Load("Invoices", "Accountant", true);
 
     [ObservableProperty]
-    private bool _showCustomerColumn = true;
+    private bool _showCustomerColumn = ColumnVisibilityHelper.Load("Invoices", "Customer", true);
 
     [ObservableProperty]
-    private bool _showIssueDateColumn = true;
+    private bool _showIssueDateColumn = ColumnVisibilityHelper.Load("Invoices", "IssueDate", true);
 
     [ObservableProperty]
-    private bool _showDueDateColumn = true;
+    private bool _showDueDateColumn = ColumnVisibilityHelper.Load("Invoices", "DueDate", true);
 
     [ObservableProperty]
-    private bool _showAmountColumn = true;
+    private bool _showAmountColumn = ColumnVisibilityHelper.Load("Invoices", "Amount", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("Invoices", "Status", true);
 
-    partial void OnShowIdColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Id", value);
-    partial void OnShowAccountantColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Accountant", value);
-    partial void OnShowCustomerColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Customer", value);
-    partial void OnShowIssueDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("IssueDate", value);
-    partial void OnShowDueDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("DueDate", value);
-    partial void OnShowAmountColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Amount", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
+    partial void OnShowIdColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Id", value); ColumnVisibilityHelper.Save("Invoices", "Id", value); }
+    partial void OnShowAccountantColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Accountant", value); ColumnVisibilityHelper.Save("Invoices", "Accountant", value); }
+    partial void OnShowCustomerColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Customer", value); ColumnVisibilityHelper.Save("Invoices", "Customer", value); }
+    partial void OnShowIssueDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("IssueDate", value); ColumnVisibilityHelper.Save("Invoices", "IssueDate", value); }
+    partial void OnShowDueDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("DueDate", value); ColumnVisibilityHelper.Save("Invoices", "DueDate", value); }
+    partial void OnShowAmountColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Amount", value); ColumnVisibilityHelper.Save("Invoices", "Amount", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("Invoices", "Status", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/LocationsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/LocationsPageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Models.Entities;
+using ArgoBooks.Helpers;
 using ArgoBooks.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -57,21 +58,21 @@ public partial class LocationsPageViewModel : SortablePageViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showLocationColumn = true;
+    private bool _showLocationColumn = ColumnVisibilityHelper.Load("Locations", "Location", true);
 
     [ObservableProperty]
-    private bool _showTypeColumn = true;
+    private bool _showTypeColumn = ColumnVisibilityHelper.Load("Locations", "Type", true);
 
     [ObservableProperty]
-    private bool _showAddressColumn = true;
+    private bool _showAddressColumn = ColumnVisibilityHelper.Load("Locations", "Address", true);
 
     [ObservableProperty]
-    private bool _showManagerColumn = true;
+    private bool _showManagerColumn = ColumnVisibilityHelper.Load("Locations", "Manager", true);
 
-    partial void OnShowLocationColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Location", value);
-    partial void OnShowTypeColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Type", value);
-    partial void OnShowAddressColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Address", value);
-    partial void OnShowManagerColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Manager", value);
+    partial void OnShowLocationColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Location", value); ColumnVisibilityHelper.Save("Locations", "Location", value); }
+    partial void OnShowTypeColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Type", value); ColumnVisibilityHelper.Save("Locations", "Type", value); }
+    partial void OnShowAddressColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Address", value); ColumnVisibilityHelper.Save("Locations", "Address", value); }
+    partial void OnShowManagerColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Manager", value); ColumnVisibilityHelper.Save("Locations", "Manager", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/LostDamagedPageViewModel.cs
+++ b/ArgoBooks/ViewModels/LostDamagedPageViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Models.Tracking;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
@@ -44,25 +45,25 @@ public partial class LostDamagedPageViewModel : ViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showIdColumn = true;
+    private bool _showIdColumn = ColumnVisibilityHelper.Load("LostDamaged", "Id", true);
 
     [ObservableProperty]
-    private bool _showProductColumn = true;
+    private bool _showProductColumn = ColumnVisibilityHelper.Load("LostDamaged", "Product", true);
 
     [ObservableProperty]
-    private bool _showDateColumn = true;
+    private bool _showDateColumn = ColumnVisibilityHelper.Load("LostDamaged", "Date", true);
 
     [ObservableProperty]
-    private bool _showReasonColumn = true;
+    private bool _showReasonColumn = ColumnVisibilityHelper.Load("LostDamaged", "Reason", true);
 
     [ObservableProperty]
-    private bool _showLossColumn = true;
+    private bool _showLossColumn = ColumnVisibilityHelper.Load("LostDamaged", "Loss", true);
 
-    partial void OnShowIdColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Id", value);
-    partial void OnShowProductColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Product", value);
-    partial void OnShowDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Date", value);
-    partial void OnShowReasonColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Reason", value);
-    partial void OnShowLossColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Loss", value);
+    partial void OnShowIdColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Id", value); ColumnVisibilityHelper.Save("LostDamaged", "Id", value); }
+    partial void OnShowProductColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Product", value); ColumnVisibilityHelper.Save("LostDamaged", "Product", value); }
+    partial void OnShowDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Date", value); ColumnVisibilityHelper.Save("LostDamaged", "Date", value); }
+    partial void OnShowReasonColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Reason", value); ColumnVisibilityHelper.Save("LostDamaged", "Reason", value); }
+    partial void OnShowLossColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Loss", value); ColumnVisibilityHelper.Save("LostDamaged", "Loss", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/PaymentsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/PaymentsPageViewModel.cs
@@ -7,6 +7,7 @@ using ArgoBooks.Services;
 using ArgoBooks.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using ArgoBooks.Helpers;
 
 namespace ArgoBooks.ViewModels;
 
@@ -128,33 +129,33 @@ public partial class PaymentsPageViewModel : SortablePageViewModelBase
     public PaymentsTableColumnWidths ColumnWidths => App.PaymentsColumnWidths;
 
     [ObservableProperty]
-    private bool _showIdColumn = true;
+    private bool _showIdColumn = ColumnVisibilityHelper.Load("Payments", "Id", true);
 
     [ObservableProperty]
-    private bool _showInvoiceColumn = true;
+    private bool _showInvoiceColumn = ColumnVisibilityHelper.Load("Payments", "Invoice", true);
 
     [ObservableProperty]
-    private bool _showCustomerColumn = true;
+    private bool _showCustomerColumn = ColumnVisibilityHelper.Load("Payments", "Customer", true);
 
     [ObservableProperty]
-    private bool _showDateColumn = true;
+    private bool _showDateColumn = ColumnVisibilityHelper.Load("Payments", "Date", true);
 
     [ObservableProperty]
-    private bool _showMethodColumn = true;
+    private bool _showMethodColumn = ColumnVisibilityHelper.Load("Payments", "Method", true);
 
     [ObservableProperty]
-    private bool _showAmountColumn = true;
+    private bool _showAmountColumn = ColumnVisibilityHelper.Load("Payments", "Amount", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("Payments", "Status", true);
 
-    partial void OnShowIdColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Id", value);
-    partial void OnShowInvoiceColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Invoice", value);
-    partial void OnShowCustomerColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Customer", value);
-    partial void OnShowDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Date", value);
-    partial void OnShowMethodColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Method", value);
-    partial void OnShowAmountColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Amount", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
+    partial void OnShowIdColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Id", value); ColumnVisibilityHelper.Save("Payments", "Id", value); }
+    partial void OnShowInvoiceColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Invoice", value); ColumnVisibilityHelper.Save("Payments", "Invoice", value); }
+    partial void OnShowCustomerColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Customer", value); ColumnVisibilityHelper.Save("Payments", "Customer", value); }
+    partial void OnShowDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Date", value); ColumnVisibilityHelper.Save("Payments", "Date", value); }
+    partial void OnShowMethodColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Method", value); ColumnVisibilityHelper.Save("Payments", "Method", value); }
+    partial void OnShowAmountColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Amount", value); ColumnVisibilityHelper.Save("Payments", "Amount", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("Payments", "Status", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/ProductsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ProductsPageViewModel.cs
@@ -7,6 +7,7 @@ using ArgoBooks.Services;
 using ArgoBooks.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using ArgoBooks.Helpers;
 
 namespace ArgoBooks.ViewModels;
 
@@ -45,33 +46,33 @@ public partial class ProductsPageViewModel : SortablePageViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showNameColumn = true;
+    private bool _showNameColumn = ColumnVisibilityHelper.Load("Products", "Name", true);
 
     [ObservableProperty]
-    private bool _showTypeColumn = true;
+    private bool _showTypeColumn = ColumnVisibilityHelper.Load("Products", "Type", true);
 
     [ObservableProperty]
-    private bool _showDescriptionColumn = true;
+    private bool _showDescriptionColumn = ColumnVisibilityHelper.Load("Products", "Description", true);
 
     [ObservableProperty]
-    private bool _showCategoryColumn = true;
+    private bool _showCategoryColumn = ColumnVisibilityHelper.Load("Products", "Category", true);
 
     [ObservableProperty]
-    private bool _showSupplierColumn = true;
+    private bool _showSupplierColumn = ColumnVisibilityHelper.Load("Products", "Supplier", true);
 
     [ObservableProperty]
-    private bool _showReorderColumn = true;
+    private bool _showReorderColumn = ColumnVisibilityHelper.Load("Products", "Reorder", true);
 
     [ObservableProperty]
-    private bool _showOverstockColumn = true;
+    private bool _showOverstockColumn = ColumnVisibilityHelper.Load("Products", "Overstock", true);
 
-    partial void OnShowNameColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Name", value);
-    partial void OnShowTypeColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Type", value);
-    partial void OnShowDescriptionColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Description", value);
-    partial void OnShowCategoryColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Category", value);
-    partial void OnShowSupplierColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Supplier", value);
-    partial void OnShowReorderColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Reorder", value);
-    partial void OnShowOverstockColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Overstock", value);
+    partial void OnShowNameColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Name", value); ColumnVisibilityHelper.Save("Products", "Name", value); }
+    partial void OnShowTypeColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Type", value); ColumnVisibilityHelper.Save("Products", "Type", value); }
+    partial void OnShowDescriptionColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Description", value); ColumnVisibilityHelper.Save("Products", "Description", value); }
+    partial void OnShowCategoryColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Category", value); ColumnVisibilityHelper.Save("Products", "Category", value); }
+    partial void OnShowSupplierColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Supplier", value); ColumnVisibilityHelper.Save("Products", "Supplier", value); }
+    partial void OnShowReorderColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Reorder", value); ColumnVisibilityHelper.Save("Products", "Reorder", value); }
+    partial void OnShowOverstockColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Overstock", value); ColumnVisibilityHelper.Save("Products", "Overstock", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/PurchaseOrdersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/PurchaseOrdersPageViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Inventory;
 using ArgoBooks.Utilities;
@@ -57,33 +58,33 @@ public partial class PurchaseOrdersPageViewModel : SortablePageViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showPONumberColumn = true;
+    private bool _showPONumberColumn = ColumnVisibilityHelper.Load("PurchaseOrders", "PONumber", true);
 
     [ObservableProperty]
-    private bool _showDateColumn = true;
+    private bool _showDateColumn = ColumnVisibilityHelper.Load("PurchaseOrders", "Date", true);
 
     [ObservableProperty]
-    private bool _showSupplierColumn = true;
+    private bool _showSupplierColumn = ColumnVisibilityHelper.Load("PurchaseOrders", "Supplier", true);
 
     [ObservableProperty]
-    private bool _showItemsColumn = true;
+    private bool _showItemsColumn = ColumnVisibilityHelper.Load("PurchaseOrders", "Items", true);
 
     [ObservableProperty]
-    private bool _showTotalColumn = true;
+    private bool _showTotalColumn = ColumnVisibilityHelper.Load("PurchaseOrders", "Total", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("PurchaseOrders", "Status", true);
 
     [ObservableProperty]
-    private bool _showExpectedColumn = true;
+    private bool _showExpectedColumn = ColumnVisibilityHelper.Load("PurchaseOrders", "Expected", true);
 
-    partial void OnShowPONumberColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("PONumber", value);
-    partial void OnShowDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Date", value);
-    partial void OnShowSupplierColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Supplier", value);
-    partial void OnShowItemsColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Items", value);
-    partial void OnShowTotalColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Total", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
-    partial void OnShowExpectedColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Expected", value);
+    partial void OnShowPONumberColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("PONumber", value); ColumnVisibilityHelper.Save("PurchaseOrders", "PONumber", value); }
+    partial void OnShowDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Date", value); ColumnVisibilityHelper.Save("PurchaseOrders", "Date", value); }
+    partial void OnShowSupplierColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Supplier", value); ColumnVisibilityHelper.Save("PurchaseOrders", "Supplier", value); }
+    partial void OnShowItemsColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Items", value); ColumnVisibilityHelper.Save("PurchaseOrders", "Items", value); }
+    partial void OnShowTotalColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Total", value); ColumnVisibilityHelper.Save("PurchaseOrders", "Total", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("PurchaseOrders", "Status", value); }
+    partial void OnShowExpectedColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Expected", value); ColumnVisibilityHelper.Save("PurchaseOrders", "Expected", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Models.Tracking;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Localization;
 using ArgoBooks.Utilities;
@@ -239,43 +240,48 @@ public partial class ReceiptsPageViewModel : ViewModelBase
     public ReceiptsTableColumnWidths ColumnWidths => App.ReceiptsColumnWidths;
 
     [ObservableProperty]
-    private bool _showIdColumn = true;
+    private bool _showIdColumn = ColumnVisibilityHelper.Load("Receipts", "Id", true);
 
     [ObservableProperty]
-    private bool _showSupplierColumn = true;
+    private bool _showSupplierColumn = ColumnVisibilityHelper.Load("Receipts", "Supplier", true);
 
     [ObservableProperty]
-    private bool _showDateColumn = true;
+    private bool _showDateColumn = ColumnVisibilityHelper.Load("Receipts", "Date", true);
 
     [ObservableProperty]
-    private bool _showTypeColumn = true;
+    private bool _showTypeColumn = ColumnVisibilityHelper.Load("Receipts", "Type", true);
 
     [ObservableProperty]
-    private bool _showAmountColumn = true;
+    private bool _showAmountColumn = ColumnVisibilityHelper.Load("Receipts", "Amount", true);
 
     partial void OnShowIdColumnChanged(bool value)
     {
         ColumnWidths.SetColumnVisibility("Id", value);
+        ColumnVisibilityHelper.Save("Receipts", "Id", value);
     }
 
     partial void OnShowSupplierColumnChanged(bool value)
     {
         ColumnWidths.SetColumnVisibility("Supplier", value);
+        ColumnVisibilityHelper.Save("Receipts", "Supplier", value);
     }
 
     partial void OnShowDateColumnChanged(bool value)
     {
         ColumnWidths.SetColumnVisibility("Date", value);
+        ColumnVisibilityHelper.Save("Receipts", "Date", value);
     }
 
     partial void OnShowTypeColumnChanged(bool value)
     {
         ColumnWidths.SetColumnVisibility("Type", value);
+        ColumnVisibilityHelper.Save("Receipts", "Type", value);
     }
 
     partial void OnShowAmountColumnChanged(bool value)
     {
         ColumnWidths.SetColumnVisibility("Amount", value);
+        ColumnVisibilityHelper.Save("Receipts", "Amount", value);
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/RentalInventoryPageViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalInventoryPageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Models.Rentals;
 using ArgoBooks.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -53,37 +54,37 @@ public partial class RentalInventoryPageViewModel : SortablePageViewModelBase
     public RentalInventoryTableColumnWidths ColumnWidths => App.RentalInventoryColumnWidths;
 
     [ObservableProperty]
-    private bool _showItemColumn = true;
+    private bool _showItemColumn = ColumnVisibilityHelper.Load("RentalInventory", "Item", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("RentalInventory", "Status", true);
 
     [ObservableProperty]
-    private bool _showTotalQtyColumn = true;
+    private bool _showTotalQtyColumn = ColumnVisibilityHelper.Load("RentalInventory", "TotalQty", true);
 
     [ObservableProperty]
-    private bool _showAvailableColumn = true;
+    private bool _showAvailableColumn = ColumnVisibilityHelper.Load("RentalInventory", "Available", true);
 
     [ObservableProperty]
-    private bool _showRentedColumn = true;
+    private bool _showRentedColumn = ColumnVisibilityHelper.Load("RentalInventory", "Rented", true);
 
     [ObservableProperty]
-    private bool _showDailyRateColumn = true;
+    private bool _showDailyRateColumn = ColumnVisibilityHelper.Load("RentalInventory", "DailyRate", true);
 
     [ObservableProperty]
-    private bool _showWeeklyRateColumn = true;
+    private bool _showWeeklyRateColumn = ColumnVisibilityHelper.Load("RentalInventory", "WeeklyRate", true);
 
     [ObservableProperty]
-    private bool _showDepositColumn = true;
+    private bool _showDepositColumn = ColumnVisibilityHelper.Load("RentalInventory", "Deposit", true);
 
-    partial void OnShowItemColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Item", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
-    partial void OnShowTotalQtyColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("TotalQty", value);
-    partial void OnShowAvailableColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Available", value);
-    partial void OnShowRentedColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Rented", value);
-    partial void OnShowDailyRateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("DailyRate", value);
-    partial void OnShowWeeklyRateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("WeeklyRate", value);
-    partial void OnShowDepositColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Deposit", value);
+    partial void OnShowItemColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Item", value); ColumnVisibilityHelper.Save("RentalInventory", "Item", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("RentalInventory", "Status", value); }
+    partial void OnShowTotalQtyColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("TotalQty", value); ColumnVisibilityHelper.Save("RentalInventory", "TotalQty", value); }
+    partial void OnShowAvailableColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Available", value); ColumnVisibilityHelper.Save("RentalInventory", "Available", value); }
+    partial void OnShowRentedColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Rented", value); ColumnVisibilityHelper.Save("RentalInventory", "Rented", value); }
+    partial void OnShowDailyRateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("DailyRate", value); ColumnVisibilityHelper.Save("RentalInventory", "DailyRate", value); }
+    partial void OnShowWeeklyRateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("WeeklyRate", value); ColumnVisibilityHelper.Save("RentalInventory", "WeeklyRate", value); }
+    partial void OnShowDepositColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Deposit", value); ColumnVisibilityHelper.Save("RentalInventory", "Deposit", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/RentalRecordsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalRecordsPageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Models.Rentals;
 using ArgoBooks.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -89,41 +90,41 @@ public partial class RentalRecordsPageViewModel : SortablePageViewModelBase
     public RentalRecordsTableColumnWidths ColumnWidths => App.RentalRecordsColumnWidths;
 
     [ObservableProperty]
-    private bool _showIdColumn = true;
+    private bool _showIdColumn = ColumnVisibilityHelper.Load("RentalRecords", "Id", true);
 
     [ObservableProperty]
-    private bool _showItemColumn = true;
+    private bool _showItemColumn = ColumnVisibilityHelper.Load("RentalRecords", "Item", true);
 
     [ObservableProperty]
-    private bool _showCustomerColumn = true;
+    private bool _showCustomerColumn = ColumnVisibilityHelper.Load("RentalRecords", "Customer", true);
 
     [ObservableProperty]
-    private bool _showQuantityColumn = true;
+    private bool _showQuantityColumn = ColumnVisibilityHelper.Load("RentalRecords", "Quantity", true);
 
     [ObservableProperty]
-    private bool _showStartDateColumn = true;
+    private bool _showStartDateColumn = ColumnVisibilityHelper.Load("RentalRecords", "StartDate", true);
 
     [ObservableProperty]
-    private bool _showDueDateColumn = true;
+    private bool _showDueDateColumn = ColumnVisibilityHelper.Load("RentalRecords", "DueDate", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("RentalRecords", "Status", true);
 
     [ObservableProperty]
-    private bool _showTotalColumn = true;
+    private bool _showTotalColumn = ColumnVisibilityHelper.Load("RentalRecords", "Total", true);
 
     [ObservableProperty]
-    private bool _showDepositColumn = true;
+    private bool _showDepositColumn = ColumnVisibilityHelper.Load("RentalRecords", "Deposit", true);
 
-    partial void OnShowIdColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Id", value);
-    partial void OnShowItemColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Item", value);
-    partial void OnShowCustomerColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Customer", value);
-    partial void OnShowQuantityColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Quantity", value);
-    partial void OnShowStartDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("StartDate", value);
-    partial void OnShowDueDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("DueDate", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
-    partial void OnShowTotalColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Total", value);
-    partial void OnShowDepositColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Deposit", value);
+    partial void OnShowIdColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Id", value); ColumnVisibilityHelper.Save("RentalRecords", "Id", value); }
+    partial void OnShowItemColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Item", value); ColumnVisibilityHelper.Save("RentalRecords", "Item", value); }
+    partial void OnShowCustomerColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Customer", value); ColumnVisibilityHelper.Save("RentalRecords", "Customer", value); }
+    partial void OnShowQuantityColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Quantity", value); ColumnVisibilityHelper.Save("RentalRecords", "Quantity", value); }
+    partial void OnShowStartDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("StartDate", value); ColumnVisibilityHelper.Save("RentalRecords", "StartDate", value); }
+    partial void OnShowDueDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("DueDate", value); ColumnVisibilityHelper.Save("RentalRecords", "DueDate", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("RentalRecords", "Status", value); }
+    partial void OnShowTotalColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Total", value); ColumnVisibilityHelper.Save("RentalRecords", "Total", value); }
+    partial void OnShowDepositColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Deposit", value); ColumnVisibilityHelper.Save("RentalRecords", "Deposit", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/ReturnsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReturnsPageViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Models.Tracking;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
@@ -34,29 +35,29 @@ public partial class ReturnsPageViewModel : ViewModelBase
     private bool _isColumnMenuOpen;
 
     [ObservableProperty]
-    private bool _showIdColumn = true;
+    private bool _showIdColumn = ColumnVisibilityHelper.Load("Returns", "Id", true);
 
     [ObservableProperty]
-    private bool _showProductColumn = true;
+    private bool _showProductColumn = ColumnVisibilityHelper.Load("Returns", "Product", true);
 
     [ObservableProperty]
-    private bool _showSupplierCustomerColumn = true;
+    private bool _showSupplierCustomerColumn = ColumnVisibilityHelper.Load("Returns", "SupplierCustomer", true);
 
     [ObservableProperty]
-    private bool _showDateColumn = true;
+    private bool _showDateColumn = ColumnVisibilityHelper.Load("Returns", "Date", true);
 
     [ObservableProperty]
-    private bool _showReasonColumn = true;
+    private bool _showReasonColumn = ColumnVisibilityHelper.Load("Returns", "Reason", true);
 
     [ObservableProperty]
-    private bool _showRefundColumn = true;
+    private bool _showRefundColumn = ColumnVisibilityHelper.Load("Returns", "Refund", true);
 
-    partial void OnShowIdColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Id", value);
-    partial void OnShowProductColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Product", value);
-    partial void OnShowSupplierCustomerColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("SupplierCustomer", value);
-    partial void OnShowDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Date", value);
-    partial void OnShowReasonColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Reason", value);
-    partial void OnShowRefundColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Refund", value);
+    partial void OnShowIdColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Id", value); ColumnVisibilityHelper.Save("Returns", "Id", value); }
+    partial void OnShowProductColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Product", value); ColumnVisibilityHelper.Save("Returns", "Product", value); }
+    partial void OnShowSupplierCustomerColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("SupplierCustomer", value); ColumnVisibilityHelper.Save("Returns", "SupplierCustomer", value); }
+    partial void OnShowDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Date", value); ColumnVisibilityHelper.Save("Returns", "Date", value); }
+    partial void OnShowReasonColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Reason", value); ColumnVisibilityHelper.Save("Returns", "Reason", value); }
+    partial void OnShowRefundColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Refund", value); ColumnVisibilityHelper.Save("Returns", "Refund", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/RevenuePageViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenuePageViewModel.cs
@@ -5,6 +5,7 @@ using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Transactions;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
+using ArgoBooks.Helpers;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -84,57 +85,57 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showIdColumn = true;
+    private bool _showIdColumn = ColumnVisibilityHelper.Load("Revenue", "Id", true);
 
     [ObservableProperty]
-    private bool _showAccountantColumn; // No Accountant column in Revenue UI
+    private bool _showAccountantColumn = ColumnVisibilityHelper.Load("Revenue", "Accountant", false); // No Accountant column in Revenue UI
 
     [ObservableProperty]
-    private bool _showCustomerColumn = true;
+    private bool _showCustomerColumn = ColumnVisibilityHelper.Load("Revenue", "Customer", true);
 
     [ObservableProperty]
-    private bool _showProductColumn = true;
+    private bool _showProductColumn = ColumnVisibilityHelper.Load("Revenue", "Product", true);
 
     [ObservableProperty]
-    private bool _showDateColumn = true;
+    private bool _showDateColumn = ColumnVisibilityHelper.Load("Revenue", "Date", true);
 
     [ObservableProperty]
-    private bool _showQuantityColumn;
+    private bool _showQuantityColumn = ColumnVisibilityHelper.Load("Revenue", "Quantity", false);
 
     [ObservableProperty]
-    private bool _showAmountColumn;
+    private bool _showAmountColumn = ColumnVisibilityHelper.Load("Revenue", "Amount", false);
 
     [ObservableProperty]
-    private bool _showTaxColumn;
+    private bool _showTaxColumn = ColumnVisibilityHelper.Load("Revenue", "Tax", false);
 
     [ObservableProperty]
-    private bool _showShippingColumn;
+    private bool _showShippingColumn = ColumnVisibilityHelper.Load("Revenue", "Shipping", false);
 
     [ObservableProperty]
-    private bool _showDiscountColumn;
+    private bool _showDiscountColumn = ColumnVisibilityHelper.Load("Revenue", "Discount", false);
 
     [ObservableProperty]
-    private bool _showTotalColumn = true;
+    private bool _showTotalColumn = ColumnVisibilityHelper.Load("Revenue", "Total", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("Revenue", "Status", true);
 
     [ObservableProperty]
-    private bool _showReceiptColumn = true;
+    private bool _showReceiptColumn = ColumnVisibilityHelper.Load("Revenue", "Receipt", true);
 
-    partial void OnShowIdColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Id", value);
-    partial void OnShowAccountantColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Accountant", value);
-    partial void OnShowCustomerColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Customer", value);
-    partial void OnShowProductColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Product", value);
-    partial void OnShowDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Date", value);
-    partial void OnShowQuantityColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Quantity", value);
-    partial void OnShowAmountColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Amount", value);
-    partial void OnShowTaxColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Tax", value);
-    partial void OnShowShippingColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Shipping", value);
-    partial void OnShowDiscountColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Discount", value);
-    partial void OnShowTotalColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Total", value);
-    partial void OnShowReceiptColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Receipt", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
+    partial void OnShowIdColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Id", value); ColumnVisibilityHelper.Save("Revenue", "Id", value); }
+    partial void OnShowAccountantColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Accountant", value); ColumnVisibilityHelper.Save("Revenue", "Accountant", value); }
+    partial void OnShowCustomerColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Customer", value); ColumnVisibilityHelper.Save("Revenue", "Customer", value); }
+    partial void OnShowProductColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Product", value); ColumnVisibilityHelper.Save("Revenue", "Product", value); }
+    partial void OnShowDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Date", value); ColumnVisibilityHelper.Save("Revenue", "Date", value); }
+    partial void OnShowQuantityColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Quantity", value); ColumnVisibilityHelper.Save("Revenue", "Quantity", value); }
+    partial void OnShowAmountColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Amount", value); ColumnVisibilityHelper.Save("Revenue", "Amount", value); }
+    partial void OnShowTaxColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Tax", value); ColumnVisibilityHelper.Save("Revenue", "Tax", value); }
+    partial void OnShowShippingColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Shipping", value); ColumnVisibilityHelper.Save("Revenue", "Shipping", value); }
+    partial void OnShowDiscountColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Discount", value); ColumnVisibilityHelper.Save("Revenue", "Discount", value); }
+    partial void OnShowTotalColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Total", value); ColumnVisibilityHelper.Save("Revenue", "Total", value); }
+    partial void OnShowReceiptColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Receipt", value); ColumnVisibilityHelper.Save("Revenue", "Receipt", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("Revenue", "Status", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/StockAdjustmentsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/StockAdjustmentsPageViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Inventory;
 using ArgoBooks.Services;
@@ -62,37 +63,37 @@ public partial class StockAdjustmentsPageViewModel : SortablePageViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showDateColumn = true;
+    private bool _showDateColumn = ColumnVisibilityHelper.Load("StockAdjustments", "Date", true);
 
     [ObservableProperty]
-    private bool _showReferenceColumn = true;
+    private bool _showReferenceColumn = ColumnVisibilityHelper.Load("StockAdjustments", "Reference", true);
 
     [ObservableProperty]
-    private bool _showProductColumn = true;
+    private bool _showProductColumn = ColumnVisibilityHelper.Load("StockAdjustments", "Product", true);
 
     [ObservableProperty]
-    private bool _showLocationColumn = true;
+    private bool _showLocationColumn = ColumnVisibilityHelper.Load("StockAdjustments", "Location", true);
 
     [ObservableProperty]
-    private bool _showQuantityColumn = true;
+    private bool _showQuantityColumn = ColumnVisibilityHelper.Load("StockAdjustments", "Quantity", true);
 
     [ObservableProperty]
-    private bool _showPreviousColumn = true;
+    private bool _showPreviousColumn = ColumnVisibilityHelper.Load("StockAdjustments", "Previous", true);
 
     [ObservableProperty]
-    private bool _showNewColumn = true;
+    private bool _showNewColumn = ColumnVisibilityHelper.Load("StockAdjustments", "New", true);
 
     [ObservableProperty]
-    private bool _showReasonColumn = true;
+    private bool _showReasonColumn = ColumnVisibilityHelper.Load("StockAdjustments", "Reason", true);
 
-    partial void OnShowDateColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Date", value);
-    partial void OnShowReferenceColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Reference", value);
-    partial void OnShowProductColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Product", value);
-    partial void OnShowLocationColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Location", value);
-    partial void OnShowQuantityColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Quantity", value);
-    partial void OnShowPreviousColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Previous", value);
-    partial void OnShowNewColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("New", value);
-    partial void OnShowReasonColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Reason", value);
+    partial void OnShowDateColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Date", value); ColumnVisibilityHelper.Save("StockAdjustments", "Date", value); }
+    partial void OnShowReferenceColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Reference", value); ColumnVisibilityHelper.Save("StockAdjustments", "Reference", value); }
+    partial void OnShowProductColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Product", value); ColumnVisibilityHelper.Save("StockAdjustments", "Product", value); }
+    partial void OnShowLocationColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Location", value); ColumnVisibilityHelper.Save("StockAdjustments", "Location", value); }
+    partial void OnShowQuantityColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Quantity", value); ColumnVisibilityHelper.Save("StockAdjustments", "Quantity", value); }
+    partial void OnShowPreviousColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Previous", value); ColumnVisibilityHelper.Save("StockAdjustments", "Previous", value); }
+    partial void OnShowNewColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("New", value); ColumnVisibilityHelper.Save("StockAdjustments", "New", value); }
+    partial void OnShowReasonColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Reason", value); ColumnVisibilityHelper.Save("StockAdjustments", "Reason", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/StockLevelsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/StockLevelsPageViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Inventory;
 using ArgoBooks.Utilities;
@@ -45,41 +46,41 @@ public partial class StockLevelsPageViewModel : SortablePageViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showProductColumn = true;
+    private bool _showProductColumn = ColumnVisibilityHelper.Load("StockLevels", "Product", true);
 
     [ObservableProperty]
-    private bool _showSkuColumn = true;
+    private bool _showSkuColumn = ColumnVisibilityHelper.Load("StockLevels", "Sku", true);
 
     [ObservableProperty]
-    private bool _showCategoryColumn = true;
+    private bool _showCategoryColumn = ColumnVisibilityHelper.Load("StockLevels", "Category", true);
 
     [ObservableProperty]
-    private bool _showLocationColumn = true;
+    private bool _showLocationColumn = ColumnVisibilityHelper.Load("StockLevels", "Location", true);
 
     [ObservableProperty]
-    private bool _showInStockColumn = true;
+    private bool _showInStockColumn = ColumnVisibilityHelper.Load("StockLevels", "InStock", true);
 
     [ObservableProperty]
-    private bool _showReservedColumn = true;
+    private bool _showReservedColumn = ColumnVisibilityHelper.Load("StockLevels", "Reserved", true);
 
     [ObservableProperty]
-    private bool _showAvailableColumn = true;
+    private bool _showAvailableColumn = ColumnVisibilityHelper.Load("StockLevels", "Available", true);
 
     [ObservableProperty]
-    private bool _showReorderPointColumn = true;
+    private bool _showReorderPointColumn = ColumnVisibilityHelper.Load("StockLevels", "ReorderPoint", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("StockLevels", "Status", true);
 
-    partial void OnShowProductColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Product", value);
-    partial void OnShowSkuColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Sku", value);
-    partial void OnShowCategoryColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Category", value);
-    partial void OnShowLocationColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Location", value);
-    partial void OnShowInStockColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("InStock", value);
-    partial void OnShowReservedColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Reserved", value);
-    partial void OnShowAvailableColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Available", value);
-    partial void OnShowReorderPointColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("ReorderPoint", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
+    partial void OnShowProductColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Product", value); ColumnVisibilityHelper.Save("StockLevels", "Product", value); }
+    partial void OnShowSkuColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Sku", value); ColumnVisibilityHelper.Save("StockLevels", "Sku", value); }
+    partial void OnShowCategoryColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Category", value); ColumnVisibilityHelper.Save("StockLevels", "Category", value); }
+    partial void OnShowLocationColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Location", value); ColumnVisibilityHelper.Save("StockLevels", "Location", value); }
+    partial void OnShowInStockColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("InStock", value); ColumnVisibilityHelper.Save("StockLevels", "InStock", value); }
+    partial void OnShowReservedColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Reserved", value); ColumnVisibilityHelper.Save("StockLevels", "Reserved", value); }
+    partial void OnShowAvailableColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Available", value); ColumnVisibilityHelper.Save("StockLevels", "Available", value); }
+    partial void OnShowReorderPointColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("ReorderPoint", value); ColumnVisibilityHelper.Save("StockLevels", "ReorderPoint", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("StockLevels", "Status", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/ViewModels/SuppliersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/SuppliersPageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Models.Common;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Data;
 using ArgoBooks.Localization;
@@ -38,33 +39,33 @@ public partial class SuppliersPageViewModel : SortablePageViewModelBase
     private double _columnMenuY;
 
     [ObservableProperty]
-    private bool _showSupplierColumn = true;
+    private bool _showSupplierColumn = ColumnVisibilityHelper.Load("Suppliers", "Supplier", true);
 
     [ObservableProperty]
-    private bool _showEmailColumn = true;
+    private bool _showEmailColumn = ColumnVisibilityHelper.Load("Suppliers", "Email", true);
 
     [ObservableProperty]
-    private bool _showPhoneColumn = true;
+    private bool _showPhoneColumn = ColumnVisibilityHelper.Load("Suppliers", "Phone", true);
 
     [ObservableProperty]
-    private bool _showAddressColumn = true;
+    private bool _showAddressColumn = ColumnVisibilityHelper.Load("Suppliers", "Address", true);
 
     [ObservableProperty]
-    private bool _showCountryColumn = true;
+    private bool _showCountryColumn = ColumnVisibilityHelper.Load("Suppliers", "Country", true);
 
     [ObservableProperty]
-    private bool _showProductsColumn = true;
+    private bool _showProductsColumn = ColumnVisibilityHelper.Load("Suppliers", "Products", true);
 
     [ObservableProperty]
-    private bool _showStatusColumn = true;
+    private bool _showStatusColumn = ColumnVisibilityHelper.Load("Suppliers", "Status", true);
 
-    partial void OnShowSupplierColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Supplier", value);
-    partial void OnShowEmailColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Email", value);
-    partial void OnShowPhoneColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Phone", value);
-    partial void OnShowAddressColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Address", value);
-    partial void OnShowCountryColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Country", value);
-    partial void OnShowProductsColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Products", value);
-    partial void OnShowStatusColumnChanged(bool value) => ColumnWidths.SetColumnVisibility("Status", value);
+    partial void OnShowSupplierColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Supplier", value); ColumnVisibilityHelper.Save("Suppliers", "Supplier", value); }
+    partial void OnShowEmailColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Email", value); ColumnVisibilityHelper.Save("Suppliers", "Email", value); }
+    partial void OnShowPhoneColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Phone", value); ColumnVisibilityHelper.Save("Suppliers", "Phone", value); }
+    partial void OnShowAddressColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Address", value); ColumnVisibilityHelper.Save("Suppliers", "Address", value); }
+    partial void OnShowCountryColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Country", value); ColumnVisibilityHelper.Save("Suppliers", "Country", value); }
+    partial void OnShowProductsColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Products", value); ColumnVisibilityHelper.Save("Suppliers", "Products", value); }
+    partial void OnShowStatusColumnChanged(bool value) { ColumnWidths.SetColumnVisibility("Status", value); ColumnVisibilityHelper.Save("Suppliers", "Status", value); }
 
     [RelayCommand]
     private void ToggleColumnMenu()

--- a/ArgoBooks/Views/AppShell.axaml.cs
+++ b/ArgoBooks/Views/AppShell.axaml.cs
@@ -32,6 +32,12 @@ public partial class AppShell : UserControl
     public AppShell()
     {
         InitializeComponent();
+
+        // Use tunnel strategy to catch all pointer presses on sidebar/header,
+        // even when child controls handle the event. This ensures page-level
+        // context menus (column visibility, chart) close on any sidebar/header click.
+        AppSidebar.AddHandler(PointerPressedEvent, OnSidebarPointerPressed, RoutingStrategies.Tunnel);
+        AppHeader.AddHandler(PointerPressedEvent, OnHeaderPointerPressed, RoutingStrategies.Tunnel);
     }
 
     /// <inheritdoc />
@@ -47,6 +53,22 @@ public partial class AppShell : UserControl
         {
             vm.OpenFileScanRequested += OnOpenFileScanRequested;
         }
+    }
+
+    /// <summary>
+    /// Closes page-level context menus when the sidebar is clicked.
+    /// </summary>
+    private void OnSidebarPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        (DataContext as AppShellViewModel)?.ClosePageContextMenus();
+    }
+
+    /// <summary>
+    /// Closes page-level context menus when the header is clicked.
+    /// </summary>
+    private void OnHeaderPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        (DataContext as AppShellViewModel)?.ClosePageContextMenus();
     }
 
     /// <summary>

--- a/ArgoBooks/Views/LostDamagedPage.axaml
+++ b/ArgoBooks/Views/LostDamagedPage.axaml
@@ -53,6 +53,7 @@
                                 IsCompactMode="{Binding ResponsiveHeader.IsCompactMode}"
                                 IsMediumMode="{Binding ResponsiveHeader.IsMediumMode}"
                                 ShowButtonText="{Binding ResponsiveHeader.ShowButtonText}"
+                                ShowAddButton="False"
                                 FilterCommand="{Binding OpenFilterModalCommand}"
                                 ColumnWidthsManager="{Binding ColumnWidths}"
                                 CurrentPage="{Binding CurrentPage, Mode=TwoWay}"

--- a/ArgoBooks/Views/ProductsPage.axaml
+++ b/ArgoBooks/Views/ProductsPage.axaml
@@ -148,6 +148,7 @@
                                 EmptyIcon="{x:Static icons:Icons.Products}"
                                 EmptyTitle="{loc:Loc 'No products found'}"
                                 EmptyMessage="{loc:Loc 'Add your first product to start tracking your inventory.'}"
+                                ShowExtraButtons="{Binding ShowRemainingProducts}"
                                 BorderSizeChanged="OnHeaderSizeChanged"
                                 TableGridSizeChanged="OnTableSizeChanged">
 

--- a/ArgoBooks/Views/RevenuePage.axaml
+++ b/ArgoBooks/Views/RevenuePage.axaml
@@ -241,13 +241,13 @@
                                                                  ColumnWidth="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).ColumnWidths.ShippingColumnWidth}"
                                                                  IsColumnVisible="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).ShowShippingColumn}" />
 
-                                        <!-- Discount - Custom content for SuccessBrush color -->
+                                        <!-- Discount - Custom content for ErrorBrush color -->
                                         <table:ArgoTableCell ColumnWidth="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).ColumnWidths.DiscountColumnWidth}"
                                                                  IsColumnVisible="{Binding $parent[ItemsControl].((vm:RevenuePageViewModel)DataContext).ShowDiscountColumn}">
                                             <table:ArgoTableCell.CellContent>
                                                 <TextBlock Text="{Binding DiscountFormatted}"
                                                            FontSize="14"
-                                                           Foreground="{DynamicResource SuccessBrush}"
+                                                           Foreground="{DynamicResource ErrorBrush}"
                                                            VerticalAlignment="Center" />
                                             </table:ArgoTableCell.CellContent>
                                         </table:ArgoTableCell>


### PR DESCRIPTION
## Summary
This PR adds persistent column visibility settings that are saved to disk and restored when the app restarts. Users can now toggle column visibility in tables and have their preferences remembered across sessions.

## Key Changes

- **New `ColumnVisibilityHelper`**: Created a helper class to load and save column visibility preferences per page, with automatic persistence to global settings
- **Updated `GlobalSettings`**: Added `ColumnVisibility` dictionary to `UiSettings` to store per-page column visibility state
- **Applied to all table pages**: Updated 15+ page view models (Expenses, Invoices, Payments, Products, Categories, Customers, Departments, Locations, PurchaseOrders, LostDamaged, and more) to:
  - Load saved visibility state on initialization via `ColumnVisibilityHelper.Load()`
  - Save changes to disk via `ColumnVisibilityHelper.Save()` when visibility toggles
- **Enhanced `ArgoTable` control**: Added `ShowExtraButtons` property with multi-binding logic to control extra buttons visibility
- **Improved `AppShellViewModel`**: Added `ClosePageContextMenus()` method to properly close context menus when navigating between pages
- **UI refinements**: 
  - Adjusted receipt modal layout (increased max height from 750 to 850, improved grid proportions)
  - Removed category field from receipt modal (moved to separate workflow)
  - Fixed localization key from 'Qty' to 'Quantity'
  - Improved image scaling in receipt preview

## Implementation Details

- Column visibility state is keyed by page name (e.g., "Expenses") and column name (e.g., "Product")
- Default values are preserved for each column if no saved preference exists
- Settings are persisted asynchronously to avoid blocking the UI
- The helper only saves to disk if the value actually changed, optimizing I/O operations

https://claude.ai/code/session_01Mi8kz1JzBU3D3zYe9N3V3n