### PR TITLE
Add price input fields to product modals and apply context-aware defa…

### DIFF
--- a/ArgoBooks/Modals/ProductModals.axaml
+++ b/ArgoBooks/Modals/ProductModals.axaml
@@ -103,6 +103,16 @@
                                                             EmptyCreateCommand="{Binding OpenSuppliersWithAddModalCommand}" />
                             </StackPanel>
 
+                            <StackPanel Spacing="6" IsVisible="{Binding !IsExpensesTab}">
+                                <TextBlock Text="{loc:Loc 'Default Unit Price'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                <TextBox Text="{Binding ModalUnitPrice, Mode=TwoWay}" Classes="form-input" Watermark="0.00" MaxLength="15" />
+                            </StackPanel>
+
+                            <StackPanel Spacing="6" IsVisible="{Binding IsExpensesTab}">
+                                <TextBlock Text="{loc:Loc 'Default Cost Price'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                <TextBox Text="{Binding ModalCostPrice, Mode=TwoWay}" Classes="form-input" Watermark="0.00" MaxLength="15" />
+                            </StackPanel>
+
                             <Grid ColumnDefinitions="*,16,*" IsVisible="{Binding IsProductSelected}">
                                 <StackPanel Grid.Column="0" Spacing="6">
                                     <TextBlock Text="{loc:Loc 'Reorder Point'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
@@ -219,6 +229,16 @@
                                                             EmptyMessage="{loc:Loc 'No suppliers available.'}"
                                                             EmptyCreateLinkText="{loc:Loc 'Create one'}"
                                                             EmptyCreateCommand="{Binding OpenSuppliersWithAddModalCommand}" />
+                            </StackPanel>
+
+                            <StackPanel Spacing="6" IsVisible="{Binding !IsExpensesTab}">
+                                <TextBlock Text="{loc:Loc 'Default Unit Price'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                <TextBox Text="{Binding ModalUnitPrice, Mode=TwoWay}" Classes="form-input" Watermark="0.00" MaxLength="15" />
+                            </StackPanel>
+
+                            <StackPanel Spacing="6" IsVisible="{Binding IsExpensesTab}">
+                                <TextBlock Text="{loc:Loc 'Default Cost Price'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                <TextBox Text="{Binding ModalCostPrice, Mode=TwoWay}" Classes="form-input" Watermark="0.00" MaxLength="15" />
                             </StackPanel>
 
                             <Grid ColumnDefinitions="*,16,*" IsVisible="{Binding IsProductSelected}">

--- a/ArgoBooks/ViewModels/ProductModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ProductModalsViewModel.cs
@@ -115,7 +115,9 @@ public partial class ProductModalsViewModel : ObservableObject
 
     /// <summary>
     /// Whether we're in expenses tab (purchase) or revenue tab (sales).
+    /// Used to show the relevant price field (Cost Price for expenses, Unit Price for revenue).
     /// </summary>
+    [ObservableProperty]
     private bool _isExpensesTab = true;
 
     // Original values for change detection in edit mode
@@ -233,7 +235,7 @@ public partial class ProductModalsViewModel : ObservableObject
 
     public void OpenAddModal(bool isExpensesTab)
     {
-        _isExpensesTab = isExpensesTab;
+        IsExpensesTab = isExpensesTab;
         OpenAddModal();
     }
 
@@ -415,7 +417,7 @@ public partial class ProductModalsViewModel : ObservableObject
 
     public void OpenEditModal(ProductDisplayItem? item, bool isExpensesTab)
     {
-        _isExpensesTab = isExpensesTab;
+        IsExpensesTab = isExpensesTab;
         OpenEditModal(item);
     }
 


### PR DESCRIPTION
…ults

- Add Unit Price and Cost Price input fields to product modals
- Show only the relevant price field based on expense/revenue context
- Always apply product default price when selecting a product in line items
- Fix product modal showing wrong price field for revenue/expense tab

https://claude.ai/code/session_011uwieV7GAjZbYpQBsz7C8U