### PR TITLE
Require Ctrl modifier for zoom, allow scroll wheel for panning

### DIFF
--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -289,7 +289,7 @@ public partial class SkiaReportDesignCanvas : UserControl
             _canvasImage.PointerReleased += OnCanvasPointerReleased;
         }
 
-        // Wire up pointer wheel for zoom-to-cursor (only fires when not already handled by parent)
+        // Wire up pointer wheel for Ctrl+scroll zoom-to-cursor (only fires when not already handled by parent)
         _scrollViewer?.AddHandler(PointerWheelChangedEvent, OnPointerWheelChanged, Avalonia.Interactivity.RoutingStrategies.Bubble);
 
         // Wire up keyboard events
@@ -751,7 +751,10 @@ public partial class SkiaReportDesignCanvas : UserControl
 
     private void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
-        // Zoom with scroll wheel (no modifier key required)
+        // Only zoom when Ctrl is held; otherwise let ScrollViewer handle it for panning
+        if (!e.KeyModifiers.HasFlag(KeyModifiers.Control))
+            return;
+
         if (_scrollViewer == null || _canvasImage == null)
             return;
 

--- a/ArgoBooks/Views/ReportsPage.axaml.cs
+++ b/ArgoBooks/Views/ReportsPage.axaml.cs
@@ -389,6 +389,10 @@ public partial class ReportsPage : UserControl
 
     private void OnCanvasPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
+        // Only zoom when Ctrl is held; otherwise let ScrollViewer handle it for panning
+        if (!e.KeyModifiers.HasFlag(KeyModifiers.Control))
+            return;
+
         // Zoom at cursor position
         if (_designCanvas != null && DataContext is ReportsPageViewModel vm)
         {
@@ -451,6 +455,10 @@ public partial class ReportsPage : UserControl
 
     private void OnPreviewPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
+        // Only zoom when Ctrl is held; otherwise let ScrollViewer handle it for panning
+        if (!e.KeyModifiers.HasFlag(KeyModifiers.Control))
+            return;
+
         // Zoom at cursor position
         if (_previewScrollViewer != null && _previewZoomTransformControl != null)
         {


### PR DESCRIPTION
## Summary
Modified pointer wheel event handlers across the reports UI to require the Ctrl modifier key for zoom operations, allowing the scroll wheel to be used for panning when Ctrl is not held.

## Key Changes
- **ReportsPage.axaml.cs**: Added Ctrl modifier checks to `OnCanvasPointerWheelChanged()` and `OnPreviewPointerWheelChanged()` methods to gate zoom functionality
- **SkiaReportDesignCanvas.axaml.cs**: Added Ctrl modifier check to `OnPointerWheelChanged()` method and updated comment to reflect the new behavior
- When Ctrl is not held, the scroll wheel events are now allowed to propagate to the ScrollViewer for normal panning behavior

## Implementation Details
- All three wheel event handlers now check `e.KeyModifiers.HasFlag(KeyModifiers.Control)` and return early if Ctrl is not pressed
- This prevents zoom operations from interfering with standard scrolling/panning interactions
- The change maintains backward compatibility for users who use Ctrl+scroll to zoom while enabling intuitive scroll-to-pan behavior

https://claude.ai/code/session_01Kom2bHEEUu7r6yTkgT4dwu