### PR TITLE
Optimize telemetry serialization with shared metadata

### DIFF
--- a/ArgoBooks.Core/Models/Telemetry/TelemetryEvent.cs
+++ b/ArgoBooks.Core/Models/Telemetry/TelemetryEvent.cs
@@ -3,6 +3,11 @@ namespace ArgoBooks.Core.Models.Telemetry;
 /// <summary>
 /// Base class for all telemetry events.
 /// </summary>
+[JsonDerivedType(typeof(SessionEvent))]
+[JsonDerivedType(typeof(ExportEvent))]
+[JsonDerivedType(typeof(ApiUsageEvent))]
+[JsonDerivedType(typeof(ErrorEvent))]
+[JsonDerivedType(typeof(FeatureUsageEvent))]
 public abstract class TelemetryEvent
 {
     /// <summary>
@@ -44,6 +49,6 @@ public abstract class TelemetryEvent
     /// <summary>
     /// Whether this event has been uploaded to the server.
     /// </summary>
-    [JsonIgnore]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsUploaded { get; set; }
 }

--- a/ArgoBooks.Core/Services/OpenAiService.cs
+++ b/ArgoBooks.Core/Services/OpenAiService.cs
@@ -53,7 +53,9 @@ public class OpenAiService : IOpenAiService
         }
 
         var stopwatch = Stopwatch.StartNew();
-        var model = DotEnv.Get(ModelEnvVar) ?? DefaultModel;
+        var model = DotEnv.Get(ModelEnvVar);
+        if (string.IsNullOrEmpty(model))
+            model = DefaultModel;
         var success = false;
 
         try


### PR DESCRIPTION
## Summary
This PR optimizes telemetry event serialization by extracting shared metadata to the batch level, reducing payload size and improving JSON serialization efficiency.

## Key Changes

- **TelemetryEvent.cs**: Added `[JsonDerivedType]` attributes for polymorphic JSON serialization support of all telemetry event types (SessionEvent, ExportEvent, ApiUsageEvent, ErrorEvent, FeatureUsageEvent)
- **TelemetryEvent.cs**: Changed `IsUploaded` property to use `JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)` instead of unconditional `[JsonIgnore]` to allow serialization when the value is non-default
- **OpenAiService.cs**: Improved null-coalescing logic for model environment variable retrieval with explicit null check instead of inline operator
- **TelemetryUploadService.cs**: 
  - Added shared metadata fields (Platform, UserAgent, GeoLocation) to `TelemetryUploadData` class
  - Implemented compact serialization format that extracts common metadata from the first event to the batch level
  - Temporarily nulls event-level metadata during serialization to exclude them from JSON output (via `WhenWritingNull` condition)
  - Restores metadata on events after serialization to maintain consistency for retry scenarios and local storage

## Implementation Details

The telemetry upload optimization uses a temporary nullification pattern to achieve compact JSON serialization without permanently modifying event data. This ensures:
- Reduced payload size by eliminating duplicate metadata across events in a batch
- Proper event restoration for retry logic and local persistence
- Backward compatibility with existing telemetry event structure

https://claude.ai/code/session_01KVtbmrkui1DCdqnFekVw4v