### PR TITLE
Add company logo extraction and display in recent companies

### DIFF
--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -501,6 +501,15 @@ public class CompanyManager : IDisposable
     }
 
     /// <summary>
+    /// Extracts the company logo from a .argo file without fully opening it.
+    /// Returns null for encrypted files or files without a logo.
+    /// </summary>
+    public Task<byte[]?> ExtractLogoFromFileAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        return _fileService.ExtractLogoFromFileAsync(filePath, cancellationToken);
+    }
+
+    /// <summary>
     /// Gets the list of recent companies with their metadata.
     /// </summary>
     /// <returns>List of recent company info.</returns>

--- a/ArgoBooks.Core/Services/IFileService.cs
+++ b/ArgoBooks.Core/Services/IFileService.cs
@@ -64,4 +64,13 @@ public interface IFileService
     /// <param name="data">Object to serialize</param>
     /// <param name="cancellationToken">Cancellation token</param>
     Task WriteJsonAsync<T>(string tempDirectory, string fileName, T data, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Extracts the company logo from a .argo file without fully opening it.
+    /// Returns null for encrypted files or files without a logo.
+    /// </summary>
+    /// <param name="filePath">Path to the .argo file</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Logo image bytes, or null if not available</returns>
+    Task<byte[]?> ExtractLogoFromFileAsync(string filePath, CancellationToken cancellationToken = default);
 }

--- a/ArgoBooks/Controls/Header.axaml
+++ b/ArgoBooks/Controls/Header.axaml
@@ -187,15 +187,16 @@
                               Width="20" Height="20" />
                 </Button>
 
-                <!-- My Plan (temporary) -->
+                <!-- My Plan - hidden when user has Premium -->
                 <Button Classes="header-icon"
                         Command="{Binding OpenMyPlanCommand}"
-                        ToolTip.Tip="{loc:Loc 'My Plan'}">
+                        ToolTip.Tip="{loc:Loc 'My Plan'}"
+                        IsVisible="{Binding ShowUpgrade}">
                     <PathIcon Data="{x:Static local:Icons.Star}"
                               Width="20" Height="20" />
                 </Button>
 
-                <!-- Settings (temporary) -->
+                <!-- Settings -->
                 <Button Classes="header-icon"
                         Command="{Binding OpenSettingsCommand}"
                         ToolTip.Tip="{loc:Loc Settings}">

--- a/ArgoBooks/Modals/UpgradeModal.axaml
+++ b/ArgoBooks/Modals/UpgradeModal.axaml
@@ -16,7 +16,7 @@
 
     <Panel>
         <!-- Upgrade Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsOpen}" CloseOnBackdropClick="False">
+        <controls:ModalOverlay IsOpen="{Binding IsOpen}" ClosingCommand="{Binding CloseCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
@@ -315,7 +315,7 @@
         </controls:ModalOverlay>
 
         <!-- Enter Key Modal -->
-        <controls:ModalOverlay IsOpen="{Binding IsEnterKeyModalOpen}" CloseOnBackdropClick="False">
+        <controls:ModalOverlay IsOpen="{Binding IsEnterKeyModalOpen}" ClosingCommand="{Binding RequestCloseEnterKeyCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"

--- a/ArgoBooks/ViewModels/FileMenuPanelViewModel.cs
+++ b/ArgoBooks/ViewModels/FileMenuPanelViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using Avalonia;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -283,5 +284,7 @@ public class RecentCompanyItem
     public string? Name { get; set; }
     public string? FilePath { get; set; }
     public string? Icon { get; set; }
+    public Bitmap? Logo { get; set; }
+    public bool HasLogo => Logo != null;
     public DateTime LastOpened { get; set; } = DateTime.Now;
 }

--- a/ArgoBooks/ViewModels/UpgradeModalViewModel.cs
+++ b/ArgoBooks/ViewModels/UpgradeModalViewModel.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Telemetry;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Localization;
@@ -194,6 +195,36 @@ public partial class UpgradeModalViewModel : ViewModelBase
         {
             // Ignore errors opening URL
         }
+    }
+
+    [RelayCommand]
+    private async Task RequestCloseEnterKey()
+    {
+        // If no data was entered, just close
+        if (string.IsNullOrWhiteSpace(LicenseKey))
+        {
+            CloseEnterKey();
+            return;
+        }
+
+        // Data was entered - ask for confirmation
+        var dialog = App.ConfirmationDialog;
+        if (dialog != null)
+        {
+            var result = await dialog.ShowAsync(new ConfirmationDialogOptions
+            {
+                Title = "Discard Changes?".Translate(),
+                Message = "You have entered data that will be lost. Are you sure you want to close?".Translate(),
+                PrimaryButtonText = "Discard".Translate(),
+                CancelButtonText = "Cancel".Translate(),
+                IsPrimaryDestructive = true
+            });
+
+            if (result != ConfirmationResult.Primary)
+                return;
+        }
+
+        CloseEnterKey();
     }
 
     [RelayCommand]

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -1497,8 +1497,8 @@
                 <Border Grid.Column="1"
                         Background="{DynamicResource SurfaceBrush}"
                         Margin="0,24,24,24"
-                        CornerRadius="12"
-                        Padding="0,24,24,24">
+                        CornerRadius="0"
+                        Padding="24">
                     <StackPanel Spacing="20">
                         <TextBlock Text="{loc:Loc 'Export Settings'}"
                                    FontSize="18"

--- a/ArgoBooks/Views/WelcomeScreen.axaml
+++ b/ArgoBooks/Views/WelcomeScreen.axaml
@@ -222,15 +222,22 @@
                                             Command="{Binding $parent[ItemsControl].((vm:WelcomeScreenViewModel)DataContext).OpenRecentCompanyCommand}"
                                             CommandParameter="{Binding}">
                                         <Grid ColumnDefinitions="Auto,*,Auto,Auto">
-                                            <!-- Icon -->
+                                            <!-- Icon / Logo -->
                                             <Border Grid.Column="0"
                                                     Width="44" Height="44"
                                                     CornerRadius="8"
+                                                    ClipToBounds="True"
                                                     Background="{DynamicResource SurfaceAltBrush}"
                                                     Margin="0,0,16,0">
-                                                <PathIcon Data="{x:Static local:Icons.Departments}"
-                                                          Width="22" Height="22"
-                                                          Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                <Panel>
+                                                    <Image Source="{Binding Logo}"
+                                                           Stretch="UniformToFill"
+                                                           IsVisible="{Binding HasLogo}" />
+                                                    <PathIcon Data="{x:Static local:Icons.Departments}"
+                                                              Width="22" Height="22"
+                                                              Foreground="{DynamicResource TextSecondaryBrush}"
+                                                              IsVisible="{Binding !HasLogo}" />
+                                                </Panel>
                                             </Border>
 
                                             <!-- Company Info -->


### PR DESCRIPTION
## Summary
This PR adds the ability to extract and display company logos in the welcome screen's recent companies list, without requiring the full .argo file to be opened. It also includes UI improvements and bug fixes.

## Key Changes

### Logo Extraction Feature
- Added `ExtractLogoFromFileAsync()` method to `IFileService` and `FileService` to extract logos from .argo files without full decompression
- Implemented TAR reader logic to locate and extract logo files from the compressed archive
- Returns `null` for encrypted files or files without logos, with graceful error handling
- Added corresponding method to `CompanyManager` as a public wrapper

### Welcome Screen Improvements
- Modified `LoadRecentCompaniesAsync()` to extract logos in parallel for all recent companies
- Updated `RecentCompanyItem` to include `Logo` bitmap and `HasLogo` property
- Enhanced WelcomeScreen.axaml to display company logos in recent companies list with fallback to building icon
- Added `LoadBitmapFromBytes()` helper method to safely convert byte arrays to Avalonia bitmaps

### Company Creation Flow
- Fixed logo application during company creation to properly set and display the logo
- Moved `SaveCompanyAsync()` call to after logo setup to ensure all changes are persisted
- Updated UI to refresh with newly set logo immediately after creation

### UI/UX Fixes
- Made "My Plan" button visibility conditional on `ShowUpgrade` binding (hidden for Premium users)
- Fixed UpgradeModal closing behavior to use `ClosingCommand` instead of `CloseOnBackdropClick`
- Added confirmation dialog when closing Enter Key modal with unsaved data
- Adjusted ReportsPage export settings border styling (removed corner radius, adjusted padding)
- Added `ClipToBounds` to logo container in recent companies for proper image clipping

## Implementation Details
- Logo extraction uses TAR reader with `leaveOpen: true` to avoid closing the decompression stream prematurely
- Parallel logo extraction improves performance when loading multiple recent companies
- All logo operations are wrapped in try-catch to handle corrupted or inaccessible files gracefully
- Maintains backward compatibility with companies that don't have logos

https://claude.ai/code/session_01WXmgfqKEoBihxum4XgZof8