### PR TITLE
Add update available banner to app shell

### DIFF
--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -929,6 +929,7 @@ public class App : Application
             if (update != null)
             {
                 _appShellViewModel.CheckForUpdateModalViewModel.NotifyUpdateAvailable(update);
+                _appShellViewModel.ShowUpdateBanner($"V.{update.Version}");
             }
         }
         catch (Exception ex)

--- a/ArgoBooks/Controls/InfoBanner.axaml
+++ b/ArgoBooks/Controls/InfoBanner.axaml
@@ -1,0 +1,72 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:helpers="using:ArgoBooks.Helpers"
+             xmlns:loc="using:ArgoBooks.Localization"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="40"
+             x:Class="ArgoBooks.Controls.InfoBanner"
+             x:DataType="controls:InfoBanner">
+
+    <Border Classes="popup-banner"
+            Background="{Binding BannerBackground, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}}"
+            helpers:BannerAnimationBehavior.IsEnabled="True"
+            helpers:BannerAnimationBehavior.IsVisible="{Binding ShowBanner, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}}"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Top"
+            Margin="0,10,0,0"
+            CornerRadius="6"
+            Padding="12,8">
+        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto">
+            <!-- Icon -->
+            <PathIcon Grid.Column="0"
+                      Data="{Binding IconData, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}}"
+                      IsVisible="{Binding IconData, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}, Converter={x:Static ObjectConverters.IsNotNull}}"
+                      Width="16" Height="16"
+                      Foreground="White"
+                      VerticalAlignment="Center"
+                      Margin="0,0,10,0" />
+
+            <!-- Message -->
+            <TextBlock Grid.Column="1"
+                       Text="{Binding Message, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}}"
+                       Foreground="White"
+                       FontWeight="Medium"
+                       FontSize="13"
+                       VerticalAlignment="Center" />
+
+            <!-- Action Link -->
+            <Button Grid.Column="2"
+                    Command="{Binding ActionCommand, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}}"
+                    IsVisible="{Binding ActionText, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}, Converter={x:Static ObjectConverters.IsNotNull}}"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Padding="4,0"
+                    Margin="4,0,0,0"
+                    Cursor="Hand"
+                    VerticalAlignment="Center">
+                <TextBlock Text="{Binding ActionText, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}}"
+                           Foreground="White"
+                           FontWeight="Bold"
+                           FontSize="13"
+                           TextDecorations="Underline" />
+            </Button>
+
+            <!-- Dismiss Button -->
+            <Button Grid.Column="3"
+                    Command="{Binding DismissCommand, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}}"
+                    ToolTip.Tip="{loc:Loc 'Dismiss'}"
+                    Background="{Binding DismissBackground, RelativeSource={RelativeSource AncestorType=controls:InfoBanner}}"
+                    BorderThickness="0"
+                    CornerRadius="4"
+                    Padding="4"
+                    Margin="10,0,0,0"
+                    VerticalAlignment="Center">
+                <PathIcon Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                          Width="12" Height="12"
+                          Foreground="White" />
+            </Button>
+        </Grid>
+    </Border>
+</UserControl>

--- a/ArgoBooks/Controls/InfoBanner.axaml.cs
+++ b/ArgoBooks/Controls/InfoBanner.axaml.cs
@@ -1,0 +1,98 @@
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace ArgoBooks.Controls;
+
+/// <summary>
+/// A reusable banner control that displays an icon, message, optional action link, and dismiss button.
+/// Used for non-blocking notifications that overlay the top of the content area.
+/// </summary>
+public partial class InfoBanner : UserControl
+{
+    #region Styled Properties
+
+    public static readonly StyledProperty<string?> MessageProperty =
+        AvaloniaProperty.Register<InfoBanner, string?>(nameof(Message));
+
+    public static readonly StyledProperty<string?> ActionTextProperty =
+        AvaloniaProperty.Register<InfoBanner, string?>(nameof(ActionText));
+
+    public static readonly StyledProperty<ICommand?> ActionCommandProperty =
+        AvaloniaProperty.Register<InfoBanner, ICommand?>(nameof(ActionCommand));
+
+    public static readonly StyledProperty<ICommand?> DismissCommandProperty =
+        AvaloniaProperty.Register<InfoBanner, ICommand?>(nameof(DismissCommand));
+
+    public static readonly StyledProperty<Geometry?> IconDataProperty =
+        AvaloniaProperty.Register<InfoBanner, Geometry?>(nameof(IconData));
+
+    public static readonly StyledProperty<IBrush?> BannerBackgroundProperty =
+        AvaloniaProperty.Register<InfoBanner, IBrush?>(nameof(BannerBackground));
+
+    public static readonly StyledProperty<IBrush?> DismissBackgroundProperty =
+        AvaloniaProperty.Register<InfoBanner, IBrush?>(nameof(DismissBackground));
+
+    public static readonly StyledProperty<bool> ShowBannerProperty =
+        AvaloniaProperty.Register<InfoBanner, bool>(nameof(ShowBanner));
+
+    #endregion
+
+    #region Properties
+
+    public string? Message
+    {
+        get => GetValue(MessageProperty);
+        set => SetValue(MessageProperty, value);
+    }
+
+    public string? ActionText
+    {
+        get => GetValue(ActionTextProperty);
+        set => SetValue(ActionTextProperty, value);
+    }
+
+    public ICommand? ActionCommand
+    {
+        get => GetValue(ActionCommandProperty);
+        set => SetValue(ActionCommandProperty, value);
+    }
+
+    public ICommand? DismissCommand
+    {
+        get => GetValue(DismissCommandProperty);
+        set => SetValue(DismissCommandProperty, value);
+    }
+
+    public Geometry? IconData
+    {
+        get => GetValue(IconDataProperty);
+        set => SetValue(IconDataProperty, value);
+    }
+
+    public IBrush? BannerBackground
+    {
+        get => GetValue(BannerBackgroundProperty);
+        set => SetValue(BannerBackgroundProperty, value);
+    }
+
+    public IBrush? DismissBackground
+    {
+        get => GetValue(DismissBackgroundProperty);
+        set => SetValue(DismissBackgroundProperty, value);
+    }
+
+    public bool ShowBanner
+    {
+        get => GetValue(ShowBannerProperty);
+        set => SetValue(ShowBannerProperty, value);
+    }
+
+    #endregion
+
+    public InfoBanner()
+    {
+        InitializeComponent();
+    }
+}

--- a/ArgoBooks/Modals/CheckForUpdateModal.axaml
+++ b/ArgoBooks/Modals/CheckForUpdateModal.axaml
@@ -5,7 +5,6 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:controls="using:ArgoBooks.Controls"
-             xmlns:converters="using:ArgoBooks.Converters"
              xmlns:local="using:ArgoBooks"
              mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="350"
              x:Class="ArgoBooks.Modals.CheckForUpdateModal"
@@ -151,11 +150,6 @@
                                                Foreground="{DynamicResource TextSecondaryBrush}"
                                                HorizontalAlignment="Center" />
                                 </StackPanel>
-                                <Button Classes="primary-button"
-                                        Content="{loc:Loc 'Download Update'}"
-                                        Command="{Binding DownloadUpdateCommand}"
-                                        HorizontalAlignment="Center"
-                                        Margin="0,4,0,0" />
                             </StackPanel>
 
                             <!-- Downloading State -->
@@ -252,20 +246,10 @@
                 <Border Padding="24,16"
                         BorderBrush="{DynamicResource BorderBrush}"
                         BorderThickness="0,1,0,0">
-                    <Grid ColumnDefinitions="*,Auto">
-                        <Button Grid.Column="0"
-                                Classes="link-button"
-                                Content="{loc:Loc 'View Release Notes'}"
-                                Command="{Binding ViewReleaseNotesCommand}"
-                                HorizontalAlignment="Left" />
-                        <Button Grid.Column="1"
-                                Classes="secondary-button"
-                                Content="{loc:Loc 'Check Again'}"
-                                Command="{Binding CheckForUpdatesCommand}"
-                                IsEnabled="{Binding ShowCheckAgainButton}"
-                                IsHitTestVisible="{Binding ShowCheckAgainButton}"
-                                Opacity="{Binding ShowCheckAgainButton, Converter={x:Static converters:BoolConverters.ToWidth}, ConverterParameter='1,0'}" />
-                    </Grid>
+                    <Button Classes="link-button"
+                            Content="{loc:Loc 'View Release Notes'}"
+                            Command="{Binding ViewReleaseNotesCommand}"
+                            HorizontalAlignment="Center" />
                 </Border>
             </StackPanel>
             </Border>

--- a/ArgoBooks/ViewModels/AppShellViewModel.cs
+++ b/ArgoBooks/ViewModels/AppShellViewModel.cs
@@ -272,6 +272,44 @@ public partial class AppShellViewModel : ViewModelBase
 
     #endregion
 
+    #region Update Available Banner
+
+    [ObservableProperty]
+    private bool _showUpdateAvailableBanner;
+
+    [ObservableProperty]
+    private string _updateBannerMessage = "";
+
+    /// <summary>
+    /// Shows the update available banner with the given version.
+    /// </summary>
+    public void ShowUpdateBanner(string version)
+    {
+        UpdateBannerMessage = $"{"A new version".Translate()} {version} {"is available.".Translate()}";
+        ShowUpdateAvailableBanner = true;
+    }
+
+    /// <summary>
+    /// Dismisses the update available banner.
+    /// </summary>
+    [RelayCommand]
+    private void DismissUpdateBanner()
+    {
+        ShowUpdateAvailableBanner = false;
+    }
+
+    /// <summary>
+    /// Opens the Check for Update modal from the banner and starts downloading.
+    /// </summary>
+    [RelayCommand]
+    private void OpenUpdateModalFromBanner()
+    {
+        ShowUpdateAvailableBanner = false;
+        CheckForUpdateModalViewModel.OpenAndDownloadCommand.Execute(null);
+    }
+
+    #endregion
+
     /// <summary>
     /// Default constructor for design-time.
     /// </summary>

--- a/ArgoBooks/Views/AppShell.axaml
+++ b/ArgoBooks/Views/AppShell.axaml
@@ -88,6 +88,16 @@
                                     </Button>
                                 </Grid>
                             </Border>
+
+                            <!-- Update Available Banner -->
+                            <controls:InfoBanner ShowBanner="{Binding ShowUpdateAvailableBanner}"
+                                                 Message="{Binding UpdateBannerMessage}"
+                                                 ActionText="{loc:Loc 'Download now'}"
+                                                 ActionCommand="{Binding OpenUpdateModalFromBannerCommand}"
+                                                 DismissCommand="{Binding DismissUpdateBannerCommand}"
+                                                 IconData="M19 12v7H5v-7H3v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zm-6 .67l2.59-2.58L17 11.5l-5 5-5-5 1.41-1.41L11 12.67V3h2v9.67z"
+                                                 BannerBackground="{DynamicResource InfoBrush}"
+                                                 DismissBackground="{DynamicResource InfoDarkBrush}" />
                         </Panel>
                     </Border>
                 </Grid>


### PR DESCRIPTION
## Summary
Introduces a new reusable `InfoBanner` control and displays an update notification banner at the top of the app when a new version is detected during background checks. Users can now dismiss the banner or click "Download now" to proceed with the update.

## Key Changes
- **New `InfoBanner` control**: A reusable, customizable banner component with support for icon, message, optional action link, and dismiss button. Includes animation behavior for smooth appearance/disappearance.
- **Update banner integration**: When background update checks detect a new version, a banner now appears at the top of the app shell instead of only showing the modal.
- **Improved update flow**: 
  - Added `ShowUpdateBanner()` method to `AppShellViewModel` to display the banner with version info
  - Added `OpenAndDownloadCommand` to `CheckForUpdateModalViewModel` to start downloading immediately when user clicks "Download now" from the banner
  - Modified `OpenCommand` to intelligently handle cases where an update is already known (skips re-checking)
- **Simplified modal UI**: Removed "Check Again" button and "Download Update" button from the modal footer, streamlining the update dialog
- **Removed unused converter**: Cleaned up `BoolConverters` usage from the modal

## Implementation Details
- The `InfoBanner` uses Avalonia's styled properties pattern for full customization (colors, icons, commands)
- Banner animation is handled via `BannerAnimationBehavior` attached behavior
- Update banner appears with an info icon and blue background, positioned at the top center of the app
- The banner can be dismissed independently of the modal, allowing users to ignore the notification while continuing to use the app
- Download operations continue in the background even if the modal is closed

https://claude.ai/code/session_01Be9XyvZF34dsXP9D3ediBk