### PR TITLE
Add empty state messages for filtered date ranges in charts

### DIFF
--- a/ArgoBooks/Controls/ChartEmptyState.axaml
+++ b/ArgoBooks/Controls/ChartEmptyState.axaml
@@ -1,0 +1,28 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:loc="using:ArgoBooks.Localization"
+             mc:Ignorable="d"
+             x:Class="ArgoBooks.Controls.ChartEmptyState"
+             x:DataType="controls:ChartEmptyState">
+
+    <Border Background="{DynamicResource SurfaceAltBrush}"
+            CornerRadius="8">
+        <Panel>
+            <TextBlock Text="{Binding DefaultMessage, RelativeSource={RelativeSource AncestorType=controls:ChartEmptyState}}"
+                       IsVisible="{Binding !ShowDateRangeMessage, RelativeSource={RelativeSource AncestorType=controls:ChartEmptyState}}"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       FontSize="14"
+                       Foreground="{DynamicResource TextTertiaryBrush}" />
+            <TextBlock Text="{loc:Loc 'No data available in the selected date range'}"
+                       IsVisible="{Binding ShowDateRangeMessage, RelativeSource={RelativeSource AncestorType=controls:ChartEmptyState}}"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       FontSize="14"
+                       Foreground="{DynamicResource TextTertiaryBrush}" />
+        </Panel>
+    </Border>
+</UserControl>

--- a/ArgoBooks/Controls/ChartEmptyState.axaml.cs
+++ b/ArgoBooks/Controls/ChartEmptyState.axaml.cs
@@ -1,0 +1,42 @@
+using Avalonia;
+using Avalonia.Controls;
+
+namespace ArgoBooks.Controls;
+
+/// <summary>
+/// A reusable empty state placeholder for charts. Shows a context-aware message:
+/// either the default message (no data at all) or a date range message (data exists
+/// but not in the selected range).
+/// </summary>
+public partial class ChartEmptyState : UserControl
+{
+    public static readonly StyledProperty<string> DefaultMessageProperty =
+        AvaloniaProperty.Register<ChartEmptyState, string>(nameof(DefaultMessage), "No data available");
+
+    public static readonly StyledProperty<bool> ShowDateRangeMessageProperty =
+        AvaloniaProperty.Register<ChartEmptyState, bool>(nameof(ShowDateRangeMessage));
+
+    /// <summary>
+    /// Gets or sets the default message shown when no data exists at all.
+    /// </summary>
+    public string DefaultMessage
+    {
+        get => GetValue(DefaultMessageProperty);
+        set => SetValue(DefaultMessageProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether to show the date range message instead of the default.
+    /// When true, shows "No data available in the selected date range".
+    /// </summary>
+    public bool ShowDateRangeMessage
+    {
+        get => GetValue(ShowDateRangeMessageProperty);
+        set => SetValue(ShowDateRangeMessageProperty, value);
+    }
+
+    public ChartEmptyState()
+    {
+        InitializeComponent();
+    }
+}

--- a/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
@@ -1007,6 +1007,46 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
 
     #endregion
 
+    #region Empty State Date Range Detection
+
+    /// <summary>
+    /// True when revenue data exists in all time but the current date range filter is excluding it.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showRevenueDateRangeMessage;
+
+    /// <summary>
+    /// True when expense data exists in all time but the current date range filter is excluding it.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showExpenseDateRangeMessage;
+
+    /// <summary>
+    /// True when financial data (revenue or expenses) exists in all time but the current date range filter is excluding it.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showFinancialDateRangeMessage;
+
+    /// <summary>
+    /// True when return data exists in all time but the current date range filter is excluding it.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showReturnDateRangeMessage;
+
+    /// <summary>
+    /// True when loss data exists in all time but the current date range filter is excluding it.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showLossDateRangeMessage;
+
+    /// <summary>
+    /// True when rental data exists in all time but the current date range filter is excluding it.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showRentalDateRangeMessage;
+
+    #endregion
+
     #region Chart Titles
 
     // Dashboard Tab Chart Titles
@@ -1465,6 +1505,15 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
             "Scatter" => ChartStyle.Scatter,
             _ => ChartStyle.Line
         };
+
+        // Determine if a date range filter is active and data exists beyond it
+        var isFiltered = SelectedDateRange != "All Time";
+        ShowRevenueDateRangeMessage = isFiltered && data.Revenues.Count > 0;
+        ShowExpenseDateRangeMessage = isFiltered && data.Expenses.Count > 0;
+        ShowFinancialDateRangeMessage = isFiltered && (data.Revenues.Count > 0 || data.Expenses.Count > 0);
+        ShowReturnDateRangeMessage = isFiltered && data.Returns.Count > 0;
+        ShowLossDateRangeMessage = isFiltered && data.LostDamaged.Count > 0;
+        ShowRentalDateRangeMessage = isFiltered && data.Rentals.Count > 0;
 
         // Load statistics for stat cards
         LoadAllStatistics(data);

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -500,6 +500,17 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
 
     #endregion
 
+    #region Empty State Date Range Detection
+
+    /// <summary>
+    /// True when financial data (revenues or expenses) exists in all time but the current
+    /// date range filter is excluding it. Used to show "no data in selected date range" messages.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showFinancialDateRangeMessage;
+
+    #endregion
+
     #region Company Data Reference
 
     private CompanyManager? _companyManager;
@@ -707,6 +718,10 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
 
         // Correct rental statuses before displaying
         CorrectRentalStatuses(data);
+
+        // Determine if a date range filter is active and data exists beyond it
+        var isFiltered = SelectedDateRange != "All Time";
+        ShowFinancialDateRangeMessage = isFiltered && (data.Revenues.Count > 0 || data.Expenses.Count > 0);
 
         LoadStatistics(data);
         LoadRecentTransactions(data);

--- a/ArgoBooks/Views/AnalyticsPage.axaml
+++ b/ArgoBooks/Views/AnalyticsPage.axaml
@@ -128,15 +128,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasProfitTrendsData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasProfitTrendsData}">
-                                    <TextBlock Text="{loc:Loc 'No profit data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasProfitTrendsData}"
+                                    DefaultMessage="{loc:Loc 'No profit data available'}"
+                                    ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -159,15 +154,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasRevenueVsExpensesData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasRevenueVsExpensesData}">
-                                    <TextBlock Text="{loc:Loc 'No comparison data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasRevenueVsExpensesData}"
+                                    DefaultMessage="{loc:Loc 'No comparison data available'}"
+                                    ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -193,15 +183,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasRevenueTrendsData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasRevenueTrendsData}">
-                                    <TextBlock Text="{loc:Loc 'No revenue data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasRevenueTrendsData}"
+                                    DefaultMessage="{loc:Loc 'No revenue data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -240,15 +225,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasRevenueDistributionData}">
-                                    <TextBlock Text="{loc:Loc 'No distribution data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasRevenueDistributionData}"
+                                    DefaultMessage="{loc:Loc 'No distribution data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -274,15 +254,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasExpensesTrendsData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasExpensesTrendsData}">
-                                    <TextBlock Text="{loc:Loc 'No expense data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasExpensesTrendsData}"
+                                    DefaultMessage="{loc:Loc 'No expense data available'}"
+                                    ShowDateRangeMessage="{Binding ShowExpenseDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -321,15 +296,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasExpensesDistributionData}">
-                                    <TextBlock Text="{loc:Loc 'No distribution data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasExpensesDistributionData}"
+                                    DefaultMessage="{loc:Loc 'No distribution data available'}"
+                                    ShowDateRangeMessage="{Binding ShowExpenseDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -375,15 +345,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasCountriesOfOriginData}">
-                                    <TextBlock Text="{loc:Loc 'No country data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasCountriesOfOriginData}"
+                                    DefaultMessage="{loc:Loc 'No country data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -422,15 +387,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasCompaniesOfOriginData}">
-                                    <TextBlock Text="{loc:Loc 'No company data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasCompaniesOfOriginData}"
+                                    DefaultMessage="{loc:Loc 'No company data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -472,15 +432,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasCountriesOfDestinationData}">
-                                    <TextBlock Text="{loc:Loc 'No destination data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasCountriesOfDestinationData}"
+                                    DefaultMessage="{loc:Loc 'No destination data available'}"
+                                    ShowDateRangeMessage="{Binding ShowExpenseDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -519,15 +474,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasCompaniesOfDestinationData}">
-                                    <TextBlock Text="{loc:Loc 'No company data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasCompaniesOfDestinationData}"
+                                    DefaultMessage="{loc:Loc 'No company data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -583,35 +533,27 @@
                                                 PointerPressed="OnChartPointerPressed"
                                                     PointerReleased="OnChartPointerReleased" />
                                     <!-- No data message for Origin (only show when in origin mode AND no data) -->
-                                    <Border Background="{DynamicResource SurfaceAltBrush}"
-                                            CornerRadius="8">
-                                        <Border.IsVisible>
+                                    <controls:ChartEmptyState
+                                        DefaultMessage="{loc:Loc 'No origin data available'}"
+                                        ShowDateRangeMessage="{Binding ShowExpenseDateRangeMessage}">
+                                        <controls:ChartEmptyState.IsVisible>
                                             <MultiBinding Converter="{x:Static BoolConverters.And}">
                                                 <Binding Path="IsMapModeOrigin" />
                                                 <Binding Path="!HasOriginMapData" />
                                             </MultiBinding>
-                                        </Border.IsVisible>
-                                        <TextBlock Text="{loc:Loc 'No origin data available'}"
-                                                   HorizontalAlignment="Center"
-                                                   VerticalAlignment="Center"
-                                                   FontSize="14"
-                                                   Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    </Border>
+                                        </controls:ChartEmptyState.IsVisible>
+                                    </controls:ChartEmptyState>
                                     <!-- No data message for Destination (only show when in destination mode AND no data) -->
-                                    <Border Background="{DynamicResource SurfaceAltBrush}"
-                                            CornerRadius="8">
-                                        <Border.IsVisible>
+                                    <controls:ChartEmptyState
+                                        DefaultMessage="{loc:Loc 'No destination data available'}"
+                                        ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}">
+                                        <controls:ChartEmptyState.IsVisible>
                                             <MultiBinding Converter="{x:Static BoolConverters.And}">
                                                 <Binding Path="IsMapModeDestination" />
                                                 <Binding Path="!HasDestinationMapData" />
                                             </MultiBinding>
-                                        </Border.IsVisible>
-                                        <TextBlock Text="{loc:Loc 'No destination data available'}"
-                                                   HorizontalAlignment="Center"
-                                                   VerticalAlignment="Center"
-                                                   FontSize="14"
-                                                   Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    </Border>
+                                        </controls:ChartEmptyState.IsVisible>
+                                    </controls:ChartEmptyState>
                                 </Panel>
                             </Border>
                         </Grid>
@@ -687,15 +629,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasAccountantsTransactionsData}">
-                                    <TextBlock Text="{loc:Loc 'No accountant data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasAccountantsTransactionsData}"
+                                    DefaultMessage="{loc:Loc 'No accountant data available'}"
+                                    ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -718,15 +655,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasTotalTransactionsData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasTotalTransactionsData}">
-                                    <TextBlock Text="{loc:Loc 'No transaction data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasTotalTransactionsData}"
+                                    DefaultMessage="{loc:Loc 'No transaction data available'}"
+                                    ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -788,15 +720,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasAvgTransactionValueData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasAvgTransactionValueData}">
-                                    <TextBlock Text="{loc:Loc 'No transaction data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasAvgTransactionValueData}"
+                                    DefaultMessage="{loc:Loc 'No transaction data available'}"
+                                    ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -819,15 +746,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasTotalTransactionsData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasTotalTransactionsData}">
-                                    <TextBlock Text="{loc:Loc 'No transaction data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasTotalTransactionsData}"
+                                    DefaultMessage="{loc:Loc 'No transaction data available'}"
+                                    ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -852,15 +774,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasAvgShippingCostsData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasAvgShippingCostsData}">
-                                    <TextBlock Text="{loc:Loc 'No shipping data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasAvgShippingCostsData}"
+                                    DefaultMessage="{loc:Loc 'No shipping data available'}"
+                                    ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -938,15 +855,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasCompaniesOfOriginData}">
-                                    <TextBlock Text="{loc:Loc 'No customer data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasCompaniesOfOriginData}"
+                                    DefaultMessage="{loc:Loc 'No customer data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -985,15 +897,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasCustomerPaymentStatusData}">
-                                    <TextBlock Text="{loc:Loc 'No payment data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasCustomerPaymentStatusData}"
+                                    DefaultMessage="{loc:Loc 'No payment data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -1019,15 +926,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasCustomerGrowthData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasCustomerGrowthData}">
-                                    <TextBlock Text="{loc:Loc 'No growth data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasCustomerGrowthData}"
+                                    DefaultMessage="{loc:Loc 'No growth data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -1050,15 +952,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasAvgTransactionValueData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasAvgTransactionValueData}">
-                                    <TextBlock Text="{loc:Loc 'No value data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasAvgTransactionValueData}"
+                                    DefaultMessage="{loc:Loc 'No value data available'}"
+                                    ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -1100,15 +997,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasActiveInactiveCustomersData}">
-                                    <TextBlock Text="{loc:Loc 'No customer activity data'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasActiveInactiveCustomersData}"
+                                    DefaultMessage="{loc:Loc 'No customer activity data'}"
+                                    ShowDateRangeMessage="{Binding ShowRevenueDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -1131,15 +1023,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasTotalTransactionsData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasTotalTransactionsData}">
-                                    <TextBlock Text="{loc:Loc 'No rental data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasTotalTransactionsData}"
+                                    DefaultMessage="{loc:Loc 'No rental data available'}"
+                                    ShowDateRangeMessage="{Binding ShowRentalDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -1201,15 +1088,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasReturnsOverTimeData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasReturnsOverTimeData}">
-                                    <TextBlock Text="{loc:Loc 'No returns data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasReturnsOverTimeData}"
+                                    DefaultMessage="{loc:Loc 'No returns data available'}"
+                                    ShowDateRangeMessage="{Binding ShowReturnDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -1248,15 +1130,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasReturnReasonsData}">
-                                    <TextBlock Text="{loc:Loc 'No return reasons data'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasReturnReasonsData}"
+                                    DefaultMessage="{loc:Loc 'No return reasons data'}"
+                                    ShowDateRangeMessage="{Binding ShowReturnDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -1282,15 +1159,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasReturnFinancialImpactData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasReturnFinancialImpactData}">
-                                    <TextBlock Text="{loc:Loc 'No financial impact data'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasReturnFinancialImpactData}"
+                                    DefaultMessage="{loc:Loc 'No financial impact data'}"
+                                    ShowDateRangeMessage="{Binding ShowReturnDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -1329,15 +1201,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasReturnsByCategoryData}">
-                                    <TextBlock Text="{loc:Loc 'No category data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasReturnsByCategoryData}"
+                                    DefaultMessage="{loc:Loc 'No category data available'}"
+                                    ShowDateRangeMessage="{Binding ShowReturnDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -1379,15 +1246,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasReturnsByProductData}">
-                                    <TextBlock Text="{loc:Loc 'No product data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasReturnsByProductData}"
+                                    DefaultMessage="{loc:Loc 'No product data available'}"
+                                    ShowDateRangeMessage="{Binding ShowReturnDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -1410,15 +1272,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasExpenseVsRevenueReturnsData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasExpenseVsRevenueReturnsData}">
-                                    <TextBlock Text="{loc:Loc 'No comparison data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasExpenseVsRevenueReturnsData}"
+                                    DefaultMessage="{loc:Loc 'No comparison data available'}"
+                                    ShowDateRangeMessage="{Binding ShowReturnDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -1480,15 +1337,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasLossesOverTimeData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasLossesOverTimeData}">
-                                    <TextBlock Text="{loc:Loc 'No losses data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasLossesOverTimeData}"
+                                    DefaultMessage="{loc:Loc 'No losses data available'}"
+                                    ShowDateRangeMessage="{Binding ShowLossDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -1527,15 +1379,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasLossReasonsData}">
-                                    <TextBlock Text="{loc:Loc 'No loss reasons data'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasLossReasonsData}"
+                                    DefaultMessage="{loc:Loc 'No loss reasons data'}"
+                                    ShowDateRangeMessage="{Binding ShowLossDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -1561,15 +1408,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasLossFinancialImpactData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasLossFinancialImpactData}">
-                                    <TextBlock Text="{loc:Loc 'No financial impact data'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasLossFinancialImpactData}"
+                                    DefaultMessage="{loc:Loc 'No financial impact data'}"
+                                    ShowDateRangeMessage="{Binding ShowLossDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -1608,15 +1450,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasLossesByCategoryData}">
-                                    <TextBlock Text="{loc:Loc 'No category data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasLossesByCategoryData}"
+                                    DefaultMessage="{loc:Loc 'No category data available'}"
+                                    ShowDateRangeMessage="{Binding ShowLossDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>
@@ -1658,15 +1495,10 @@
                                     </Grid>
                                 </Grid>
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasLossesByProductData}">
-                                    <TextBlock Text="{loc:Loc 'No product data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasLossesByProductData}"
+                                    DefaultMessage="{loc:Loc 'No product data available'}"
+                                    ShowDateRangeMessage="{Binding ShowLossDateRangeMessage}" />
                             </Panel>
                         </Border>
 
@@ -1689,15 +1521,10 @@
                                                     ZoomMode="Both"
                                                     IsVisible="{Binding HasExpenseVsRevenueLossesData}" />
                                 <!-- No data placeholder -->
-                                <Border Background="{DynamicResource SurfaceAltBrush}"
-                                        CornerRadius="8"
-                                        IsVisible="{Binding !HasExpenseVsRevenueLossesData}">
-                                    <TextBlock Text="{loc:Loc 'No comparison data available'}"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontSize="14"
-                                               Foreground="{DynamicResource TextTertiaryBrush}" />
-                                </Border>
+                                <controls:ChartEmptyState
+                                    IsVisible="{Binding !HasExpenseVsRevenueLossesData}"
+                                    DefaultMessage="{loc:Loc 'No comparison data available'}"
+                                    ShowDateRangeMessage="{Binding ShowLossDateRangeMessage}" />
                             </Panel>
                         </Border>
                     </Grid>

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -417,15 +417,10 @@
                             PointerReleased="OnChartPointerReleased" />
 
                         <!-- Empty state placeholder -->
-                        <Border Background="{DynamicResource SurfaceAltBrush}"
-                                CornerRadius="8"
-                                IsVisible="{Binding !HasProfitsChartData}">
-                            <TextBlock Text="{loc:Loc 'No profit data'}"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       FontSize="14"
-                                       Foreground="{DynamicResource TextTertiaryBrush}" />
-                        </Border>
+                        <controls:ChartEmptyState
+                            IsVisible="{Binding !HasProfitsChartData}"
+                            DefaultMessage="{loc:Loc 'No profit data'}"
+                            ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                     </Grid>
                 </Border>
 
@@ -446,15 +441,10 @@
                             IsVisible="{Binding HasRevenueVsExpensesData}"
                             PointerPressed="OnChartPointerPressed"
                             PointerReleased="OnChartPointerReleased" />
-                        <Border Background="{DynamicResource SurfaceAltBrush}"
-                                CornerRadius="8"
-                                IsVisible="{Binding !HasRevenueVsExpensesData}">
-                            <TextBlock Text="{loc:Loc 'No expense/revenue data available'}"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       FontSize="14"
-                                       Foreground="{DynamicResource TextTertiaryBrush}" />
-                        </Border>
+                        <controls:ChartEmptyState
+                            IsVisible="{Binding !HasRevenueVsExpensesData}"
+                            DefaultMessage="{loc:Loc 'No expense/revenue data available'}"
+                            ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
                     </Grid>
                 </Border>
             </Grid>


### PR DESCRIPTION
## Summary
This PR introduces a new `ChartEmptyState` control and implements intelligent empty state messaging across the analytics and dashboard pages. When users filter by a date range and no data exists within that range, charts now display a contextual message indicating "No data available in the selected date range" instead of a generic empty state.

## Key Changes

- **New ChartEmptyState Control**: Created a reusable `ChartEmptyState` UserControl that displays context-aware messages:
  - Shows a default message when no data exists at all
  - Shows a date range-specific message when data exists but is filtered out by the selected date range
  - Supports customizable default message via the `DefaultMessage` property

- **AnalyticsPageViewModel Updates**: Added six new observable properties to track date range filtering for different data types:
  - `ShowRevenueDateRangeMessage`
  - `ShowExpenseDateRangeMessage`
  - `ShowFinancialDateRangeMessage`
  - `ShowReturnDateRangeMessage`
  - `ShowLossDateRangeMessage`
  - `ShowRentalDateRangeMessage`
  - Logic to detect when a non-"All Time" date range is selected and data exists beyond the filter

- **DashboardPageViewModel Updates**: Added `ShowFinancialDateRangeMessage` property with similar date range detection logic for the dashboard's financial charts

## Implementation Details

- The empty state detection logic checks two conditions:
  1. A date range filter is active (`SelectedDateRange != "All Time"`)
  2. Data exists in the unfiltered dataset (e.g., `data.Revenues.Count > 0`)
  
- When both conditions are true, the appropriate message flag is set to display the date range-specific message
- The control uses Avalonia's binding system with relative source binding to access the parent control's properties
- Localization support is included for the date range message via the `loc:Loc` markup extension

https://claude.ai/code/session_011u1VEi2RqvB6fixzZuyeEV