### PR TITLE
Add translation cost estimation and confirmation prompt

### DIFF
--- a/ArgoBooks.TranslationTool/Program.cs
+++ b/ArgoBooks.TranslationTool/Program.cs
@@ -1,4 +1,6 @@
+using System.Net.Http.Json;
 using System.Text.Json;
+using ArgoBooks.Core.Services;
 using ArgoBooks.Data;
 using ArgoBooks.Localization;
 
@@ -11,12 +13,14 @@ using ArgoBooks.Localization;
 //   --languages fr,de   Translate to specific languages only
 //   --output <path>     Output directory for JSON files
 //   --source <path>     Source directory to scan (default: ../ArgoBooks)
+//   --yes               Skip confirmation prompt
 
 Console.WriteLine("=== Argo Books Translation Generator ===\n");
 
 // Parse command line arguments (args is provided by top-level statements)
 var collectOnly = args.Contains("--collect");
 var translateAll = args.Contains("--translate");
+var skipConfirmation = args.Contains("--yes") || args.Contains("-y");
 var specificLanguages = new List<string>();
 var outputDir = "./translations";
 var sourceDir = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "ArgoBooks"));
@@ -37,9 +41,16 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
+// Load .env file for API keys
+DotEnv.Load();
+
 // Get Azure API key from environment
 var azureKey = Environment.GetEnvironmentVariable("AZURE_TRANSLATOR_KEY");
 var azureRegion = Environment.GetEnvironmentVariable("AZURE_TRANSLATOR_REGION") ?? "eastus";
+
+// Fetch USD to CAD exchange rate for cost display
+var usdToCad = await GetUsdToCadRateAsync();
+
 
 // If translation was requested but no API key, exit with error
 var translationRequested = translateAll || specificLanguages.Count > 0;
@@ -110,9 +121,95 @@ var languagesToTranslate = specificLanguages.Count > 0
     ? specificLanguages
     : Languages.All.Where(l => l != "English").ToList();
 
-Console.WriteLine($"\nStep 2: Translating to {languagesToTranslate.Count} languages...");
-Console.WriteLine("Languages: " + string.Join(", ", languagesToTranslate.Take(10)) +
-    (languagesToTranslate.Count > 10 ? $" ... and {languagesToTranslate.Count - 10} more" : ""));
+// Resolve ISO codes for each language
+var resolvedLanguages = new List<(string isoCode, string displayName)>();
+foreach (var lang in languagesToTranslate)
+{
+    if (Languages.IsValidIsoCode(lang))
+        resolvedLanguages.Add((lang, Languages.GetLanguageName(lang)));
+    else
+        resolvedLanguages.Add((Languages.GetIsoCode(lang), lang));
+}
+
+// Check existing translations and count new vs existing per language
+Console.WriteLine($"\nStep 2: Checking existing translations...");
+var totalNewStrings = 0;
+var totalExistingStrings = 0;
+var totalCharsToTranslate = 0L;
+
+foreach (var (isoCode, displayName) in resolvedLanguages)
+{
+    if (isoCode == "en") continue;
+
+    var existingFile = Path.Combine(outputDir, $"{isoCode}.json");
+    var existingKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    if (File.Exists(existingFile))
+    {
+        try
+        {
+            var json = await File.ReadAllTextAsync(existingFile);
+            var existing = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            if (existing != null)
+            {
+                foreach (var kvp in existing)
+                {
+                    if (!string.IsNullOrEmpty(kvp.Value))
+                        existingKeys.Add(kvp.Key);
+                }
+            }
+        }
+        catch { /* ignore parse errors */ }
+    }
+
+    var newCount = strings.Keys.Count(k => !existingKeys.Contains(k));
+    var existingCount = strings.Keys.Count(k => existingKeys.Contains(k));
+    var newChars = strings.Where(kvp => !existingKeys.Contains(kvp.Key)).Sum(kvp => (long)kvp.Value.Length);
+
+    totalNewStrings += newCount;
+    totalExistingStrings += existingCount;
+    totalCharsToTranslate += newChars;
+
+    if (existingKeys.Count > 0)
+        Console.WriteLine($"  {displayName} ({isoCode}): {newCount} new, {existingCount} existing");
+    else
+        Console.WriteLine($"  {displayName} ({isoCode}): {strings.Count} new (no existing file)");
+}
+
+var nonEnglishCount = resolvedLanguages.Count(l => l.isoCode != "en");
+
+// If nothing new to translate, skip entirely
+if (totalNewStrings == 0)
+{
+    Console.WriteLine($"\nAll {totalExistingStrings} translations are up to date. Nothing to do.");
+    return 0;
+}
+
+// Cost estimate based only on new characters that need translating
+var estimatedCostUsd = totalCharsToTranslate / 1_000_000m * 10m;
+
+Console.WriteLine();
+Console.WriteLine($"New strings to translate: {totalNewStrings} across {nonEnglishCount} language(s)");
+Console.WriteLine($"Characters to translate:  {totalCharsToTranslate:N0}");
+Console.WriteLine($"Estimated cost:           {FormatCost(estimatedCostUsd, usdToCad)}");
+Console.WriteLine();
+
+// Confirmation prompt
+if (!skipConfirmation)
+{
+    Console.Write("Proceed with translation? [y/N] ");
+    var response = Console.ReadLine()?.Trim().ToLowerInvariant();
+    if (response != "y" && response != "yes")
+    {
+        Console.WriteLine("Translation cancelled.");
+        return 0;
+    }
+    Console.WriteLine();
+}
+
+Console.WriteLine($"Translating to {nonEnglishCount} languages...");
+Console.WriteLine("Languages: " + string.Join(", ", resolvedLanguages.Where(l => l.isoCode != "en").Select(l => l.displayName).Take(10)) +
+    (nonEnglishCount > 10 ? $" ... and {nonEnglishCount - 10} more" : ""));
 Console.WriteLine();
 
 try
@@ -126,6 +223,15 @@ try
 
     Console.WriteLine($"\nDone! Translations saved to: {outputDir}");
     Console.WriteLine($"Generated {translations.Count} language files.");
+
+    // Print Azure API usage summary
+    Console.WriteLine();
+    Console.WriteLine("--- Azure Translator API Usage ---");
+    Console.WriteLine($"  Languages translated:  {generator.LanguagesTranslated}");
+    Console.WriteLine($"  API calls made:        {generator.ApiCallCount}");
+    Console.WriteLine($"  Characters translated: {generator.TotalCharactersTranslated:N0}");
+    Console.WriteLine($"  Estimated cost:        {FormatCost(generator.EstimatedCost, usdToCad)}");
+    Console.WriteLine("----------------------------------");
 }
 catch (Exception ex)
 {
@@ -134,3 +240,36 @@ catch (Exception ex)
 }
 
 return 0;
+
+// --- Helper functions ---
+
+static string FormatCost(decimal costUsd, decimal? usdToCad)
+{
+    if (usdToCad.HasValue)
+    {
+        var costCad = costUsd * usdToCad.Value;
+        return $"${costCad:F4} CAD (${costUsd:F4} USD @ {usdToCad.Value:F4})";
+    }
+    return $"${costUsd:F4} USD (S1 @ $10 USD/1M chars)";
+}
+
+static async Task<decimal?> GetUsdToCadRateAsync()
+{
+    var oxrKey = DotEnv.Get("OPENEXCHANGERATES_API_KEY");
+    if (string.IsNullOrEmpty(oxrKey))
+        return null;
+
+    try
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var url = $"https://openexchangerates.org/api/latest.json?app_id={oxrKey}&symbols=CAD";
+        var response = await http.GetFromJsonAsync<JsonElement>(url);
+        if (response.TryGetProperty("rates", out var rates) && rates.TryGetProperty("CAD", out var cad))
+            return cad.GetDecimal();
+    }
+    catch
+    {
+        // Silently fall back to USD-only display
+    }
+    return null;
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <!-- Dependency Injection -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <!-- Windows-specific (DPAPI for secure credential storage) -->
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.2" />
     <!-- Charts -->
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
     <!-- Color Picker -->
@@ -42,7 +42,6 @@
     <PackageVersion Include="Azure.AI.FormRecognizer" Version="4.1.0" />
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />


### PR DESCRIPTION
## Summary
Enhanced the translation tool with cost estimation, exchange rate conversion, and a confirmation prompt before translating. Users can now see the estimated Azure Translator API cost in both USD and CAD before proceeding with translations.

## Key Changes

- **Cost Estimation**: Calculate estimated Azure Translator costs based on character count ($10 per 1M characters)
- **Exchange Rate Integration**: Fetch live USD to CAD exchange rates from Open Exchange Rates API for cost display in Canadian dollars
- **Confirmation Prompt**: Added `--yes`/`-y` flag to skip confirmation and display cost summary before translation begins
- **Translation Tracking**: Added metrics to `TranslationGenerator` to track:
  - Number of API calls made
  - Total characters translated
  - Number of languages translated
  - Estimated cost based on actual usage
- **Existing Translation Detection**: Check for existing translation files and only count new strings that need translating in cost estimates
- **Enhanced Output**: Display detailed translation statistics including new vs. existing strings per language
- **Dependencies**: Added `System.Net.Http.Json` for API calls and integrated `DotEnv` for environment variable loading
- **Package Updates**: Updated `System.Security.Cryptography.ProtectedData` to v10.0.2 and removed duplicate entry

## Implementation Details

- Cost calculation only includes new/untranslated strings, not existing translations
- Exchange rate fetch has a 5-second timeout and gracefully falls back to USD-only display if unavailable
- Translation proceeds automatically with `--yes` flag or after user confirmation
- API usage summary printed after successful translation completion
- Fixed property accessors in `TranslationResponse` and `Translation` classes to use `{ get; set; }`

https://claude.ai/code/session_011JYyXCqwhcF3D3XK5Au6C2