### PR TITLE
Add CenteringWrapPanel for centered quick action buttons

### DIFF
--- a/ArgoBooks/Controls/CenteringWrapPanel.cs
+++ b/ArgoBooks/Controls/CenteringWrapPanel.cs
@@ -1,0 +1,99 @@
+using Avalonia;
+using Avalonia.Controls;
+
+namespace ArgoBooks.Controls;
+
+/// <summary>
+/// A WrapPanel variant that centers each row of items horizontally.
+/// Standard WrapPanel left-aligns items per row; this panel distributes
+/// the leftover space equally on both sides of each row.
+/// </summary>
+public class CenteringWrapPanel : Panel
+{
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        double rowWidth = 0;
+        double rowHeight = 0;
+        double totalHeight = 0;
+        double maxRowWidth = 0;
+
+        foreach (var child in Children)
+        {
+            child.Measure(availableSize);
+
+            if (!child.IsVisible)
+                continue;
+
+            var desired = child.DesiredSize;
+
+            if (rowWidth + desired.Width > availableSize.Width && rowWidth > 0)
+            {
+                maxRowWidth = Math.Max(maxRowWidth, rowWidth);
+                totalHeight += rowHeight;
+                rowWidth = 0;
+                rowHeight = 0;
+            }
+
+            rowWidth += desired.Width;
+            rowHeight = Math.Max(rowHeight, desired.Height);
+        }
+
+        maxRowWidth = Math.Max(maxRowWidth, rowWidth);
+        totalHeight += rowHeight;
+
+        return new Size(maxRowWidth, totalHeight);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        // Collect visible children into rows, then center each row.
+        var children = Children;
+        double y = 0;
+        int rowStart = 0;
+        double rowWidth = 0;
+        double rowHeight = 0;
+
+        for (int i = 0; i <= children.Count; i++)
+        {
+            bool isEnd = i == children.Count;
+            bool wrap = false;
+            Size desired = default;
+
+            if (!isEnd)
+            {
+                if (!children[i].IsVisible)
+                    continue;
+
+                desired = children[i].DesiredSize;
+                wrap = rowWidth + desired.Width > finalSize.Width && rowWidth > 0;
+            }
+
+            if (isEnd || wrap)
+            {
+                // Arrange the completed row centered
+                double x = (finalSize.Width - rowWidth) / 2.0;
+                for (int j = rowStart; j < i; j++)
+                {
+                    if (!children[j].IsVisible)
+                        continue;
+                    var d = children[j].DesiredSize;
+                    children[j].Arrange(new Rect(x, y, d.Width, rowHeight));
+                    x += d.Width;
+                }
+
+                y += rowHeight;
+                rowStart = i;
+                rowWidth = 0;
+                rowHeight = 0;
+            }
+
+            if (!isEnd)
+            {
+                rowWidth += desired.Width;
+                rowHeight = Math.Max(rowHeight, desired.Height);
+            }
+        }
+
+        return new Size(finalSize.Width, y);
+    }
+}

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -173,16 +173,9 @@
                         </Button>
                     </Grid>
 
-                    <!-- Responsive WrapPanel for Quick Actions -->
-                    <ItemsControl>
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel Orientation="Horizontal" HorizontalAlignment="Center" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.Items>
-                            <!-- New Invoice -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                    <!-- Responsive WrapPanel for Quick Actions (centered per row) -->
+                    <controls:CenteringWrapPanel Margin="0,8,0,0">
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewInvoiceCommand}"
                                 IsVisible="{Binding ShowNewInvoice}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -190,13 +183,13 @@
                                     <PathIcon Data="{x:Static local:Icons.Invoices}"
                                               Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Invoice'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Invoice'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Expense -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding AddExpenseCommand}"
                                 IsVisible="{Binding ShowNewExpense}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -204,13 +197,13 @@
                                     <PathIcon Data="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                                               Width="16" Height="16" Foreground="{DynamicResource DangerBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Expense'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Expense'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Revenue -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding RecordSaleCommand}"
                                 IsVisible="{Binding ShowNewRevenue}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -218,13 +211,13 @@
                                     <PathIcon Data="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
                                               Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Revenue'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Revenue'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- Scan Receipt -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding ScanReceiptCommand}"
                                 IsVisible="{Binding ShowScanReceipt}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -232,13 +225,13 @@
                                     <PathIcon Data="{x:Static local:Icons.ScanReceipt}"
                                               Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'Scan Receipt'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'Scan Receipt'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Customer -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewCustomerCommand}"
                                 IsVisible="{Binding ShowNewCustomer}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -246,13 +239,13 @@
                                     <PathIcon Data="{x:Static local:Icons.NewCustomer}"
                                               Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Customer'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Customer'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Supplier -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewSupplierCommand}"
                                 IsVisible="{Binding ShowNewSupplier}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -260,13 +253,13 @@
                                     <PathIcon Data="{x:Static local:Icons.Suppliers}"
                                               Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Supplier'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Supplier'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Product -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewProductCommand}"
                                 IsVisible="{Binding ShowNewProduct}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -274,13 +267,13 @@
                                     <PathIcon Data="{x:Static local:Icons.NewProduct}"
                                               Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Product'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Product'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- Record Payment -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding RecordPaymentCommand}"
                                 IsVisible="{Binding ShowRecordPayment}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -288,13 +281,13 @@
                                     <PathIcon Data="{x:Static local:Icons.Payments}"
                                               Width="16" Height="16" Foreground="{DynamicResource SuccessBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'Record Payment'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'Record Payment'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Rental Item -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewRentalItemCommand}"
                                 IsVisible="{Binding ShowNewRentalItem}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -302,13 +295,13 @@
                                     <PathIcon Data="{x:Static local:Icons.NewRentalItem}"
                                               Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Rental Item'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Rental Item'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Rental Record -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewRentalCommand}"
                                 IsVisible="{Binding ShowNewRentalRecord}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -316,13 +309,13 @@
                                     <PathIcon Data="{x:Static local:Icons.RentalRecords}"
                                               Width="16" Height="16" Foreground="{DynamicResource InfoBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Rental'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Rental'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Category -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewCategoryCommand}"
                                 IsVisible="{Binding ShowNewCategory}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -330,13 +323,13 @@
                                     <PathIcon Data="M12 2l-5.5 9h11L12 2zm0 3.84L13.93 9h-3.87L12 5.84z"
                                               Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Category'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Category'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Department -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewDepartmentCommand}"
                                 IsVisible="{Binding ShowNewDepartment}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -344,13 +337,13 @@
                                     <PathIcon Data="{x:Static local:Icons.Departments}"
                                               Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Department'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Department'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Location -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewLocationCommand}"
                                 IsVisible="{Binding ShowNewLocation}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -358,13 +351,13 @@
                                     <PathIcon Data="{x:Static local:Icons.Locations}"
                                               Width="16" Height="16" Foreground="{DynamicResource WarningBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'New Location'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'New Location'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Purchase Order -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewPurchaseOrderCommand}"
                                 IsVisible="{Binding ShowNewPurchaseOrder}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -372,13 +365,13 @@
                                     <PathIcon Data="{x:Static local:Icons.NewPurchaseOrder}"
                                               Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'Purchase Order'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'Purchase Order'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
 
                         <!-- New Stock Adjustment -->
-                        <Button Classes="quick-action-compact" Margin="6" Width="160"
+                        <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewStockAdjustmentCommand}"
                                 IsVisible="{Binding ShowNewStockAdjustment}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
@@ -386,12 +379,11 @@
                                     <PathIcon Data="{x:Static local:Icons.NewStockAdjustment}"
                                               Width="16" Height="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'Stock Adjustment'}" FontSize="13" FontWeight="Medium"
+                                <TextBlock Text="{loc:Loc 'Stock Adjustment'}" FontSize="12" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" VerticalAlignment="Center" />
                             </StackPanel>
                         </Button>
-                        </ItemsControl.Items>
-                    </ItemsControl>
+                    </controls:CenteringWrapPanel>
                 </StackPanel>
             </Border>
 


### PR DESCRIPTION
## Summary
Replaces the standard WrapPanel with a custom `CenteringWrapPanel` control that centers each row of quick action buttons horizontally on the dashboard, improving visual balance and responsiveness.

## Changes
- **New Control**: Added `CenteringWrapPanel` class that extends `Panel` to provide row-based horizontal centering
  - Implements custom `MeasureOverride` to calculate row dimensions
  - Implements custom `ArrangeOverride` to center each row by distributing leftover space equally on both sides
  - Properly handles visibility of child elements
  
- **Dashboard Update**: Replaced `ItemsControl` with `WrapPanel` with the new `CenteringWrapPanel`
  - Simplified markup by removing `ItemsPanel` template wrapper
  - Updated button widths from 160 to 165 for better proportions
  - Reduced button text font size from 13 to 12 for improved fit
  - Added margin to the panel for better spacing

## Implementation Details
The `CenteringWrapPanel` calculates the maximum width needed for each row during measurement, then during arrangement, centers each completed row by calculating `x = (finalSize.Width - rowWidth) / 2.0` before positioning child elements. This ensures responsive behavior across different screen sizes while maintaining centered alignment.

https://claude.ai/code/session_015sSwHCjKcGiYdXKKNaRcsT