### PR TITLE
Implement per-company chart settings persistence

### DIFF
--- a/ArgoBooks.Core/Models/GlobalSettings.cs
+++ b/ArgoBooks.Core/Models/GlobalSettings.cs
@@ -47,6 +47,12 @@ public class UiSettings
     /// </summary>
     public string TimeFormat { get; set; } = "12h";
     public ChartSettings Chart { get; set; } = new();
+
+    /// <summary>
+    /// Per-company chart settings, keyed by company file path.
+    /// </summary>
+    public Dictionary<string, ChartSettings> CompanyChartSettings { get; set; } = new();
+
     public QuickActionsSettings QuickActions { get; set; } = new();
     public EmojiPickerSettings EmojiPicker { get; set; } = new();
 

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -1178,6 +1178,9 @@ public class App : Application
                 }
             }
 
+            // Load company-specific chart preferences before navigating to Dashboard
+            ChartSettingsService.Instance.LoadForCompany(args.FilePath);
+
             // Check for low stock and overdue invoice notifications
             CheckAndSendNotifications();
 


### PR DESCRIPTION
## Summary
This PR implements per-company chart settings persistence, allowing each company to maintain its own chart preferences (chart type, date range, custom dates) independently. Previously, chart settings were shared globally across all companies.

## Key Changes
- **ChartSettingsService**: Added `LoadForCompany()` method to load company-specific settings when a company is opened, with fallback to defaults
- **Per-company storage**: Modified `SaveToGlobalSettings()` to store settings in a `CompanyChartSettings` dictionary keyed by company file path instead of a single global `Chart` object
- **GlobalSettings model**: Added `CompanyChartSettings` dictionary to `UiSettings` to support per-company preferences
- **App initialization**: Integrated `LoadForCompany()` call in the company manager event handler to load preferences before navigating to Dashboard
- **Loading state management**: Added `_isLoading` flag to prevent saving settings during the load operation

## Implementation Details
- Settings are reset to defaults before loading company-specific preferences, ensuring a clean state when switching companies
- The service maintains backward compatibility by keeping the global `Chart` property for potential legacy use
- Custom date ranges are only persisted when explicitly applied by the user
- All computed properties are notified after loading to ensure UI consistency

https://claude.ai/code/session_016xeJMbqA2YS8VU1e98KWuX