### PR TITLE
Add configurable axis font size for charts

### DIFF
--- a/ArgoBooks.Core/Models/Reports/ReportElementBase.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportElementBase.cs
@@ -215,6 +215,13 @@ public class ChartReportElement : ReportElementBase
         set => SetField(ref field, value);
     } = 12;
 
+    [JsonPropertyName("axisFontSize")]
+    public double AxisFontSize
+    {
+        get;
+        set => SetField(ref field, value);
+    } = 10;
+
     [JsonPropertyName("legendFontSize")]
     public double LegendFontSize
     {
@@ -279,6 +286,7 @@ public class ChartReportElement : ReportElementBase
             FontFamily = FontFamily,
             TitleFontFamily = TitleFontFamily,
             TitleFontSize = TitleFontSize,
+            AxisFontSize = AxisFontSize,
             LegendFontSize = LegendFontSize,
             LegendMaxCharacters = LegendMaxCharacters,
             BorderColor = BorderColor,

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -942,7 +942,7 @@ public class ReportRenderer : IDisposable
         var legendX = centerX + radius + 20 * _renderScale;
         var legendY = chartArea.Top + 10 * _renderScale;
 
-        using var labelFont = new SKFont(chartTypeface, 9 * _renderScale);
+        using var labelFont = new SKFont(chartTypeface, (float)chart.LegendFontSize * _renderScale);
         using var labelPaint = new SKPaint();
         labelPaint.Color = SKColors.Black;
         labelPaint.IsAntialias = true;

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -600,7 +600,7 @@ public class ReportRenderer : IDisposable
 
             // Draw Y-axis value labels using the full padded range
             var value = paddedMaxValue - totalRange * i / gridLineCount;
-            using var yLabelFont = new SKFont(chartTypeface, 9 * _renderScale);
+            using var yLabelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
             using var yLabelPaint = new SKPaint();
             yLabelPaint.Color = ChartAxisColor;
             yLabelPaint.IsAntialias = true;
@@ -662,7 +662,7 @@ public class ReportRenderer : IDisposable
         }
 
         // Draw X-axis labels - dynamically based on date range and available width
-        using var xLabelFont = new SKFont(chartTypeface, 10 * _renderScale);
+        using var xLabelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
         using var xLabelPaint = new SKPaint();
         xLabelPaint.Color = ChartAxisColor;
         xLabelPaint.IsAntialias = true;
@@ -736,7 +736,7 @@ public class ReportRenderer : IDisposable
 
             // Draw Y-axis value labels using the full padded range
             var value = paddedMaxValue - totalRange * i / gridLineCount;
-            using var yLabelFont = new SKFont(chartTypeface, 9 * _renderScale);
+            using var yLabelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
             using var yLabelPaint = new SKPaint();
             yLabelPaint.Color = ChartAxisColor;
             yLabelPaint.IsAntialias = true;
@@ -876,7 +876,7 @@ public class ReportRenderer : IDisposable
         }
 
         // Draw X-axis labels - dynamically based on date range and available width
-        using var xLabelFont = new SKFont(chartTypeface, 10 * _renderScale);
+        using var xLabelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
         using var xLabelPaint = new SKPaint();
         xLabelPaint.Color = ChartAxisColor;
         xLabelPaint.IsAntialias = true;
@@ -1063,7 +1063,7 @@ public class ReportRenderer : IDisposable
 
             // Draw Y-axis value labels using the full padded range
             var value = paddedMaxValue - totalRange * i / gridLineCount;
-            using var yLabelFont = new SKFont(chartTypeface, 9 * _renderScale);
+            using var yLabelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
             using var yLabelPaint = new SKPaint();
             yLabelPaint.Color = ChartAxisColor;
             yLabelPaint.IsAntialias = true;
@@ -1129,7 +1129,7 @@ public class ReportRenderer : IDisposable
         }
 
         // Draw X-axis labels - dynamically based on date range and available width
-        using var xLabelFont = new SKFont(chartTypeface, 10 * _renderScale);
+        using var xLabelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
         using var xLabelPaint = new SKPaint();
         xLabelPaint.Color = ChartAxisColor;
         xLabelPaint.IsAntialias = true;
@@ -1201,7 +1201,7 @@ public class ReportRenderer : IDisposable
 
             // Draw Y-axis value labels using the full padded range
             var value = paddedMaxValue - totalRange * i / gridLineCount;
-            using var yLabelFont = new SKFont(chartTypeface, 9 * _renderScale);
+            using var yLabelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
             using var yLabelPaint = new SKPaint();
             yLabelPaint.Color = ChartAxisColor;
             yLabelPaint.IsAntialias = true;
@@ -1342,7 +1342,7 @@ public class ReportRenderer : IDisposable
         }
 
         // Draw X-axis labels
-        using var xLabelFont = new SKFont(chartTypeface, 10 * _renderScale);
+        using var xLabelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
         using var xLabelPaint = new SKPaint();
         xLabelPaint.Color = ChartAxisColor;
         xLabelPaint.IsAntialias = true;
@@ -1391,8 +1391,8 @@ public class ReportRenderer : IDisposable
         var maxBarWidth = chartArea.Width * 0.6f;
         var labelWidth = chartArea.Width * 0.25f;
 
-        using var labelFont = new SKFont(chartTypeface, 10 * _renderScale);
-        using var valueFont = new SKFont(chartTypeface, 9 * _renderScale);
+        using var labelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
+        using var valueFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
         using var labelPaint = new SKPaint();
         labelPaint.Color = SKColors.Black;
         labelPaint.IsAntialias = true;

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -980,6 +980,10 @@
                                     <TextBlock Text="{loc:Loc 'Title Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.TitleFontSize}" Minimum="6" Maximum="36" />
                                 </StackPanel>
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="{loc:Loc 'Axis Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.AxisFontSize}" Minimum="6" Maximum="24" />
+                                </StackPanel>
                                 <StackPanel Spacing="4" IsVisible="{Binding IsDistributionChartSelected}">
                                     <TextBlock Text="{loc:Loc 'Legend Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.LegendFontSize}" Minimum="6" Maximum="24" />

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -970,7 +970,7 @@
                                               SelectedItem="{Binding SelectedChartElement.TitleFontFamily}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
-                                <StackPanel Spacing="4">
+                                <StackPanel Spacing="4" IsVisible="{Binding !IsDistributionChartSelected}">
                                     <TextBlock Text="{loc:Loc 'Axis Font'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding FontFamilies}"
                                               SelectedItem="{Binding SelectedChartElement.FontFamily}"
@@ -980,7 +980,7 @@
                                     <TextBlock Text="{loc:Loc 'Title Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.TitleFontSize}" Minimum="6" Maximum="36" />
                                 </StackPanel>
-                                <StackPanel Spacing="4">
+                                <StackPanel Spacing="4" IsVisible="{Binding !IsDistributionChartSelected}">
                                     <TextBlock Text="{loc:Loc 'Axis Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.AxisFontSize}" Minimum="6" Maximum="24" />
                                 </StackPanel>


### PR DESCRIPTION
## Summary
This PR introduces a new `AxisFontSize` property to chart elements, allowing users to customize the font size of axis labels independently from other chart text elements. Previously, axis label font sizes were hardcoded (9pt for Y-axis, 10pt for X-axis across different chart types).

## Key Changes
- **Added `AxisFontSize` property** to `ReportElementBase` model with a default value of 10pt
  - Includes JSON serialization support via `[JsonPropertyName("axisFontSize")]`
  - Properly integrated into the `Clone()` method for element duplication

- **Updated all chart rendering methods** to use the new `AxisFontSize` property:
  - `RenderBarChart()` - Y-axis and X-axis labels
  - `RenderLineChart()` - Y-axis and X-axis labels
  - `RenderPieChart()` - Legend labels (uses `LegendFontSize` instead)
  - `RenderMultiSeriesBarChart()` - Y-axis and X-axis labels
  - `RenderMultiSeriesLineChart()` - Y-axis and X-axis labels
  - `RenderGeoMap()` - Both label and value fonts

- **Added UI control** in ReportsPage.axaml:
  - New numeric input field for "Axis Size" with range 6-24pt
  - Visibility bound to `!IsDistributionChartSelected` to hide for pie charts (which use legend font size)
  - Positioned logically after the title font size control

## Implementation Details
- All hardcoded font size values (9 and 10) are replaced with `(float)chart.AxisFontSize * _renderScale`
- The pie chart legend continues to use `LegendFontSize` as it serves a different purpose
- Font size values are cast to float to match the SKFont constructor requirements
- The render scale multiplier is preserved to maintain DPI-aware scaling

https://claude.ai/code/session_01LsUPN8TPdqvTLC9VRW2koc