### PR TITLE
Merge stat card fixes, responsive layout, receipt scanner, and UI improvements

### DIFF
--- a/ArgoBooks/Controls/Sidebar.axaml
+++ b/ArgoBooks/Controls/Sidebar.axaml
@@ -81,16 +81,21 @@
                                 </Panel>
                             </Border>
 
-                            <!-- Brand Name -->
-                            <TextBlock Grid.Column="1"
-                                       Text="{Binding CompanyName}"
-                                       FontSize="15"
-                                       FontWeight="SemiBold"
-                                       Foreground="{DynamicResource SidebarTextBrush}"
-                                       VerticalAlignment="Center"
-                                       Margin="12,0,0,0"
-                                       MaxWidth="110"
-                                       TextTrimming="CharacterEllipsis" />
+                            <!-- Brand Name - auto-shrinks to fit, min effective font ~11px -->
+                            <Viewbox Grid.Column="1"
+                                     StretchDirection="DownOnly"
+                                     Stretch="Uniform"
+                                     VerticalAlignment="Center"
+                                     HorizontalAlignment="Left"
+                                     Margin="8,0,0,0">
+                                <TextBlock Text="{Binding CompanyName}"
+                                           FontSize="15"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource SidebarTextBrush}"
+                                           TextWrapping="NoWrap"
+                                           TextTrimming="CharacterEllipsis"
+                                           MaxWidth="200" />
+                            </Viewbox>
                         </Grid>
                     </Button>
 

--- a/ArgoBooks/Controls/StatCard.axaml
+++ b/ArgoBooks/Controls/StatCard.axaml
@@ -24,9 +24,13 @@
         <Style Selector="controls|StatCard.compact Border#OuterBorder">
             <Setter Property="Padding" Value="12" />
         </Style>
+        <Style Selector="controls|StatCard.minimal Border#OuterBorder">
+            <Setter Property="Padding" Value="10" />
+        </Style>
 
         <!-- Icon container base styles -->
         <Style Selector="controls|StatCard Border#IconContainer">
+            <Setter Property="IsVisible" Value="{Binding Icon, RelativeSource={RelativeSource AncestorType=controls:StatCard}, Converter={x:Static ObjectConverters.IsNotNull}}" />
             <Setter Property="Width" Value="48" />
             <Setter Property="Height" Value="48" />
             <Setter Property="CornerRadius" Value="12" />
@@ -37,6 +41,9 @@
             <Setter Property="Height" Value="36" />
             <Setter Property="Margin" Value="0,0,10,0" />
             <Setter Property="CornerRadius" Value="10" />
+        </Style>
+        <Style Selector="controls|StatCard.minimal Border#IconContainer">
+            <Setter Property="IsVisible" Value="False" />
         </Style>
 
         <!-- Icon container colors -->
@@ -92,6 +99,11 @@
         <Style Selector="controls|StatCard.compact TextBlock#ValueText">
             <Setter Property="FontSize" Value="18" />
         </Style>
+        <Style Selector="controls|StatCard.minimal TextBlock#ValueText">
+            <Setter Property="FontSize" Value="15" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+        </Style>
         <Style Selector="controls|StatCard.value-success TextBlock#ValueText">
             <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
         </Style>
@@ -107,6 +119,10 @@
         <Style Selector="controls|StatCard.compact TextBlock#LabelText">
             <Setter Property="FontSize" Value="11" />
         </Style>
+        <Style Selector="controls|StatCard.minimal TextBlock#LabelText">
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+        </Style>
 
         <!-- Content stack panel -->
         <Style Selector="controls|StatCard StackPanel#ContentPanel">
@@ -114,6 +130,10 @@
         </Style>
         <Style Selector="controls|StatCard.compact StackPanel#ContentPanel">
             <Setter Property="Spacing" Value="2" />
+        </Style>
+        <Style Selector="controls|StatCard.minimal StackPanel#ContentPanel">
+            <Setter Property="Spacing" Value="1" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
         </Style>
 
         <!-- Trend stack panel -->
@@ -126,6 +146,18 @@
         <Style Selector="controls|StatCard.compact StackPanel#TrendPanel TextBlock">
             <Setter Property="FontSize" Value="10" />
         </Style>
+        <Style Selector="controls|StatCard.minimal StackPanel#TrendPanel">
+            <Setter Property="Spacing" Value="2" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="controls|StatCard.minimal StackPanel#TrendPanel TextBlock">
+            <Setter Property="FontSize" Value="9" />
+        </Style>
+
+        <!-- Secondary text -->
+        <Style Selector="controls|StatCard.minimal TextBlock#SecondaryTextBlock">
+            <Setter Property="HorizontalAlignment" Value="Center" />
+        </Style>
     </UserControl.Styles>
 
     <Border x:Name="OuterBorder">
@@ -133,8 +165,7 @@
             <!-- Icon Container -->
             <Border Grid.Column="0"
                     x:Name="IconContainer"
-                    VerticalAlignment="Top"
-                    IsVisible="{Binding Icon, RelativeSource={RelativeSource AncestorType=controls:StatCard}, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    VerticalAlignment="Top">
                 <PathIcon x:Name="IconPath"
                           Data="{Binding Icon, RelativeSource={RelativeSource AncestorType=controls:StatCard}}" />
             </Border>
@@ -203,7 +234,8 @@
                 </StackPanel>
 
                 <!-- Secondary Text -->
-                <TextBlock Text="{Binding SecondaryText, RelativeSource={RelativeSource AncestorType=controls:StatCard}}"
+                <TextBlock x:Name="SecondaryTextBlock"
+                           Text="{Binding SecondaryText, RelativeSource={RelativeSource AncestorType=controls:StatCard}}"
                            FontSize="10"
                            Foreground="{DynamicResource TextTertiaryBrush}"
                            IsVisible="{Binding SecondaryText, RelativeSource={RelativeSource AncestorType=controls:StatCard}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />

--- a/ArgoBooks/Controls/StatCard.axaml.cs
+++ b/ArgoBooks/Controls/StatCard.axaml.cs
@@ -78,10 +78,18 @@ public partial class StatCard : UserControl
     public static readonly StyledProperty<bool> IsCompactProperty =
         AvaloniaProperty.Register<StatCard, bool>(nameof(IsCompact));
 
+    public static readonly StyledProperty<bool> IsMinimalProperty =
+        AvaloniaProperty.Register<StatCard, bool>(nameof(IsMinimal));
+
     /// <summary>
     /// The width threshold below which the card switches to compact mode.
     /// </summary>
-    private const double CompactThreshold = 250;
+    private const double CompactThreshold = 320;
+
+    /// <summary>
+    /// The width threshold below which the card switches to minimal mode (hides icon, smaller text).
+    /// </summary>
+    private const double MinimalThreshold = 260;
 
     #endregion
 
@@ -276,6 +284,16 @@ public partial class StatCard : UserControl
         set => SetValue(IsCompactProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets whether the card is in minimal mode (icon hidden, smaller text).
+    /// This is automatically set based on the card's width.
+    /// </summary>
+    public bool IsMinimal
+    {
+        get => GetValue(IsMinimalProperty);
+        set => SetValue(IsMinimalProperty, value);
+    }
+
     #endregion
 
     public StatCard()
@@ -295,6 +313,16 @@ public partial class StatCard : UserControl
         {
             IsCompact = shouldBeCompact;
             UpdateCompactClass();
+        }
+
+        // Update minimal mode based on available width
+        var wasMinimal = IsMinimal;
+        var shouldBeMinimal = finalSize.Width > 0 && finalSize.Width < MinimalThreshold;
+
+        if (wasMinimal != shouldBeMinimal)
+        {
+            IsMinimal = shouldBeMinimal;
+            UpdateMinimalClass();
         }
 
         return base.ArrangeOverride(finalSize);
@@ -331,6 +359,12 @@ public partial class StatCard : UserControl
         if (change.Property == IsCompactProperty)
         {
             UpdateCompactClass();
+        }
+
+        // Update minimal class
+        if (change.Property == IsMinimalProperty)
+        {
+            UpdateMinimalClass();
         }
 
         // Auto-show change indicator when ChangeValue or ChangeText is set
@@ -405,5 +439,13 @@ public partial class StatCard : UserControl
             Classes.Add("compact");
         else
             Classes.Remove("compact");
+    }
+
+    private void UpdateMinimalClass()
+    {
+        if (IsMinimal)
+            Classes.Add("minimal");
+        else
+            Classes.Remove("minimal");
     }
 }

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -244,8 +244,7 @@
                     </Border>
 
                     <!-- Content -->
-                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                        <Panel>
+                    <Panel Grid.Row="1">
                             <!-- Loading State -->
                             <StackPanel IsVisible="{Binding IsScanning}"
                                         HorizontalAlignment="Center"
@@ -308,13 +307,13 @@
                             <Grid IsVisible="{Binding HasScanResult}"
                                   ColumnDefinitions="2*,3*"
                                   Margin="24">
-                                <!-- Left: Receipt Preview -->
+                                <!-- Left: Receipt Preview (zoomable/pannable) -->
                                 <Border Grid.Column="0"
                                         Background="{DynamicResource SurfaceAltBrush}"
                                         CornerRadius="8"
                                         Margin="0,0,24,0"
                                         ClipToBounds="True">
-                                    <Grid RowDefinitions="Auto,*">
+                                    <Grid RowDefinitions="Auto,*,Auto">
                                         <TextBlock Grid.Row="0"
                                                    Text="{loc:Loc 'Receipt Preview'}"
                                                    FontSize="13"
@@ -323,16 +322,65 @@
                                                    Margin="16,12" />
                                         <Border Grid.Row="1"
                                                 Background="#1A000000"
-                                                Margin="8,0,8,8"
-                                                CornerRadius="4">
-                                            <Image Source="{Binding ReceiptImagePath, Converter={x:Static local:BoolConverters.ToImageSource}}"
-                                                   Stretch="Uniform" />
+                                                Margin="8,0,8,4"
+                                                CornerRadius="4"
+                                                ClipToBounds="True">
+                                            <ScrollViewer x:Name="ScanPreviewScrollViewer"
+                                                          HorizontalScrollBarVisibility="Auto"
+                                                          VerticalScrollBarVisibility="Auto">
+                                                <LayoutTransformControl x:Name="ScanPreviewZoomTransform"
+                                                                        HorizontalAlignment="Center"
+                                                                        VerticalAlignment="Center">
+                                                    <Image x:Name="ScanPreviewImage"
+                                                           Source="{Binding ReceiptImagePath, Converter={x:Static local:BoolConverters.ToImageSource}}"
+                                                           Stretch="Uniform" />
+                                                </LayoutTransformControl>
+                                            </ScrollViewer>
                                         </Border>
+                                        <!-- Zoom Controls -->
+                                        <StackPanel Grid.Row="2"
+                                                    Orientation="Horizontal"
+                                                    Spacing="2"
+                                                    HorizontalAlignment="Center"
+                                                    Margin="4,0,4,8">
+                                            <Button Classes="icon-button"
+                                                    Click="ScanPreviewZoomOut_Click"
+                                                    ToolTip.Tip="{loc:Loc 'Zoom Out'}">
+                                                <PathIcon Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"
+                                                          Width="14" Height="14" />
+                                            </Button>
+                                            <Slider x:Name="ScanPreviewZoomSlider"
+                                                    Minimum="0.25"
+                                                    Maximum="4.0"
+                                                    Width="80"
+                                                    VerticalAlignment="Center"
+                                                    ValueChanged="ScanPreviewZoomSlider_ValueChanged" />
+                                            <Button Classes="icon-button"
+                                                    Click="ScanPreviewZoomIn_Click"
+                                                    ToolTip.Tip="{loc:Loc 'Zoom In'}">
+                                                <PathIcon Data="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zm.5-7H9v2H7v1h2v2h1v-2h2V9h-2z"
+                                                          Width="14" Height="14" />
+                                            </Button>
+                                            <TextBlock x:Name="ScanPreviewZoomText"
+                                                       Text="100%"
+                                                       VerticalAlignment="Center"
+                                                       FontSize="11"
+                                                       Width="38"
+                                                       TextAlignment="Center"
+                                                       Foreground="{DynamicResource TextSecondaryBrush}" />
+                                            <Button Classes="icon-button"
+                                                    Click="ScanPreviewFitToWindow_Click"
+                                                    ToolTip.Tip="{loc:Loc 'Fit to Window'}">
+                                                <PathIcon Data="M5 15H3v4c0 1.1.9 2 2 2h4v-2H5v-4zM5 5h4V3H5c-1.1 0-2 .9-2 2v4h2V5zm14-2h-4v2h4v4h2V5c0-1.1-.9-2-2-2zm0 16h-4v2h4c1.1 0 2-.9 2-2v-4h-2v4zM12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 6c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"
+                                                          Width="14" Height="14" />
+                                            </Button>
+                                        </StackPanel>
                                     </Grid>
                                 </Border>
 
                                 <!-- Right: Extracted Data -->
-                                <StackPanel Grid.Column="1" Spacing="20">
+                                <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                <StackPanel Spacing="20">
                                     <!-- Confidence Score -->
                                     <Border Background="{DynamicResource SurfaceAltBrush}"
                                             CornerRadius="8"
@@ -612,7 +660,7 @@
                                                 Margin="0,0,0,8">
                                             <StackPanel Orientation="Horizontal" Spacing="10">
                                                 <controls:LoadingSpinner SizePreset="Small" />
-                                                <TextBlock Text="{loc:Loc 'AI is suggesting supplier and category...'}"
+                                                <TextBlock Text="{loc:Loc 'AI is suggesting supplier...'}"
                                                            FontSize="13"
                                                            Foreground="#1E40AF"
                                                            VerticalAlignment="Center" />
@@ -767,9 +815,9 @@
                                         </StackPanel>
                                     </StackPanel>
                                 </StackPanel>
+                                </ScrollViewer>
                             </Grid>
-                        </Panel>
-                    </ScrollViewer>
+                    </Panel>
 
                     <!-- Footer -->
                     <Border Grid.Row="2"

--- a/ArgoBooks/Modals/ReceiptsModals.axaml.cs
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml.cs
@@ -1,4 +1,13 @@
+using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using ArgoBooks.Helpers;
+using ArgoBooks.ViewModels;
 
 namespace ArgoBooks.Modals;
 
@@ -7,8 +16,286 @@ namespace ArgoBooks.Modals;
 /// </summary>
 public partial class ReceiptsModals : UserControl
 {
+    // Zoom settings for scan preview
+    private double _scanZoomLevel = 1.0;
+    private const double MinZoom = 0.25;
+    private const double MaxZoom = 4.0;
+    private const double ZoomStep = 0.25;
+    private bool _updatingSlider;
+
+    // Panning (right-click or middle-click drag)
+    private bool _isPanning;
+    private Point _panStartPoint;
+    private Vector _panStartOffset;
+    private OverscrollHelper? _overscrollHelper;
+
     public ReceiptsModals()
     {
         InitializeComponent();
     }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+
+        if (ScanPreviewScrollViewer != null)
+        {
+            ScanPreviewScrollViewer.AddHandler(PointerWheelChangedEvent, OnScanPreviewPointerWheelChanged, RoutingStrategies.Tunnel);
+        }
+
+        if (ScanPreviewZoomTransform != null && _overscrollHelper == null)
+        {
+            _overscrollHelper = new OverscrollHelper(ScanPreviewZoomTransform);
+        }
+
+        if (ScanPreviewZoomSlider != null)
+        {
+            _updatingSlider = true;
+            ScanPreviewZoomSlider.Value = _scanZoomLevel;
+            _updatingSlider = false;
+        }
+
+        // Subscribe to ViewModel to fit image when scan results arrive
+        if (DataContext is ReceiptsModalsViewModel vm)
+        {
+            vm.PropertyChanged += OnScanViewModelPropertyChanged;
+        }
+    }
+
+    private void OnScanViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ReceiptsModalsViewModel.HasScanResult) &&
+            sender is ReceiptsModalsViewModel { HasScanResult: true })
+        {
+            // Reset zoom and fit when results first appear
+            _scanZoomLevel = 1.0;
+            _ = FitScanPreviewAfterLayoutAsync();
+        }
+    }
+
+    private async Task FitScanPreviewAfterLayoutAsync()
+    {
+        // Wait for layout to settle after results state becomes visible
+        await Task.Delay(150);
+        ScanPreviewFitToWindow();
+    }
+
+    #region Scan Preview Zoom
+
+    private void ApplyScanZoom()
+    {
+        if (ScanPreviewZoomTransform == null) return;
+        ScanPreviewZoomTransform.LayoutTransform = new ScaleTransform(_scanZoomLevel, _scanZoomLevel);
+        UpdateScanZoomDisplay();
+    }
+
+    private void UpdateScanZoomDisplay()
+    {
+        if (ScanPreviewZoomSlider != null && !_updatingSlider)
+        {
+            _updatingSlider = true;
+            ScanPreviewZoomSlider.Value = _scanZoomLevel;
+            _updatingSlider = false;
+        }
+
+        if (ScanPreviewZoomText != null)
+        {
+            ScanPreviewZoomText.Text = $"{_scanZoomLevel:P0}";
+        }
+    }
+
+    private void ScanPreviewZoomIn_Click(object? sender, RoutedEventArgs e) => ScanPreviewZoomTowardsCenter(true);
+    private void ScanPreviewZoomOut_Click(object? sender, RoutedEventArgs e) => ScanPreviewZoomTowardsCenter(false);
+
+    private void ScanPreviewZoomSlider_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+    {
+        if (_updatingSlider) return;
+        ScanPreviewZoomToLevel(e.NewValue);
+    }
+
+    private void ScanPreviewZoomToLevel(double newZoom)
+    {
+        if (ScanPreviewScrollViewer == null || ScanPreviewZoomTransform == null) return;
+
+        var oldZoom = _scanZoomLevel;
+        newZoom = Math.Clamp(newZoom, MinZoom, MaxZoom);
+        if (Math.Abs(oldZoom - newZoom) < 0.001) return;
+
+        var viewportCenterX = ScanPreviewScrollViewer.Viewport.Width / 2;
+        var viewportCenterY = ScanPreviewScrollViewer.Viewport.Height / 2;
+        var contentCenterX = (ScanPreviewScrollViewer.Offset.X + viewportCenterX) / oldZoom;
+        var contentCenterY = (ScanPreviewScrollViewer.Offset.Y + viewportCenterY) / oldZoom;
+
+        _scanZoomLevel = newZoom;
+        ApplyScanZoom();
+        ScanPreviewZoomTransform.UpdateLayout();
+
+        var newOffsetX = contentCenterX * newZoom - viewportCenterX;
+        var newOffsetY = contentCenterY * newZoom - viewportCenterY;
+        var maxX = Math.Max(0, ScanPreviewScrollViewer.Extent.Width - ScanPreviewScrollViewer.Viewport.Width);
+        var maxY = Math.Max(0, ScanPreviewScrollViewer.Extent.Height - ScanPreviewScrollViewer.Viewport.Height);
+
+        ScanPreviewScrollViewer.Offset = new Vector(
+            Math.Clamp(newOffsetX, 0, maxX),
+            Math.Clamp(newOffsetY, 0, maxY)
+        );
+    }
+
+    private void ScanPreviewFitToWindow_Click(object? sender, RoutedEventArgs e) => ScanPreviewFitToWindow();
+
+    private void ScanPreviewFitToWindow()
+    {
+        if (ScanPreviewScrollViewer == null || ScanPreviewImage?.Source == null) return;
+
+        double imageWidth = 0, imageHeight = 0;
+        if (ScanPreviewImage.Source is Bitmap bitmap)
+        {
+            imageWidth = bitmap.PixelSize.Width;
+            imageHeight = bitmap.PixelSize.Height;
+        }
+
+        if (imageWidth <= 0 || imageHeight <= 0) return;
+
+        var viewportWidth = ScanPreviewScrollViewer.Bounds.Width;
+        var viewportHeight = ScanPreviewScrollViewer.Bounds.Height;
+        if (viewportWidth <= 0 || viewportHeight <= 0) return;
+
+        var scaleX = viewportWidth / imageWidth;
+        var scaleY = viewportHeight / imageHeight;
+
+        _scanZoomLevel = Math.Clamp(Math.Min(scaleX, scaleY), MinZoom, MaxZoom);
+        ApplyScanZoom();
+    }
+
+    private void ScanPreviewZoomTowardsCenter(bool zoomIn)
+    {
+        var newZoom = zoomIn
+            ? Math.Min(_scanZoomLevel + ZoomStep, MaxZoom)
+            : Math.Max(_scanZoomLevel - ZoomStep, MinZoom);
+        ScanPreviewZoomToLevel(newZoom);
+    }
+
+    private void OnScanPreviewPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        var delta = e.Delta.Y;
+        if (delta != 0 && ScanPreviewZoomTransform != null)
+        {
+            var viewportPoint = e.GetPosition(ScanPreviewScrollViewer);
+            var contentPoint = e.GetPosition(ScanPreviewZoomTransform);
+            ScanPreviewZoomAtPoint(delta > 0, viewportPoint, contentPoint);
+        }
+        e.Handled = true;
+    }
+
+    private void ScanPreviewZoomAtPoint(bool zoomIn, Point viewportPoint, Point scaledContentPoint)
+    {
+        if (ScanPreviewScrollViewer == null || ScanPreviewZoomTransform == null) return;
+
+        var oldZoom = _scanZoomLevel;
+        var newZoom = zoomIn
+            ? Math.Min(oldZoom + ZoomStep, MaxZoom)
+            : Math.Max(oldZoom - ZoomStep, MinZoom);
+        if (Math.Abs(oldZoom - newZoom) < 0.001) return;
+
+        var oldExtent = ScanPreviewScrollViewer.Extent;
+        var viewportWidth = ScanPreviewScrollViewer.Viewport.Width;
+        var viewportHeight = ScanPreviewScrollViewer.Viewport.Height;
+        var oldOffset = ScanPreviewScrollViewer.Offset;
+
+        var centeringOffsetX = oldExtent.Width < viewportWidth ? (viewportWidth - oldExtent.Width) / 2 : 0;
+        var centeringOffsetY = oldExtent.Height < viewportHeight ? (viewportHeight - oldExtent.Height) / 2 : 0;
+
+        var contentX = viewportPoint.X + oldOffset.X - centeringOffsetX;
+        var contentY = viewportPoint.Y + oldOffset.Y - centeringOffsetY;
+        var unscaledX = contentX / oldZoom;
+        var unscaledY = contentY / oldZoom;
+
+        _scanZoomLevel = newZoom;
+        ApplyScanZoom();
+        ScanPreviewZoomTransform.UpdateLayout();
+
+        var newExtent = ScanPreviewScrollViewer.Extent;
+        var newCenteringOffsetX = newExtent.Width < viewportWidth ? (viewportWidth - newExtent.Width) / 2 : 0;
+        var newCenteringOffsetY = newExtent.Height < viewportHeight ? (viewportHeight - newExtent.Height) / 2 : 0;
+
+        var newOffsetX = unscaledX * newZoom - viewportPoint.X + newCenteringOffsetX;
+        var newOffsetY = unscaledY * newZoom - viewportPoint.Y + newCenteringOffsetY;
+
+        var maxX = Math.Max(0, newExtent.Width - viewportWidth);
+        var maxY = Math.Max(0, newExtent.Height - viewportHeight);
+
+        ScanPreviewScrollViewer.Offset = new Vector(
+            Math.Clamp(newOffsetX, 0, maxX),
+            Math.Clamp(newOffsetY, 0, maxY)
+        );
+    }
+
+    #endregion
+
+    #region Scan Preview Panning
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+
+        var point = e.GetCurrentPoint(this);
+        if (point.Properties.IsRightButtonPressed || point.Properties.IsMiddleButtonPressed)
+        {
+            if (ScanPreviewScrollViewer != null)
+            {
+                _isPanning = true;
+                _panStartPoint = e.GetPosition(this);
+                _panStartOffset = new Vector(ScanPreviewScrollViewer.Offset.X, ScanPreviewScrollViewer.Offset.Y);
+                e.Pointer.Capture(this);
+                Cursor = new Cursor(StandardCursorType.SizeAll);
+                e.Handled = true;
+            }
+        }
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+
+        if (_isPanning && ScanPreviewScrollViewer != null && _overscrollHelper != null)
+        {
+            var currentPoint = e.GetPosition(this);
+            var delta = _panStartPoint - currentPoint;
+
+            var desiredX = _panStartOffset.X + delta.X;
+            var desiredY = _panStartOffset.Y + delta.Y;
+
+            var maxX = Math.Max(0, ScanPreviewScrollViewer.Extent.Width - ScanPreviewScrollViewer.Viewport.Width);
+            var maxY = Math.Max(0, ScanPreviewScrollViewer.Extent.Height - ScanPreviewScrollViewer.Viewport.Height);
+
+            var (clampedX, clampedY, overscrollX, overscrollY) =
+                _overscrollHelper.CalculateOverscroll(desiredX, desiredY, maxX, maxY);
+
+            ScanPreviewScrollViewer.Offset = new Vector(clampedX, clampedY);
+            _overscrollHelper.ApplyOverscroll(overscrollX, overscrollY);
+
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+
+        if (_isPanning)
+        {
+            _isPanning = false;
+            e.Pointer.Capture(null);
+            Cursor = Cursor.Default;
+
+            if (_overscrollHelper?.HasOverscroll == true)
+            {
+                _ = _overscrollHelper.AnimateSnapBackAsync();
+            }
+
+            e.Handled = true;
+        }
+    }
+
+    #endregion
 }

--- a/ArgoBooks/Panels/CompanySwitcherPanel.axaml
+++ b/ArgoBooks/Panels/CompanySwitcherPanel.axaml
@@ -5,7 +5,7 @@
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:local="using:ArgoBooks"
-             mc:Ignorable="d" d:DesignWidth="280" d:DesignHeight="400"
+             mc:Ignorable="d" d:DesignWidth="340" d:DesignHeight="400"
              x:Class="ArgoBooks.Panels.CompanySwitcherPanel"
              x:DataType="vm:CompanySwitcherPanelViewModel">
 
@@ -24,7 +24,7 @@
                 BorderBrush="{DynamicResource BorderBrush}"
                 BorderThickness="1"
                 CornerRadius="12"
-                Width="280"
+                Width="340"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
                 Margin="15,70,0,0"

--- a/ArgoBooks/Panels/HelpPanel.axaml
+++ b/ArgoBooks/Panels/HelpPanel.axaml
@@ -43,16 +43,6 @@
                 </Transitions>
             </Border.Transitions>
             <StackPanel>
-                <!-- Header -->
-                <Border Padding="20,16"
-                        BorderBrush="{DynamicResource BorderBrush}"
-                        BorderThickness="0,0,0,1">
-                    <TextBlock Text="{loc:Loc 'Help &amp; Resources'}"
-                               FontSize="14"
-                               FontWeight="SemiBold"
-                               Foreground="{DynamicResource TextPrimaryBrush}" />
-                </Border>
-
                 <!-- Menu Items -->
                 <StackPanel Margin="0,8">
                     <!-- What's New -->

--- a/ArgoBooks/ViewModels/ExpenseModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ExpenseModalsViewModel.cs
@@ -501,7 +501,7 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
             Total = Total,
             PaymentMethod = Enum.TryParse<PaymentMethod>(SelectedPaymentMethod.Replace(" ", ""), out var pm) ? pm : PaymentMethod.Cash,
             Notes = ModalNotes,
-            ReferenceNumber = ReceiptFilePath ?? string.Empty,
+            ReferenceNumber = string.Empty,
             CreatedAt = DateTime.Now,
             UpdatedAt = DateTime.Now,
             // USD conversion fields
@@ -585,7 +585,6 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
         expense.Total = Total;
         expense.PaymentMethod = Enum.TryParse<PaymentMethod>(SelectedPaymentMethod.Replace(" ", ""), out var pm) ? pm : PaymentMethod.Cash;
         expense.Notes = ModalNotes;
-        expense.ReferenceNumber = ReceiptFilePath ?? string.Empty;
         expense.UpdatedAt = DateTime.Now;
         // USD conversion fields
         expense.OriginalCurrency = ConvertedTotal?.OriginalCurrency ?? "USD";
@@ -635,7 +634,6 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
                 expense.Total = Total;
                 expense.PaymentMethod = pm;
                 expense.Notes = ModalNotes;
-                expense.ReferenceNumber = ReceiptFilePath ?? string.Empty;
                 if (capturedNewReceipt != null)
                 {
                     expense.ReceiptId = capturedNewReceipt.Id;

--- a/ArgoBooks/ViewModels/ExpensesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ExpensesPageViewModel.cs
@@ -441,7 +441,8 @@ public partial class ExpensesPageViewModel : SortablePageViewModelBase
             var accountant = companyData?.GetAccountant(purchase.AccountantId ?? "");
             var statusDisplay = GetStatusDisplay(purchase, companyData);
             var hasReceipt = !string.IsNullOrEmpty(purchase.ReceiptId);
-            var receiptFilePath = purchase.ReferenceNumber;
+            var receipt = hasReceipt ? companyData?.Receipts.FirstOrDefault(r => r.Id == purchase.ReceiptId) : null;
+            var receiptFilePath = receipt?.OriginalFilePath ?? string.Empty;
 
             return new ExpenseDisplayItem
             {

--- a/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
@@ -621,9 +621,9 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
         UpdatePreview();
     }
 
-    partial void OnTemplateNameChanged(string oldValue, string newValue)
+    partial void OnTemplateNameChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change template name", v => TemplateName = v, oldValue, newValue);
+        RecordChange("Change template name", v => TemplateName = v, oldValue!, newValue);
         // Clear validation message when user starts typing
         if (HasValidationMessage)
         {
@@ -637,69 +637,69 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
         RecordChange("Toggle default template", v => IsDefault = v, oldValue, newValue);
     }
 
-    partial void OnPrimaryColorChanged(string oldValue, string newValue)
+    partial void OnPrimaryColorChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change primary color", v => PrimaryColor = v, oldValue, newValue);
+        RecordChange("Change primary color", v => PrimaryColor = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnSecondaryColorChanged(string oldValue, string newValue)
+    partial void OnSecondaryColorChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change secondary color", v => SecondaryColor = v, oldValue, newValue);
+        RecordChange("Change secondary color", v => SecondaryColor = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnAccentColorChanged(string oldValue, string newValue)
+    partial void OnAccentColorChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change accent color", v => AccentColor = v, oldValue, newValue);
+        RecordChange("Change accent color", v => AccentColor = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnHeaderColorChanged(string oldValue, string newValue)
+    partial void OnHeaderColorChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change header color", v => HeaderColor = v, oldValue, newValue);
+        RecordChange("Change header color", v => HeaderColor = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnTextColorChanged(string oldValue, string newValue)
+    partial void OnTextColorChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change text color", v => TextColor = v, oldValue, newValue);
+        RecordChange("Change text color", v => TextColor = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnBackgroundColorChanged(string oldValue, string newValue)
+    partial void OnBackgroundColorChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change background color", v => BackgroundColor = v, oldValue, newValue);
+        RecordChange("Change background color", v => BackgroundColor = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnSelectedFontFamilyChanged(string oldValue, string newValue)
+    partial void OnSelectedFontFamilyChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change font family", v => SelectedFontFamily = v, oldValue, newValue);
+        RecordChange("Change font family", v => SelectedFontFamily = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnHeaderTextChanged(string oldValue, string newValue)
+    partial void OnHeaderTextChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change header text", v => HeaderText = v, oldValue, newValue);
+        RecordChange("Change header text", v => HeaderText = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnFooterTextChanged(string oldValue, string newValue)
+    partial void OnFooterTextChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change footer text", v => FooterText = v, oldValue, newValue);
+        RecordChange("Change footer text", v => FooterText = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnPaymentInstructionsChanged(string oldValue, string newValue)
+    partial void OnPaymentInstructionsChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change payment instructions", v => PaymentInstructions = v, oldValue, newValue);
+        RecordChange("Change payment instructions", v => PaymentInstructions = v, oldValue!, newValue);
         UpdatePreview();
     }
 
-    partial void OnDefaultNotesChanged(string oldValue, string newValue)
+    partial void OnDefaultNotesChanged(string? oldValue, string newValue)
     {
-        RecordChange("Change default notes", v => DefaultNotes = v, oldValue, newValue);
+        RecordChange("Change default notes", v => DefaultNotes = v, oldValue!, newValue);
         UpdatePreview();
     }
 

--- a/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
@@ -55,6 +55,7 @@ public partial class ReceiptsPageViewModel : ViewModelBase
     partial void OnIsGridViewChanged(bool value)
     {
         if (value) IsListView = false;
+        if (value) ColumnWidths.NeedsHorizontalScroll = false;
     }
 
     partial void OnIsListViewChanged(bool value)

--- a/ArgoBooks/ViewModels/RevenueModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenueModalsViewModel.cs
@@ -485,7 +485,7 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
             Total = Total,
             PaymentMethod = Enum.TryParse<PaymentMethod>(SelectedPaymentMethod.Replace(" ", ""), out var pm) ? pm : PaymentMethod.Cash,
             Notes = ModalNotes,
-            ReferenceNumber = ReceiptFilePath ?? string.Empty,
+            ReferenceNumber = string.Empty,
             CreatedAt = DateTime.Now,
             UpdatedAt = DateTime.Now,
             // USD conversion fields
@@ -569,7 +569,6 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
         revenue.Total = Total;
         revenue.PaymentMethod = Enum.TryParse<PaymentMethod>(SelectedPaymentMethod.Replace(" ", ""), out var pm) ? pm : PaymentMethod.Cash;
         revenue.Notes = ModalNotes;
-        revenue.ReferenceNumber = ReceiptFilePath ?? string.Empty;
         revenue.UpdatedAt = DateTime.Now;
         // USD conversion fields
         revenue.OriginalCurrency = ConvertedTotal?.OriginalCurrency ?? "USD";
@@ -619,7 +618,6 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
                 revenue.Total = Total;
                 revenue.PaymentMethod = pm;
                 revenue.Notes = ModalNotes;
-                revenue.ReferenceNumber = ReceiptFilePath ?? string.Empty;
                 if (capturedNewReceipt != null)
                 {
                     revenue.ReceiptId = capturedNewReceipt.Id;

--- a/ArgoBooks/ViewModels/RevenuePageViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenuePageViewModel.cs
@@ -420,7 +420,8 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
             var statusDisplay = GetStatusDisplay(revenue, companyData);
 
             var hasReceipt = !string.IsNullOrEmpty(revenue.ReceiptId);
-            var receiptFilePath = revenue.ReferenceNumber;
+            var receipt = hasReceipt ? companyData?.Receipts.FirstOrDefault(r => r.Id == revenue.ReceiptId) : null;
+            var receiptFilePath = receipt?.OriginalFilePath ?? string.Empty;
 
             return new RevenueDisplayItem
             {

--- a/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
+++ b/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
@@ -547,11 +547,26 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
         }
         UpdateTotals();
 
-        // Load receipt info
-        ReceiptFilePath = transaction.ReferenceNumber;
-        ReceiptFileName = string.IsNullOrEmpty(transaction.ReferenceNumber)
-            ? "No receipt attached"
-            : Path.GetFileName(transaction.ReferenceNumber);
+        // Load receipt info from the Receipt record (not ReferenceNumber, which stores general references like PO numbers)
+        if (!string.IsNullOrEmpty(transaction.ReceiptId))
+        {
+            var receipt = App.CompanyManager?.CompanyData?.Receipts.FirstOrDefault(r => r.Id == transaction.ReceiptId);
+            if (receipt != null)
+            {
+                ReceiptFilePath = receipt.OriginalFilePath;
+                ReceiptFileName = receipt.FileName;
+            }
+            else
+            {
+                ReceiptFilePath = null;
+                ReceiptFileName = "No receipt attached";
+            }
+        }
+        else
+        {
+            ReceiptFilePath = null;
+            ReceiptFileName = "No receipt attached";
+        }
 
         ClearValidationErrors();
 

--- a/ArgoBooks/Views/AppShell.axaml
+++ b/ArgoBooks/Views/AppShell.axaml
@@ -46,7 +46,8 @@
                             Grid.Row="1"
                             Background="{DynamicResource BackgroundSecondaryBrush}">
                         <Panel>
-                            <ContentControl Content="{Binding CurrentPage}"
+                            <ContentControl x:Name="PageContentControl"
+                                            Content="{Binding CurrentPage}"
                                             Margin="30" />
 
                             <!-- Unsaved Changes Reminder Banner (overlays on top of page content) -->

--- a/ArgoBooks/Views/AppShell.axaml.cs
+++ b/ArgoBooks/Views/AppShell.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -11,6 +12,9 @@ namespace ArgoBooks.Views;
 /// </summary>
 public partial class AppShell : UserControl
 {
+    private const double CompactPageThreshold = 1200;
+    private const double MinimalPageThreshold = 900;
+
     private static readonly FilePickerFileType ImageFileType = new("Images")
     {
         Patterns = ["*.jpg", "*.jpeg", "*.png"],
@@ -38,6 +42,20 @@ public partial class AppShell : UserControl
         // context menus (column visibility, chart) close on any sidebar/header click.
         AppSidebar.AddHandler(PointerPressedEvent, OnSidebarPointerPressed, RoutingStrategies.Tunnel);
         AppHeader.AddHandler(PointerPressedEvent, OnHeaderPointerPressed, RoutingStrategies.Tunnel);
+
+        // Responsive page content margin
+        AppContent.SizeChanged += OnContentSizeChanged;
+    }
+
+    private void OnContentSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        var width = e.NewSize.Width;
+        if (width < MinimalPageThreshold)
+            PageContentControl.Margin = new Thickness(0);
+        else if (width < CompactPageThreshold)
+            PageContentControl.Margin = new Thickness(12);
+        else
+            PageContentControl.Margin = new Thickness(30);
     }
 
     /// <inheritdoc />

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -103,7 +103,7 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto"
                   HorizontalScrollBarVisibility="Disabled"
                   Background="{DynamicResource BackgroundSecondaryBrush}">
-        <StackPanel Margin="24" Spacing="24">
+        <StackPanel x:Name="ContentPanel" Margin="24" Spacing="24">
             <!-- Page Header -->
             <Grid ColumnDefinitions="*,Auto,Auto">
                 <StackPanel Grid.Column="0" Spacing="4">
@@ -155,7 +155,7 @@
             <controls:SetupChecklist DataContext="{Binding SetupChecklist}" />
 
             <!-- Quick Actions Section -->
-            <Border Classes="card" Padding="20" IsVisible="{Binding HasVisibleQuickActions}">
+            <Border x:Name="QuickActionsCard" Classes="card" Padding="20" IsVisible="{Binding HasVisibleQuickActions}">
                 <StackPanel>
                     <Grid ColumnDefinitions="*,Auto">
                         <TextBlock Grid.Column="0"
@@ -174,7 +174,7 @@
                     </Grid>
 
                     <!-- Responsive WrapPanel for Quick Actions (centered per row) -->
-                    <controls:CenteringWrapPanel Margin="0,8,0,0">
+                    <controls:CenteringWrapPanel x:Name="QuickActionsWrapPanel" Margin="0,8,0,0">
                         <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding NewInvoiceCommand}"
                                 IsVisible="{Binding ShowNewInvoice}">

--- a/ArgoBooks/Views/DashboardPage.axaml.cs
+++ b/ArgoBooks/Views/DashboardPage.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -22,6 +23,8 @@ public partial class DashboardPage : UserControl
     private Control? _clickedChart;
     private string _clickedChartName = "Chart";
 
+    private const double CompactQuickActionsThreshold = 1050;
+
     public DashboardPage()
     {
         InitializeComponent();
@@ -32,8 +35,38 @@ public partial class DashboardPage : UserControl
         // Subscribe to ViewModel events when DataContext changes
         DataContextChanged += OnDataContextChanged;
 
+        // Responsive quick actions padding
+        QuickActionsCard.SizeChanged += OnQuickActionsSizeChanged;
+
         // Wire up chart scroll handler after control is loaded
         Loaded += OnLoaded;
+    }
+
+    private void OnQuickActionsSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        var width = e.NewSize.Width;
+        if (width < CompactQuickActionsThreshold)
+        {
+            foreach (var child in QuickActionsWrapPanel.Children)
+            {
+                if (child is Button btn)
+                {
+                    btn.Padding = new Thickness(8, 6);
+                    btn.Margin = new Thickness(3);
+                }
+            }
+        }
+        else
+        {
+            foreach (var child in QuickActionsWrapPanel.Children)
+            {
+                if (child is Button btn)
+                {
+                    btn.Padding = new Thickness(12, 10);
+                    btn.Margin = new Thickness(6);
+                }
+            }
+        }
     }
 
     private void OnLoaded(object? sender, RoutedEventArgs e)

--- a/ArgoBooks/Views/ReceiptsPage.axaml
+++ b/ArgoBooks/Views/ReceiptsPage.axaml
@@ -74,6 +74,26 @@
                                 BorderSizeChanged="OnHeaderSizeChanged"
                                 TableGridSizeChanged="OnTableSizeChanged">
 
+                <!-- View Toggle Buttons -->
+                <table:ArgoTable.ExtraButtonsContent>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <Button Classes="view-toggle-button"
+                                Classes.selected="{Binding IsGridView}"
+                                Command="{Binding SetGridViewCommand}"
+                                ToolTip.Tip="{loc:Loc 'Grid View'}">
+                            <PathIcon Data="M4 11h5V5H4v6zm0 7h5v-6H4v6zm6 0h5v-6h-5v6zm6 0h5v-6h-5v6zm-6-7h5V5h-5v6zm6-6v6h5V5h-5z"
+                                      Width="16" Height="16" />
+                        </Button>
+                        <Button Classes="view-toggle-button"
+                                Classes.selected="{Binding IsListView}"
+                                Command="{Binding SetListViewCommand}"
+                                ToolTip.Tip="{loc:Loc 'List View'}">
+                            <PathIcon Data="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z"
+                                      Width="16" Height="16" />
+                        </Button>
+                    </StackPanel>
+                </table:ArgoTable.ExtraButtonsContent>
+
                 <!-- Table Header Content (List View Column Headers) - Using ArgoTableHeader -->
                 <table:ArgoTable.HeaderContent>
                     <StackPanel Orientation="Horizontal" IsVisible="{Binding IsListView}">

--- a/ArgoBooks/Views/ReceiptsPage.axaml.cs
+++ b/ArgoBooks/Views/ReceiptsPage.axaml.cs
@@ -120,6 +120,8 @@ public partial class ReceiptsPage : UserControl
         if (DataContext is ReceiptsPageViewModel viewModel && e.WidthChanged)
         {
             viewModel.ColumnWidths.SetAvailableWidth(e.NewSize.Width);
+            if (viewModel.IsGridView)
+                viewModel.ColumnWidths.NeedsHorizontalScroll = false;
         }
     }
 

--- a/ArgoBooks/Views/ReportsPage.axaml.cs
+++ b/ArgoBooks/Views/ReportsPage.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Controls.Presenters;
 using Avalonia.Media;
 
 namespace ArgoBooks.Views;


### PR DESCRIPTION
Cherry-pick all changes from claude/fix-stat-card-overflow-wRmHY except commit 8d4b2db (report template card responsiveness).

Includes:
- Responsive stat cards with minimal/compact states
- Responsive page padding (AppShell-consolidated)
- Quick actions responsive thresholds and padding
- Zoom/pan controls and preview fixes for receipt scanner
- Grid/table view toggle for Receipts page
- Sidebar company name auto-shrink and panel widening
- Nullability warning fixes in InvoiceTemplateDesignerViewModel
- Product mismatch fix in import and receipt reference decoupling
- Transaction edit fixes for PO numbers and product dropdown
- Help panel title removal