### PR TITLE
Remove legacy data migration code and update dependencies

### DIFF
--- a/ArgoBooks.Core/ArgoBooks.Core.csproj
+++ b/ArgoBooks.Core/ArgoBooks.Core.csproj
@@ -43,9 +43,9 @@
         <PackageReference Include="Microsoft.ML.TimeSeries" />
     </ItemGroup>
 
-    <!-- Windows-specific packages -->
-    <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
-        <!-- DPAPI for secure credential storage -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.17763.0'">
         <PackageReference Include="System.Security.Cryptography.ProtectedData" />
     </ItemGroup>
+
+    <!-- Windows-specific packages -->
 </Project>

--- a/ArgoBooks.Core/Models/Common/MonetaryValue.cs
+++ b/ArgoBooks.Core/Models/Common/MonetaryValue.cs
@@ -69,17 +69,6 @@ public class MonetaryValue
     }
 
     /// <summary>
-    /// Creates a MonetaryValue from a legacy decimal value, assuming it's in USD.
-    /// Used for data migration from older file formats.
-    /// </summary>
-    /// <param name="legacyAmount">The legacy decimal amount.</param>
-    /// <returns>A new MonetaryValue with the amount set as USD.</returns>
-    public static MonetaryValue FromLegacy(decimal legacyAmount)
-    {
-        return new MonetaryValue(legacyAmount);
-    }
-
-    /// <summary>
     /// Implicit conversion from decimal to MonetaryValue (assumes USD).
     /// </summary>
     public static implicit operator MonetaryValue(decimal amount) => new(amount);

--- a/ArgoBooks.Core/Services/ChartExcelExportService.cs
+++ b/ArgoBooks.Core/Services/ChartExcelExportService.cs
@@ -22,7 +22,7 @@ public class ChartExcelExportService
     static ChartExcelExportService()
     {
         // Set EPPlus license for non-commercial use
-        ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+        ExcelPackage.License.SetNonCommercialPersonal("ArgoBooks");
     }
 
     /// <summary>

--- a/ArgoBooks.Core/Services/FileService.cs
+++ b/ArgoBooks.Core/Services/FileService.cs
@@ -279,67 +279,7 @@ public class FileService(
             ReportTemplates = await ReadJsonAsync<List<Models.Reports.ReportTemplate>>(tempDirectory, "reportTemplates.json", cancellationToken) ?? []
         };
 
-        // Migrate legacy data: set USD values for transactions that don't have them
-        MigrateCurrencyData(data);
-
         return data;
-    }
-
-    /// <summary>
-    /// Migrates legacy company data to support multi-currency.
-    /// For existing transactions without USD fields, assumes amounts are in USD.
-    /// </summary>
-    private static void MigrateCurrencyData(CompanyData data)
-    {
-        // Migrate Revenues
-        foreach (var revenue in data.Revenues)
-        {
-            if (revenue.TotalUSD == 0 && revenue.Total != 0)
-            {
-                // Legacy data - assume amounts are in USD
-                revenue.OriginalCurrency = "USD";
-                revenue.TotalUSD = revenue.Total;
-                revenue.UnitPriceUSD = revenue.UnitPrice;
-                revenue.ShippingCostUSD = revenue.ShippingCost;
-                revenue.TaxAmountUSD = revenue.TaxAmount;
-                revenue.DiscountUSD = revenue.Discount;
-            }
-        }
-
-        // Migrate Expenses
-        foreach (var expense in data.Expenses)
-        {
-            if (expense.TotalUSD == 0 && expense.Total != 0)
-            {
-                expense.OriginalCurrency = "USD";
-                expense.TotalUSD = expense.Total;
-                expense.UnitPriceUSD = expense.UnitPrice;
-                expense.ShippingCostUSD = expense.ShippingCost;
-                expense.TaxAmountUSD = expense.TaxAmount;
-                expense.DiscountUSD = expense.Discount;
-            }
-        }
-
-        // Migrate Invoices
-        foreach (var invoice in data.Invoices)
-        {
-            if (invoice.TotalUSD == 0 && invoice.Total != 0)
-            {
-                invoice.OriginalCurrency = "USD";
-                invoice.TotalUSD = invoice.Total;
-                invoice.BalanceUSD = invoice.Balance;
-            }
-        }
-
-        // Migrate Payments
-        foreach (var payment in data.Payments)
-        {
-            if (payment.AmountUSD == 0 && payment.Amount != 0)
-            {
-                payment.OriginalCurrency = "USD";
-                payment.AmountUSD = payment.Amount;
-            }
-        }
     }
 
     /// <summary>

--- a/ArgoBooks.Core/Services/SampleCompanyService.cs
+++ b/ArgoBooks.Core/Services/SampleCompanyService.cs
@@ -255,10 +255,12 @@ public class SampleCompanyService
     {
         var dates = new List<DateTime>();
 
-        // Only consider Revenue and Expense dates for time-shifting
-        // This ensures the dashboard "This Month" view shows meaningful data
+        // Consider all date-bearing records so the time-shift offset ensures
+        // no records end up with future dates (which would be excluded by filters)
         dates.AddRange(data.Revenues.Select(s => s.Date));
         dates.AddRange(data.Expenses.Select(p => p.Date));
+        dates.AddRange(data.Returns.Select(r => r.ReturnDate));
+        dates.AddRange(data.LostDamaged.Select(ld => ld.DateDiscovered));
 
         return dates.Count > 0 ? dates.Max() : DateTime.MinValue;
     }

--- a/ArgoBooks/Services/ChartLoaderService.cs
+++ b/ArgoBooks/Services/ChartLoaderService.cs
@@ -1949,10 +1949,6 @@ public class ChartLoaderService
             "Losses by Category" => "Loss Reasons",
             "Expense vs Revenue Losses" => "Expenses vs Revenue",
 
-            // Legacy Dashboard page chart identifiers
-            "ExpenseDistributionChart" => "Expense Distribution",
-            "ExpensesChart" => "Expenses Overview",
-
             // Dashboard dynamic titles
             "Total profits" => "Profits Overview",
 

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -548,7 +548,10 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
         ThemeService.Instance.ThemeChanged += (_, _) =>
         {
             LoadDashboardData();
-            // Notify chart titles that have static text (no backing field changes during load)
+            // Notify chart titles to recreate LabelVisuals with the new theme's text color.
+            // Without this, titles whose backing string hasn't changed won't re-evaluate
+            // the computed LabelVisual and will keep the previous theme's paint color.
+            OnPropertyChanged(nameof(ProfitsChartTitleVisual));
             OnPropertyChanged(nameof(RevenueVsExpensesChartTitle));
         };
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,63 +1,50 @@
 <Project>
-    <!-- https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management -->
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
-        <!-- Avalonia packages -->
-        <PackageVersion Include="Avalonia" Version="11.3.9" />
-        <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.9" />
-        <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.9" />
-        <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.9" />
-        <PackageVersion Include="Avalonia.Desktop" Version="11.3.9" />
-        <PackageVersion Include="Avalonia.Browser" Version="11.3.9" />
-
-        <!-- MVVM -->
-        <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-
-        <!-- Dependency Injection -->
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-
-        <!-- Windows-specific (DPAPI for secure credential storage) -->
-        <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
-
-        <!-- Charts -->
-        <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
-
-        <!-- Color Picker -->
-        <PackageVersion Include="PixiEditor.ColorPicker.AvaloniaUI" Version="1.0.7" />
-
-        <!-- HTML Rendering (WebView2 for Windows) -->
-        <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
-
-        <!-- Graphics (for report rendering) -->
-        <PackageVersion Include="SkiaSharp" Version="3.116.1" />
-
-        <!-- PDF -->
-        <PackageVersion Include="QuestPDF" Version="2024.10.3" />
-
-        <!-- Excel -->
-        <PackageVersion Include="ClosedXML" Version="0.104.2" />
-        <PackageVersion Include="EPPlus" Version="7.7.2" />
-
-        <!-- Auto-Update (Desktop only) -->
-        <PackageVersion Include="NetSparkleUpdater.UI.Avalonia" Version="2.3.0" />
-
-        <!-- Google APIs -->
-        <PackageVersion Include="Google.Apis.Sheets.v4" Version="1.68.0.3525" />
-        <PackageVersion Include="Google.Apis.Drive.v3" Version="1.68.0.3533" />
-
-        <!-- Machine Learning (for local forecasting) -->
-        <PackageVersion Include="Microsoft.ML" Version="4.0.2" />
-        <PackageVersion Include="Microsoft.ML.TimeSeries" Version="4.0.2" />
-
-        <!-- Azure Document Intelligence (AI Receipt Scanning) -->
-        <PackageVersion Include="Azure.AI.FormRecognizer" Version="4.1.0" />
-
-        <!-- Testing -->
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageVersion Include="xunit" Version="2.9.2" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    </ItemGroup>
+  <!-- https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Avalonia packages -->
+    <PackageVersion Include="Avalonia" Version="11.3.11" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.11" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.11" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.11" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.11" />
+    <PackageVersion Include="Avalonia.Browser" Version="11.3.11" />
+    <!-- MVVM -->
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <!-- Dependency Injection -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <!-- Windows-specific (DPAPI for secure credential storage) -->
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
+    <!-- Charts -->
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
+    <!-- Color Picker -->
+    <PackageVersion Include="PixiEditor.ColorPicker.AvaloniaUI" Version="1.0.10" />
+    <!-- HTML Rendering (WebView2 for Windows) -->
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
+    <!-- Graphics (for report rendering) -->
+    <PackageVersion Include="SkiaSharp" Version="3.116.1" />
+    <!-- PDF -->
+    <PackageVersion Include="QuestPDF" Version="2025.12.4" />
+    <!-- Excel -->
+    <PackageVersion Include="ClosedXML" Version="0.105.0" />
+    <PackageVersion Include="EPPlus" Version="8.4.2" />
+    <!-- Auto-Update (Desktop only) -->
+    <PackageVersion Include="NetSparkleUpdater.UI.Avalonia" Version="2.3.0" />
+    <!-- Google APIs -->
+    <PackageVersion Include="Google.Apis.Sheets.v4" Version="1.72.0.3966" />
+    <PackageVersion Include="Google.Apis.Drive.v3" Version="1.73.0.4045" />
+    <!-- Machine Learning (for local forecasting) -->
+    <PackageVersion Include="Microsoft.ML" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.ML.TimeSeries" Version="5.0.0" />
+    <!-- Azure Document Intelligence (AI Receipt Scanning) -->
+    <PackageVersion Include="Azure.AI.FormRecognizer" Version="4.1.0" />
+    <!-- Testing -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.2" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
This PR removes legacy data migration code that is no longer needed and updates NuGet package dependencies to their latest versions. The changes clean up technical debt while modernizing the dependency stack.

## Key Changes

### Legacy Code Removal
- **Currency Migration**: Removed `MigrateCurrencyData()` method and related logic from `FileService` that handled converting old single-currency data to multi-currency format
- **License Key Migration**: Removed legacy MAC-address-based machine key generation and backward compatibility fallbacks in `LicenseService`, keeping only the stable machine key approach
- **MonetaryValue Helper**: Removed `FromLegacy()` static method that was used for data migration from older file formats
- **Chart Identifiers**: Removed legacy dashboard chart identifier mappings ("ExpenseDistributionChart", "ExpensesChart") from `ChartLoaderService`

### Dependency Updates
- **Avalonia**: 11.3.9 → 11.3.11
- **Microsoft.Extensions.DependencyInjection**: 9.0.0 → 10.0.2
- **PixiEditor.ColorPicker.AvaloniaUI**: 1.0.7 → 1.0.10
- **QuestPDF**: 2024.10.3 → 2025.12.4
- **ClosedXML**: 0.104.2 → 0.105.0
- **EPPlus**: 7.7.2 → 8.4.2 (with updated license API usage)
- **Google.Apis.Sheets.v4**: 1.68.0.3525 → 1.72.0.3966
- **Google.Apis.Drive.v3**: 1.68.0.3533 → 1.73.0.4045
- **Microsoft.ML**: 4.0.2 → 5.0.0
- **Microsoft.ML.TimeSeries**: 4.0.2 → 5.0.0
- **Microsoft.NET.Test.SDK**: 17.12.0 → 18.0.1
- **xunit**: 2.9.2 → 2.9.3
- **xunit.runner.visualstudio**: 2.8.2 → 3.1.5
- **coverlet.collector**: 6.0.2 → 6.0.4

### Other Updates
- Updated EPPlus license context API call from `ExcelPackage.LicenseContext = LicenseContext.NonCommercial` to `ExcelPackage.License.SetNonCommercialPersonal("ArgoBooks")`
- Updated Windows platform condition in `ArgoBooks.Core.csproj` to be more specific
- Enhanced `SampleCompanyService.FindMaxDate()` to include Returns and LostDamaged records in date calculation
- Improved `DashboardPageViewModel` theme change handling with additional property notification for chart titles
- Removed unused `System.Net.NetworkInformation` import from `LicenseService`

## Notes
- These changes assume all legacy data has been migrated in previous versions
- The removal of MAC-address-based license key generation simplifies the license system
- Package updates include security patches and new features from upstream libraries

https://claude.ai/code/session_01Y5bH798FoUaeeC2LV9FLni