### PR TITLE
Add undo/redo support for company edits and event persistence

### DIFF
--- a/ArgoBooks.Core/Models/AuditEvent.cs
+++ b/ArgoBooks.Core/Models/AuditEvent.cs
@@ -85,6 +85,14 @@ public class AuditEvent
     public string? RelatedEventId { get; set; }
 
     /// <summary>
+    /// Runtime-only flag indicating whether this event has been persisted to disk.
+    /// Events loaded from file are marked as saved; new in-session events start unsaved.
+    /// Not serialized to JSON.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsSaved { get; set; }
+
+    /// <summary>
     /// The ID of the accountant who performed this action.
     /// Currently unused — reserved for future multi-accountant support.
     /// </summary>

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -1103,6 +1103,10 @@ public class App : Application
     {
         if (EventLogService != null && CompanyManager?.CompanyData != null)
         {
+            // Commit pending events: remove events for actions that were undone,
+            // and mark remaining unsaved events as saved
+            EventLogService.CommitPendingEvents(UndoRedoManager.UndoHistory);
+
             EventLogService.SyncToCompanyData(CompanyManager.CompanyData);
         }
     }

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -1890,9 +1890,27 @@ public class App : Application
                 var settings = CompanyManager.CurrentCompanySettings;
                 if (settings != null)
                 {
+                    // Capture old values for undo
                     var oldName = settings.Company.Name;
+                    var oldBusinessType = settings.Company.BusinessType;
+                    var oldIndustry = settings.Company.Industry;
+                    var oldPhone = settings.Company.Phone;
+                    var oldCountry = settings.Company.Country;
+                    var oldCity = settings.Company.City;
+                    var oldAddress = settings.Company.Address;
+                    var oldLogoFileName = settings.Company.LogoFileName;
+
+                    // Save old logo bytes for potential undo restore
+                    byte[]? oldLogoBytes = null;
+                    var oldLogoFilePath = CompanyManager.CurrentCompanyLogoPath;
+                    if (!string.IsNullOrEmpty(oldLogoFilePath) && File.Exists(oldLogoFilePath))
+                    {
+                        oldLogoBytes = await Task.Run(() => File.ReadAllBytes(oldLogoFilePath));
+                    }
+
                     var nameChanged = oldName != args.CompanyName;
 
+                    // Apply new values
                     settings.Company.Name = args.CompanyName;
                     settings.Company.BusinessType = args.BusinessType;
                     settings.Company.Industry = args.Industry;
@@ -1912,10 +1930,27 @@ public class App : Application
                         await CompanyManager.RemoveCompanyLogoAsync();
                     }
 
+                    // Capture new logo state after changes
+                    var newLogoFileName = settings.Company.LogoFileName;
+                    byte[]? newLogoBytes = null;
+                    var newLogoFilePath = CompanyManager.CurrentCompanyLogoPath;
+                    if (!string.IsNullOrEmpty(newLogoFilePath) && File.Exists(newLogoFilePath))
+                    {
+                        newLogoBytes = await Task.Run(() => File.ReadAllBytes(newLogoFilePath));
+                    }
+
+                    // Derive temp directory for logo file operations during undo/redo
+                    var logoTempDir = !string.IsNullOrEmpty(oldLogoFilePath)
+                        ? Path.GetDirectoryName(oldLogoFilePath)
+                        : (!string.IsNullOrEmpty(newLogoFilePath)
+                            ? Path.GetDirectoryName(newLogoFilePath)
+                            : null);
+
                     // Mark settings as changed
                     settings.ChangesMade = true;
 
                     // If company name changed, save and rename file (skip for sample company)
+                    var oldFilePath = CompanyManager.CurrentFilePath;
                     if (nameChanged && CompanyManager.CurrentFilePath != null && !CompanyManager.IsSampleCompany)
                     {
                         // Save first to persist the new name in the file
@@ -1931,8 +1966,8 @@ public class App : Application
                         {
                             CompanyManager.RenameFile(newPath);
                         }
-
                     }
+                    var newFilePath = CompanyManager.CurrentFilePath;
 
                     // Update UI
                     _mainWindowViewModel?.OpenCompany(args.CompanyName);
@@ -1942,6 +1977,74 @@ public class App : Application
                         args.CompanyName,
                         CompanyManager.CurrentFilePath,
                         logo);
+
+                    // Record undo/redo action
+                    var newName = args.CompanyName;
+                    var newBusinessType = args.BusinessType;
+                    var newIndustry = args.Industry;
+                    var newPhone = args.Phone;
+                    var newCountry = args.Country;
+                    var newCity = args.City;
+                    var newAddress = args.Address;
+
+                    UndoRedoManager.RecordAction(new DelegateAction(
+                        $"Edit company '{newName}'",
+                        () =>
+                        {
+                            // Restore old values
+                            settings.Company.Name = oldName;
+                            settings.Company.BusinessType = oldBusinessType;
+                            settings.Company.Industry = oldIndustry;
+                            settings.Company.Phone = oldPhone;
+                            settings.Company.Country = oldCountry;
+                            settings.Company.City = oldCity;
+                            settings.Company.Address = oldAddress;
+
+                            // Restore old logo
+                            RestoreCompanyLogo(settings, oldLogoFileName, oldLogoBytes, logoTempDir);
+
+                            // Rename file back if it was renamed
+                            if (oldFilePath != newFilePath && oldFilePath != null)
+                            {
+                                try
+                                {
+                                    if (!File.Exists(oldFilePath))
+                                        CompanyManager!.RenameFile(oldFilePath);
+                                }
+                                catch { /* Continue if rename fails - settings are already correct */ }
+                            }
+
+                            settings.ChangesMade = true;
+                            RefreshCompanyUI(oldName);
+                        },
+                        () =>
+                        {
+                            // Re-apply new values
+                            settings.Company.Name = newName;
+                            settings.Company.BusinessType = newBusinessType;
+                            settings.Company.Industry = newIndustry;
+                            settings.Company.Phone = newPhone;
+                            settings.Company.Country = newCountry;
+                            settings.Company.City = newCity;
+                            settings.Company.Address = newAddress;
+
+                            // Restore new logo
+                            RestoreCompanyLogo(settings, newLogoFileName, newLogoBytes, logoTempDir);
+
+                            // Rename file to new name if it was renamed
+                            if (oldFilePath != newFilePath && newFilePath != null)
+                            {
+                                try
+                                {
+                                    if (!File.Exists(newFilePath))
+                                        CompanyManager!.RenameFile(newFilePath);
+                                }
+                                catch { /* Continue if rename fails - settings are already correct */ }
+                            }
+
+                            settings.ChangesMade = true;
+                            RefreshCompanyUI(newName);
+                        }));
                 }
             }
             catch (Exception ex)
@@ -1981,6 +2084,36 @@ public class App : Application
                 }
             }
         };
+    }
+
+    /// <summary>
+    /// Restores a company logo file and updates the LogoFileName setting.
+    /// Used by undo/redo to restore logo state.
+    /// </summary>
+    private static void RestoreCompanyLogo(CompanySettings settings, string? logoFileName, byte[]? logoBytes, string? tempDir)
+    {
+        settings.Company.LogoFileName = logoFileName;
+        if (tempDir != null && logoFileName != null && logoBytes != null)
+        {
+            var path = Path.Combine(tempDir, logoFileName);
+            File.WriteAllBytes(path, logoBytes);
+        }
+    }
+
+    /// <summary>
+    /// Refreshes company-related UI elements (sidebar, company switcher, main window title).
+    /// Used by undo/redo to update the UI after restoring company data.
+    /// </summary>
+    private static void RefreshCompanyUI(string companyName)
+    {
+        if (_appShellViewModel == null) return;
+        _mainWindowViewModel?.OpenCompany(companyName);
+        var logo = LoadBitmapFromPath(CompanyManager?.CurrentCompanyLogoPath);
+        _appShellViewModel.SetCompanyInfo(companyName, logo);
+        _appShellViewModel.CompanySwitcherPanelViewModel.SetCurrentCompany(
+            companyName,
+            CompanyManager?.CurrentFilePath,
+            logo);
     }
 
     /// <summary>

--- a/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
@@ -1767,7 +1767,8 @@ public partial class LineItemDisplayModel : ObservableObject
         if (value != null)
         {
             Description = value.Name;
-            UnitPrice = value.UnitPrice;
+            if (UnitPrice is null or 0)
+                UnitPrice = value.UnitPrice;
             HasProductError = false;
         }
     }

--- a/ArgoBooks/ViewModels/PurchaseOrdersModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/PurchaseOrdersModalsViewModel.cs
@@ -1092,7 +1092,8 @@ public partial class OrderLineItemViewModel : ObservableObject
             {
                 ProductId = value.Id;
                 ProductName = value.Name;
-                UnitCost = value.CostPrice.ToString("F2");
+                if (string.IsNullOrEmpty(UnitCost) || UnitCost == "0.00")
+                    UnitCost = value.CostPrice.ToString("F2");
                 HasProductError = false;
                 OnPropertyChanged();
             }

--- a/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
+++ b/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
@@ -1098,7 +1098,8 @@ public abstract partial class TransactionLineItemBase : ObservableObject
         if (value != null)
         {
             Description = value.Name;
-            UnitPrice = value.UnitPrice;
+            if (UnitPrice is null or 0)
+                UnitPrice = value.UnitPrice;
             HasProductError = false;
         }
     }

--- a/ArgoBooks/ViewModels/VersionHistoryModalViewModel.cs
+++ b/ArgoBooks/ViewModels/VersionHistoryModalViewModel.cs
@@ -286,10 +286,12 @@ public partial class VersionHistoryModalViewModel : ViewModelBase
             : SelectedEntityTypeFilter;
 
         // Get events filtered by action/entity type (no text search — we handle that with Levenshtein)
+        // Only show saved events — unsaved events are still pending in the undo stack
         var events = _eventLogService.GetFilteredEvents(
             searchQuery: null,
             actionFilter: actionFilter,
             entityTypeFilter: entityTypeFilter)
+            .Where(e => e.IsSaved)
             .ToList();
 
         // Apply fuzzy search using Levenshtein scoring
@@ -319,7 +321,7 @@ public partial class VersionHistoryModalViewModel : ViewModelBase
                 .ToList();
         }
 
-        TotalEventCount = _eventLogService.EventCount;
+        TotalEventCount = _eventLogService.SavedEventCount;
         FilteredEventCount = filteredEvents.Count;
         HasEvents = TotalEventCount > 0;
         IsFiltered = actionFilter.HasValue


### PR DESCRIPTION
## Summary
This PR implements comprehensive undo/redo support for company profile edits and improves event log persistence by tracking which events have been saved to disk versus pending in the undo stack.

## Key Changes

- **Company Edit Undo/Redo**: Added full undo/redo support for editing company information (name, business type, industry, contact details, address, and logo). The implementation captures both old and new states, handles file renaming when company name changes, and properly restores logo files during undo/redo operations.

- **Event Persistence Tracking**: Introduced `IsSaved` flag to `AuditEvent` to distinguish between persisted events (loaded from disk or committed) and pending events (created during the current session but not yet saved).

- **Event Commit Logic**: Added `CommitPendingEvents()` method to `EventLogService` that:
  - Removes unsaved events whose corresponding undo actions have been undone (via Ctrl+Z)
  - Marks remaining unsaved events as saved before persistence
  - Cleans up stale meta-events (Undone/Redone actions) that no longer have active parent actions

- **UI Refresh Helpers**: Extracted `RestoreCompanyLogo()` and `RefreshCompanyUI()` helper methods to reduce code duplication and ensure consistent UI updates during undo/redo operations.

- **Event Log Filtering**: Updated `GetEntityTypes()` and version history display to only show saved events, preventing unsaved pending events from appearing in audit reports.

- **Product Selection Improvements**: Fixed product selection behavior in invoices, purchase orders, and transactions to only auto-populate unit price/cost when the field is empty or zero, preserving user-entered values.

## Implementation Details

- Logo restoration during undo/redo uses a temporary directory approach to handle file I/O operations safely
- File rename operations include error handling to gracefully continue if rename fails (settings are already correct)
- The undo/redo action captures all company fields at the time of edit to ensure complete state restoration
- Event commit is called during `SyncEventLogBeforeSave()` to ensure only committed events are persisted to disk

https://claude.ai/code/session_018cLaHhWH2uzjpniR6bL6dC