### PR TITLE
Implement action coalescing for undo/redo during rapid changes

### DIFF
--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -1029,6 +1029,10 @@ public partial class SkiaReportDesignCanvas : UserControl
         _interactionMode = InteractionMode.Dragging;
         _interactionStartPoint = point;
 
+        // Suppress property change undo recording during drag - EndDrag records the final action
+        if (UndoRedoManager != null)
+            UndoRedoManager.SuppressRecording = true;
+
         // Store start bounds for all selected elements
         _multiDragStartBounds.Clear();
         foreach (var element in _selectedElements)
@@ -1073,6 +1077,10 @@ public partial class SkiaReportDesignCanvas : UserControl
 
     private void EndDrag()
     {
+        // Re-enable undo recording after drag
+        if (UndoRedoManager != null)
+            UndoRedoManager.SuppressRecording = false;
+
         // Record undo action for moved elements (as a single batch action)
         if (UndoRedoManager != null && Configuration != null && _selectedElements.Count > 0)
         {
@@ -1119,6 +1127,10 @@ public partial class SkiaReportDesignCanvas : UserControl
         _interactionStartPoint = point;
         _elementStartPosition = new Point(element.X, element.Y);
         _elementStartSize = new Size(element.Width, element.Height);
+
+        // Suppress property change undo recording during resize - EndResize records the final action
+        if (UndoRedoManager != null)
+            UndoRedoManager.SuppressRecording = true;
 
         // Ensure only this element is selected during resize
         _selectedElements.Clear();
@@ -1221,6 +1233,10 @@ public partial class SkiaReportDesignCanvas : UserControl
 
     private void EndResize()
     {
+        // Re-enable undo recording after resize
+        if (UndoRedoManager != null)
+            UndoRedoManager.SuppressRecording = false;
+
         // Record undo action for resized element
         if (UndoRedoManager != null && Configuration != null && _selectedElements.Count == 1)
         {


### PR DESCRIPTION
## Summary
This PR improves the undo/redo system to handle rapid sequential changes more intelligently by coalescing them into single undo entries. It also prevents duplicate undo entries during canvas drag and resize operations.

## Key Changes

- **Action Coalescing**: Introduced `ICoalescingAction` interface that allows similar actions (e.g., multiple spinner value changes) occurring within 500ms to be merged into a single undo entry instead of creating separate entries for each change.

- **Suppress Recording During Drag/Resize**: Added `SuppressRecording` flag to `ReportUndoRedoManager` that is toggled during canvas drag and resize operations. This prevents property change notifications from creating duplicate undo entries since the final state is recorded as a single batch action.

- **Enhanced MoveResizeElementAction**: Converted `MoveResizeElementAction` to implement `ICoalescingAction`, allowing rapid position/size changes to be coalesced. The action now uses fields instead of constructor parameters to support state updates.

- **Property Change Tracking**: Updated `ReportsPageViewModel.OnElementPropertyChanging` to record `MoveResizeElementAction` for X/Y/Width/Height changes, enabling coalescing for spinner controls and keyboard input while respecting the `SuppressRecording` flag during canvas operations.

## Implementation Details

- Coalescing uses a 500ms time window (`CoalesceThresholdMs`) to determine if actions should be merged
- When coalescing occurs, the original "old state" is preserved while the "new state" is updated, ensuring undo returns to the initial state
- The `_lastRecordTime` tracks when the last action was recorded to enforce the time window
- Canvas drag/resize operations now suppress recording during the interaction and record a single final action on completion

https://claude.ai/code/session_018FQaEcCPNds3me4sJSKVhh