### PR TITLE
Refactor translation workflow to save files incrementally

### DIFF
--- a/ArgoBooks.TranslationTool/Program.cs
+++ b/ArgoBooks.TranslationTool/Program.cs
@@ -214,15 +214,14 @@ Console.WriteLine();
 
 try
 {
-    var translations = await generator.TranslateAllAsync(
+    await generator.TranslateAllAsync(
         strings,
         languagesToTranslate,
+        outputDir,
         CancellationToken.None);
 
-    await generator.SaveTranslationsAsync(translations, outputDir);
-
     Console.WriteLine($"\nDone! Translations saved to: {outputDir}");
-    Console.WriteLine($"Generated {translations.Count} language files.");
+    Console.WriteLine($"Translated {generator.LanguagesTranslated} languages.");
 
     // Print Azure API usage summary
     Console.WriteLine();
@@ -236,6 +235,8 @@ try
 catch (Exception ex)
 {
     Console.WriteLine($"\nERROR: Translation failed: {ex.Message}");
+    if (generator.LanguagesTranslated > 0)
+        Console.WriteLine($"  {generator.LanguagesTranslated} language(s) were saved before the error. Re-run to continue.");
     return 1;
 }
 


### PR DESCRIPTION
## Summary
Refactored the translation generation workflow to save translation files immediately after each language completes, rather than collecting all results in memory and saving at the end. This enables progress preservation across runs and graceful recovery from interruptions.

## Key Changes
- **Modified `TranslateAllAsync` method**: Changed return type from `Dictionary<string, Dictionary<string, string>>` to `Task` (void). Now accepts `outputDirectory` parameter and saves JSON files immediately after translating each language.
- **Added incremental translation logic**: Only translates strings that don't already exist in output files, preserving previous work and allowing resumable translation runs.
- **New `LoadExistingTranslationsAsync` method**: Loads existing translations from JSON files to identify which strings still need translation, with graceful error handling for corrupted files.
- **Removed `SaveTranslationsAsync` method**: No longer needed since translations are saved immediately within `TranslateAllAsync`.
- **Updated progress reporting**: Now reports the count of new strings being translated and total strings per language, plus confirmation when files are saved.
- **Simplified calling code**: `GenerateAllTranslationsAsync` and `GenerateTranslationsAsync` now call `TranslateAllAsync` directly without intermediate collection step.
- **Improved error messaging**: Added helpful message when translation fails, indicating how many languages were successfully saved and suggesting re-run to continue.

## Implementation Details
- Uses `JsonSerializerOptions` with `WriteIndented = true` and `UnsafeRelaxedJsonEscaping` for consistent JSON formatting
- Maintains case-insensitive dictionary comparisons for translation keys
- Skips languages that are already up-to-date (no new strings to translate)
- English language handling simplified to just skip (no longer saved separately)

https://claude.ai/code/session_01CGJGJeLJ54K818NakSvNyk