### PR TITLE
Fix ErrorLogger JSON export to serialize enums as strings

### DIFF
--- a/ArgoBooks.Core/Services/ErrorLogger.cs
+++ b/ArgoBooks.Core/Services/ErrorLogger.cs
@@ -51,7 +51,8 @@ public partial class ErrorLogger : IErrorLogger
         _jsonOptions = new JsonSerializerOptions
         {
             WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter() }
         };
     }
 

--- a/ArgoBooks.Tests/Services/ErrorLoggerTests.cs
+++ b/ArgoBooks.Tests/Services/ErrorLoggerTests.cs
@@ -200,6 +200,7 @@ public class ErrorLoggerTests
         Assert.NotEmpty(json);
         Assert.Contains("Test error", json);
         Assert.Contains("Test warning", json);
+        Assert.Contains("Api", json);
     }
 
     #endregion


### PR DESCRIPTION
Add JsonStringEnumConverter to ErrorLogger's JSON serializer options so that enum values like ErrorCategory and LogLevel are exported as readable strings (e.g. "Api") instead of integer values. Restore the "Api" assertion in ExportErrorLogAsync_ReturnsValidJson test.

The other three reported test failures (LicenseService null platform constructor, IdGenerator expense/category prefixes) were already fixed in previous commits.