### PR TITLE
Add PaymentProviderService for payment provider state management

### DIFF
--- a/ArgoBooks.Core/Models/Portal/PortalModels.cs
+++ b/ArgoBooks.Core/Models/Portal/PortalModels.cs
@@ -41,8 +41,42 @@ public class PortalPublishResponse
     [JsonPropertyName("emailSent")]
     public bool EmailSent { get; set; }
 
+    /// <summary>
+    /// The currently connected payment methods (e.g. ["stripe", "square"]).
+    /// Returned by the server so the desktop app can stay in sync.
+    /// </summary>
+    [JsonPropertyName("payment_methods")]
+    public List<string>? PaymentMethods { get; set; }
+
     [JsonPropertyName("errorCode")]
     public string? ErrorCode { get; set; }
+}
+
+/// <summary>
+/// Response from disconnecting a payment provider.
+/// </summary>
+public class PortalDisconnectResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// The updated connected provider state after disconnection.
+    /// </summary>
+    [JsonPropertyName("connectedProviders")]
+    public ConnectedPaymentAccounts? ConnectedProviders { get; set; }
+
+    /// <summary>
+    /// The currently connected payment methods (e.g. ["paypal", "square"]).
+    /// </summary>
+    [JsonPropertyName("payment_methods")]
+    public List<string>? PaymentMethods { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public string? Timestamp { get; set; }
 }
 
 /// <summary>

--- a/ArgoBooks/Modals/SettingsModal.axaml
+++ b/ArgoBooks/Modals/SettingsModal.axaml
@@ -753,26 +753,8 @@
                     <TabItem Header="{loc:Loc 'Payment Portal'}">
                         <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="24,20,16,20" Padding="0,0,8,0">
                             <StackPanel Spacing="16">
-                                <!-- Sync Interval -->
-                                <StackPanel Spacing="6">
-                                    <TextBlock Text="{loc:Loc 'Auto-Sync Interval'}"
-                                               FontSize="13"
-                                               FontWeight="Medium"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <StackPanel Orientation="Horizontal" Spacing="12">
-                                        <ComboBox ItemsSource="{Binding SyncIntervalOptions}"
-                                                  SelectedItem="{Binding PortalSyncInterval}"
-                                                  Classes="form-combobox"
-                                                  Width="100" />
-                                        <TextBlock Text="{loc:Loc 'minutes (0 = manual sync only)'}"
-                                                   FontSize="12"
-                                                   Foreground="{DynamicResource TextTertiaryBrush}"
-                                                   VerticalAlignment="Center" />
-                                    </StackPanel>
-                                </StackPanel>
-
                                 <!-- Connected Payment Providers -->
-                                <StackPanel Spacing="8" Margin="0,8,0,0">
+                                <StackPanel Spacing="8">
                                     <TextBlock Text="{loc:Loc 'Connected Payment Providers'}"
                                                FontSize="13"
                                                FontWeight="Medium"
@@ -888,6 +870,24 @@
                                                     Padding="12,6" />
                                         </Grid>
                                     </Border>
+                                </StackPanel>
+
+                                <!-- Sync Interval -->
+                                <StackPanel Spacing="6" Margin="0,8,0,0">
+                                    <TextBlock Text="{loc:Loc 'Auto-Sync Interval'}"
+                                               FontSize="13"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <StackPanel Orientation="Horizontal" Spacing="12">
+                                        <ComboBox ItemsSource="{Binding SyncIntervalOptions}"
+                                                  SelectedItem="{Binding PortalSyncInterval}"
+                                                  Classes="form-combobox"
+                                                  Width="100" />
+                                        <TextBlock Text="{loc:Loc 'minutes (0 = manual sync only)'}"
+                                                   FontSize="12"
+                                                   Foreground="{DynamicResource TextTertiaryBrush}"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
                                 </StackPanel>
                             </StackPanel>
                         </ScrollViewer>

--- a/ArgoBooks/Services/PaymentProviderService.cs
+++ b/ArgoBooks/Services/PaymentProviderService.cs
@@ -1,0 +1,107 @@
+using ArgoBooks.Core.Models.Portal;
+
+namespace ArgoBooks.Services;
+
+/// <summary>
+/// Static service for notifying subscribers when payment provider connection state changes.
+/// Follows the same pattern as CurrencyService and DateFormatService.
+/// </summary>
+public static class PaymentProviderService
+{
+    /// <summary>
+    /// Event raised when payment provider connections change (connect or disconnect).
+    /// </summary>
+    public static event EventHandler? ProvidersChanged;
+
+    /// <summary>
+    /// Raises the ProvidersChanged event to notify subscribers.
+    /// </summary>
+    public static void NotifyProvidersChanged()
+    {
+        ProvidersChanged?.Invoke(null, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Updates the local PortalSettings.ConnectedAccounts from a ConnectedPaymentAccounts
+    /// object (e.g. from a server response) and fires the ProvidersChanged event.
+    /// </summary>
+    public static void UpdateConnectedAccounts(ConnectedPaymentAccounts accounts)
+    {
+        var settings = App.CompanyManager?.CompanyData?.Settings?.PaymentPortal;
+        if (settings == null) return;
+
+        settings.ConnectedAccounts.StripeConnected = accounts.StripeConnected;
+        settings.ConnectedAccounts.StripeEmail = accounts.StripeEmail;
+        settings.ConnectedAccounts.PaypalConnected = accounts.PaypalConnected;
+        settings.ConnectedAccounts.PaypalEmail = accounts.PaypalEmail;
+        settings.ConnectedAccounts.SquareConnected = accounts.SquareConnected;
+        settings.ConnectedAccounts.SquareEmail = accounts.SquareEmail;
+
+        NotifyProvidersChanged();
+    }
+
+    /// <summary>
+    /// Updates the local PortalSettings.ConnectedAccounts from a payment_methods list
+    /// (e.g. ["stripe", "square"]) and fires the ProvidersChanged event.
+    /// Providers not in the list are marked as disconnected.
+    /// </summary>
+    public static void UpdateFromPaymentMethods(List<string> paymentMethods)
+    {
+        var settings = App.CompanyManager?.CompanyData?.Settings?.PaymentPortal;
+        if (settings == null) return;
+
+        var methods = new HashSet<string>(paymentMethods.Select(m => m.ToLowerInvariant()));
+
+        // Only update the connected flags; preserve emails for providers still connected
+        if (!methods.Contains("stripe"))
+        {
+            settings.ConnectedAccounts.StripeConnected = false;
+            settings.ConnectedAccounts.StripeEmail = null;
+        }
+        else
+        {
+            settings.ConnectedAccounts.StripeConnected = true;
+        }
+
+        if (!methods.Contains("paypal"))
+        {
+            settings.ConnectedAccounts.PaypalConnected = false;
+            settings.ConnectedAccounts.PaypalEmail = null;
+        }
+        else
+        {
+            settings.ConnectedAccounts.PaypalConnected = true;
+        }
+
+        if (!methods.Contains("square"))
+        {
+            settings.ConnectedAccounts.SquareConnected = false;
+            settings.ConnectedAccounts.SquareEmail = null;
+        }
+        else
+        {
+            settings.ConnectedAccounts.SquareConnected = true;
+        }
+
+        NotifyProvidersChanged();
+    }
+
+    /// <summary>
+    /// Gets the list of currently connected payment method names (e.g. ["stripe", "paypal"]).
+    /// Reads from the current PortalSettings.ConnectedAccounts.
+    /// </summary>
+    public static List<string> GetConnectedMethods()
+    {
+        var settings = App.CompanyManager?.CompanyData?.Settings?.PaymentPortal;
+        if (settings == null) return [];
+
+        var methods = new List<string>();
+        if (settings.ConnectedAccounts.StripeConnected)
+            methods.Add("stripe");
+        if (settings.ConnectedAccounts.PaypalConnected)
+            methods.Add("paypal");
+        if (settings.ConnectedAccounts.SquareConnected)
+            methods.Add("square");
+        return methods;
+    }
+}

--- a/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
@@ -1251,6 +1251,13 @@ public partial class InvoiceModalsViewModel : ViewModelBase
                                 Timestamp = DateTime.UtcNow
                             });
                         }
+
+                        // Update local provider state from the server's response so the
+                        // desktop app stays in sync with which methods are available.
+                        if (publishResponse.PaymentMethods != null)
+                        {
+                            PaymentProviderService.UpdateFromPaymentMethods(publishResponse.PaymentMethods);
+                        }
                     }
                     else
                     {

--- a/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
@@ -274,8 +274,10 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
         };
 
         // Subscribe to payment provider changes so invoice display reflects current state
+        // and the create button / warning banner update immediately
         PaymentProviderService.ProvidersChanged += (_, _) =>
         {
+            CheckPortalConfiguration();
             FilterInvoices();
         };
     }
@@ -608,10 +610,12 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
 
     private void CheckPortalConfiguration()
     {
-        // Consider the portal configured if either the API key is present (portal registered)
-        // or a PortalUrl has been persisted from a previous server response.
+        // Consider the portal configured if the API key is present (or PortalUrl persisted)
+        // AND at least one payment provider is actually connected.
         var portalUrl = App.CompanyManager?.CompanyData?.Settings?.PaymentPortal?.PortalUrl;
-        IsPortalConfigured = PortalSettings.IsConfigured || !string.IsNullOrEmpty(portalUrl);
+        var hasPortalKey = PortalSettings.IsConfigured || !string.IsNullOrEmpty(portalUrl);
+        var hasConnectedProvider = PaymentProviderService.GetConnectedMethods().Count > 0;
+        IsPortalConfigured = hasPortalKey && hasConnectedProvider;
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
@@ -272,6 +272,12 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
             UpdateStatistics();
             FilterInvoices();
         };
+
+        // Subscribe to payment provider changes so invoice display reflects current state
+        PaymentProviderService.ProvidersChanged += (_, _) =>
+        {
+            FilterInvoices();
+        };
     }
 
     private void OnUndoRedoStateChanged(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
Introduces a new `PaymentProviderService` static service to centralize payment provider connection state management and notification across the application. This ensures all views stay synchronized when payment providers are connected or disconnected.

## Key Changes

- **New PaymentProviderService**: Static service following the same pattern as `CurrencyService` and `DateFormatService`
  - `ProvidersChanged` event for notifying subscribers of provider state changes
  - `UpdateConnectedAccounts()` method to sync from server response objects
  - `UpdateFromPaymentMethods()` method to sync from payment method lists
  - `GetConnectedMethods()` method to retrieve currently connected providers

- **Enhanced PortalDisconnectResponse model**: New response type that includes:
  - `ConnectedProviders` field with full provider state after disconnection
  - `PaymentMethods` list for server-authoritative provider state
  - Proper error handling with messages and timestamps

- **Updated PaymentPortalService.DisconnectProviderAsync()**: 
  - Now returns `PortalDisconnectResponse` instead of `bool`
  - Deserializes full server response to capture updated provider state
  - Improved error handling with specific exception types

- **SettingsModalViewModel improvements**:
  - Uses server-authoritative provider state from disconnect response
  - Calls `PaymentProviderService.NotifyProvidersChanged()` after provider changes
  - Notifies subscribers in `RefreshProviderStatusAsync()` and `PollForProviderConnectionAsync()`

- **InvoicesPageViewModel updates**:
  - Subscribes to `PaymentProviderService.ProvidersChanged` event
  - Portal configuration now requires both API key AND at least one connected provider
  - Updates immediately when provider state changes

- **PaymentsPageViewModel updates**:
  - Subscribes to `PaymentProviderService.ProvidersChanged` event
  - Portal configuration requires connected providers
  - Syncs state when provider changes occur

- **InvoiceModalsViewModel updates**:
  - Calls `PaymentProviderService.UpdateFromPaymentMethods()` after publishing invoices
  - Keeps local state synchronized with server's authoritative provider list

- **UI reordering**: Moved "Auto-Sync Interval" section below "Connected Payment Providers" in settings for better logical flow

## Implementation Details

The service uses a publish-subscribe pattern to decouple provider state changes from UI updates. When a provider is connected/disconnected, the service notifies all subscribers (invoice views, payment views, etc.) so they can update their UI and business logic accordingly. This prevents stale state and ensures the portal configuration status is always accurate across the application.

https://claude.ai/code/session_01NHeAkeU7vdzxb8RrDvuVA9