### PR TITLE
Implement automatic page continuation for overflowing accounting tables

### DIFF
--- a/ArgoBooks.Core/Models/Reports/PageContinuationPlan.cs
+++ b/ArgoBooks.Core/Models/Reports/PageContinuationPlan.cs
@@ -1,0 +1,79 @@
+namespace ArgoBooks.Core.Models.Reports;
+
+/// <summary>
+/// Represents a single page in the effective page sequence.
+/// Can be either an original template page or a continuation page for an overflowing accounting table.
+/// </summary>
+public class EffectivePage
+{
+    /// <summary>
+    /// Which template page this corresponds to (1-based).
+    /// </summary>
+    public int SourcePageNumber { get; set; }
+
+    /// <summary>
+    /// Element ID of the overflowing accounting table, or null for original template pages.
+    /// </summary>
+    public string? ContinuationElementId { get; set; }
+
+    /// <summary>
+    /// First row index to render on this page (0-based into the table's Rows list).
+    /// </summary>
+    public int StartRowIndex { get; set; }
+
+    /// <summary>
+    /// Number of rows to render on this page.
+    /// </summary>
+    public int RowCount { get; set; }
+
+    /// <summary>
+    /// Starting data row index for alternating row color continuity.
+    /// </summary>
+    public int DataRowStartIndex { get; set; }
+
+    /// <summary>
+    /// Whether this is the last page for this particular accounting table's data.
+    /// Used to determine if footnote should be shown.
+    /// </summary>
+    public bool IsLastContinuationPage { get; set; }
+
+    /// <summary>
+    /// Position of this page in the effective output sequence (1-based).
+    /// </summary>
+    public int EffectivePageNumber { get; set; }
+
+    /// <summary>
+    /// True if this is a continuation page (not an original template page).
+    /// </summary>
+    public bool IsContinuationPage => ContinuationElementId != null;
+}
+
+/// <summary>
+/// Runtime plan for page continuation. Computed before rendering begins.
+/// Maps the fixed template pages into an effective page sequence that includes
+/// auto-generated continuation pages for overflowing accounting tables.
+/// </summary>
+public class PageContinuationPlan
+{
+    /// <summary>
+    /// The effective page sequence, including both original and continuation pages.
+    /// </summary>
+    public List<EffectivePage> Pages { get; set; } = [];
+
+    /// <summary>
+    /// Cached table data fetched during planning, keyed by element ID.
+    /// Prevents re-fetching during rendering.
+    /// </summary>
+    public Dictionary<string, AccountingTableData> CachedTableData { get; set; } = new();
+
+    /// <summary>
+    /// For each overflowing element, how many rows fit on the original (first) page.
+    /// Keyed by element ID. Used by the renderer to know where to stop on page 1.
+    /// </summary>
+    public Dictionary<string, int> FirstPageRowCounts { get; set; } = new();
+
+    /// <summary>
+    /// Total number of effective pages.
+    /// </summary>
+    public int TotalPageCount => Pages.Count;
+}

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -699,7 +699,8 @@ public class ReportRenderer : IDisposable
     /// </summary>
     public void RenderEffectivePageToCanvas(SKCanvas canvas, EffectivePage page, int width, int height)
     {
-        canvas.Clear(_backgroundPaint.Color);
+        // Use DrawRect instead of Clear so stacked pages aren't wiped out
+        canvas.DrawRect(0, 0, width, height, _backgroundPaint);
 
         if (_config.ShowHeader)
         {

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -328,6 +328,42 @@ public class ReportRenderer : IDisposable
         }
     }
 
+    /// <summary>
+    /// Exports an effective page (including continuation pages) to an image file.
+    /// </summary>
+    public async Task<bool> ExportEffectivePageToImageAsync(string filePath, EffectivePage page, ExportFormat format, int quality = 95)
+    {
+        try
+        {
+            using var bitmap = RenderEffectivePageToBitmap(page);
+            using var image = SKImage.FromBitmap(bitmap);
+
+            var formatType = format switch
+            {
+                ExportFormat.PNG => SKEncodedImageFormat.Png,
+                ExportFormat.JPEG => SKEncodedImageFormat.Jpeg,
+                _ => SKEncodedImageFormat.Png
+            };
+
+            using var data = image.Encode(formatType, quality);
+
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await using var stream = File.Create(filePath);
+            data.SaveTo(stream);
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public async Task<bool> ExportToImageAsync(string filePath, ExportFormat format, int quality = 95)
     {
         try
@@ -379,16 +415,20 @@ public class ReportRenderer : IDisposable
                 Directory.CreateDirectory(directory);
             }
 
-            _config.TotalPageCount = _config.PageCount;
+            // Compute continuation plan for overflow handling
+            if (_continuationPlan == null)
+                ComputeContinuationPlan();
+
+            _config.TotalPageCount = EffectivePageCount;
 
             await using var stream = File.Create(filePath);
             using var document = SKDocument.CreatePdf(stream);
 
-            for (int page = 1; page <= _config.PageCount; page++)
+            foreach (var effectivePage in _continuationPlan!.Pages)
             {
-                _config.CurrentPageNumber = page;
+                _config.CurrentPageNumber = effectivePage.EffectivePageNumber;
                 using var canvas = document.BeginPage(scaledWidth, scaledHeight);
-                RenderPageToCanvas(canvas, page, scaledWidth, scaledHeight);
+                RenderEffectivePageToCanvas(canvas, effectivePage, scaledWidth, scaledHeight);
                 document.EndPage();
             }
 
@@ -426,6 +466,358 @@ public class ReportRenderer : IDisposable
 
         return bitmap;
     }
+
+    #region Page Continuation Planning
+
+    private PageContinuationPlan? _continuationPlan;
+
+    /// <summary>
+    /// The effective number of pages after accounting for continuation pages.
+    /// </summary>
+    public int EffectivePageCount => _continuationPlan?.TotalPageCount ?? _config.PageCount;
+
+    /// <summary>
+    /// Gets the continuation plan (must call ComputeContinuationPlan first).
+    /// </summary>
+    public PageContinuationPlan? GetContinuationPlan() => _continuationPlan;
+
+    /// <summary>
+    /// Computes the height of a single accounting row based on its type.
+    /// Single source of truth used by both the planner and the renderer.
+    /// </summary>
+    internal static float GetAccountingRowHeight(AccountingRowType rowType, float dataRowHeight, float headerRowHeight)
+    {
+        return rowType switch
+        {
+            AccountingRowType.SectionHeader => headerRowHeight,
+            AccountingRowType.DataRow => dataRowHeight,
+            AccountingRowType.SubtotalRow => dataRowHeight,
+            AccountingRowType.TotalRow => dataRowHeight * 1.1f,
+            AccountingRowType.GrandTotalRow => dataRowHeight * 1.3f,
+            AccountingRowType.SeparatorLine => dataRowHeight * 0.5f,
+            AccountingRowType.BlankRow => dataRowHeight * 0.5f,
+            _ => dataRowHeight
+        };
+    }
+
+    /// <summary>
+    /// Computes the height consumed by the accounting table header area on the first page
+    /// (title bar + subtitle + column headers).
+    /// </summary>
+    internal static float GetAccountingTableFirstPageHeaderHeight(
+        AccountingTableReportElement element, AccountingTableData tableData, float renderScale)
+    {
+        var headerRowHeight = (float)element.HeaderRowHeight * renderScale;
+        var dataRowHeight = (float)element.DataRowHeight * renderScale;
+
+        var height = headerRowHeight * 1.4f; // Title bar
+        if (!string.IsNullOrEmpty(tableData.Subtitle))
+            height += dataRowHeight * 1.2f; // Subtitle
+        if (tableData.ColumnHeaders.Count > 0)
+            height += headerRowHeight; // Column headers
+        return height;
+    }
+
+    /// <summary>
+    /// Computes the height consumed by the continuation page header area
+    /// ("(Continued)" indicator + column headers).
+    /// </summary>
+    internal static float GetAccountingTableContinuationHeaderHeight(
+        AccountingTableReportElement element, AccountingTableData tableData, float renderScale)
+    {
+        var headerRowHeight = (float)element.HeaderRowHeight * renderScale;
+        var dataRowHeight = (float)element.DataRowHeight * renderScale;
+
+        var height = dataRowHeight * 0.8f; // "(Continued)" indicator
+        if (tableData.ColumnHeaders.Count > 0)
+            height += headerRowHeight; // Column headers
+        return height;
+    }
+
+    /// <summary>
+    /// Computes the continuation plan for all accounting tables that may overflow.
+    /// Must be called before rendering begins.
+    /// </summary>
+    public void ComputeContinuationPlan()
+    {
+        var plan = new PageContinuationPlan();
+        var (pageWidth, pageHeight) = PageDimensions.GetDimensions(_config.PageSize, _config.PageOrientation);
+
+        // Build effective pages: start with all template pages
+        // Then insert continuation pages after each template page as needed
+        for (int templatePage = 1; templatePage <= _config.PageCount; templatePage++)
+        {
+            // Add the original template page
+            plan.Pages.Add(new EffectivePage
+            {
+                SourcePageNumber = templatePage,
+                ContinuationElementId = null,
+                StartRowIndex = 0,
+                RowCount = 0,
+                EffectivePageNumber = 0 // will be assigned later
+            });
+
+            // Check each accounting table on this page for overflow
+            var accountingElements = _config.Elements
+                .OfType<AccountingTableReportElement>()
+                .Where(e => e.PageNumber == templatePage && e.IsVisible)
+                .OrderBy(e => e.ZOrder)
+                .ToList();
+
+            foreach (var element in accountingElements)
+            {
+                var dataService = new AccountingReportDataService(_companyData, _config.Filters);
+                var tableData = dataService.GetReportData(element.ReportType);
+                plan.CachedTableData[element.Id] = tableData;
+
+                if (tableData.Rows.Count == 0)
+                    continue;
+
+                var dataRowHeight = (float)element.DataRowHeight * _renderScale;
+                var headerRowHeight = (float)element.HeaderRowHeight * _renderScale;
+
+                // Compute available height on the first page (element's own rect)
+                var rect = GetScaledRect(element);
+                var firstPageAvailable = rect.Height
+                    - GetAccountingTableFirstPageHeaderHeight(element, tableData, _renderScale);
+
+                // Walk rows to find how many fit on page 1
+                float accumulatedHeight = 0;
+                int firstPageRowCount = 0;
+                int dataRowIndex = 0;
+
+                for (int i = 0; i < tableData.Rows.Count; i++)
+                {
+                    var rowHeight = GetAccountingRowHeight(tableData.Rows[i].RowType, dataRowHeight, headerRowHeight);
+                    if (accumulatedHeight + rowHeight > firstPageAvailable)
+                        break;
+                    accumulatedHeight += rowHeight;
+                    firstPageRowCount++;
+                    if (tableData.Rows[i].RowType == AccountingRowType.DataRow)
+                        dataRowIndex++;
+                }
+
+                // If all rows fit, no continuation needed
+                if (firstPageRowCount >= tableData.Rows.Count)
+                    continue;
+
+                plan.FirstPageRowCounts[element.Id] = firstPageRowCount;
+
+                // Compute continuation pages
+                // Available height on continuation pages: full content area
+                var continuationTop = PageDimensions.HeaderHeight * _renderScale;
+                var continuationBottom = pageHeight * _renderScale - PageDimensions.FooterHeight * _renderScale;
+                var continuationAvailable = continuationBottom - continuationTop
+                    - GetAccountingTableContinuationHeaderHeight(element, tableData, _renderScale);
+
+                // Reserve space for footnote on last page
+                var footnoteHeight = !string.IsNullOrEmpty(tableData.Footnote)
+                    ? dataRowHeight * 1.3f
+                    : 0f;
+
+                int currentRowIndex = firstPageRowCount;
+                while (currentRowIndex < tableData.Rows.Count)
+                {
+                    // Determine if this might be the last page
+                    // Try to fit remaining rows
+                    float pageAccumulated = 0;
+                    int pageRowCount = 0;
+                    int pageDataRowStart = dataRowIndex;
+
+                    // Compute how many rows fit
+                    for (int i = currentRowIndex; i < tableData.Rows.Count; i++)
+                    {
+                        var rowHeight = GetAccountingRowHeight(tableData.Rows[i].RowType, dataRowHeight, headerRowHeight);
+                        if (pageAccumulated + rowHeight > continuationAvailable)
+                            break;
+                        pageAccumulated += rowHeight;
+                        pageRowCount++;
+                        if (tableData.Rows[i].RowType == AccountingRowType.DataRow)
+                            dataRowIndex++;
+                    }
+
+                    bool isLast = currentRowIndex + pageRowCount >= tableData.Rows.Count;
+
+                    // If this is the last page and footnote would overflow, reduce rows
+                    if (isLast && footnoteHeight > 0 && pageAccumulated + footnoteHeight > continuationAvailable)
+                    {
+                        // Recalculate with footnote space reserved
+                        var availableWithFootnote = continuationAvailable - footnoteHeight;
+                        pageAccumulated = 0;
+                        pageRowCount = 0;
+                        dataRowIndex = pageDataRowStart;
+
+                        for (int i = currentRowIndex; i < tableData.Rows.Count; i++)
+                        {
+                            var rowHeight = GetAccountingRowHeight(tableData.Rows[i].RowType, dataRowHeight, headerRowHeight);
+                            if (pageAccumulated + rowHeight > availableWithFootnote)
+                                break;
+                            pageAccumulated += rowHeight;
+                            pageRowCount++;
+                            if (tableData.Rows[i].RowType == AccountingRowType.DataRow)
+                                dataRowIndex++;
+                        }
+
+                        isLast = currentRowIndex + pageRowCount >= tableData.Rows.Count;
+                    }
+
+                    // Safety: always progress at least 1 row to prevent infinite loop
+                    if (pageRowCount == 0)
+                    {
+                        pageRowCount = 1;
+                        if (tableData.Rows[currentRowIndex].RowType == AccountingRowType.DataRow)
+                            dataRowIndex++;
+                    }
+
+                    plan.Pages.Add(new EffectivePage
+                    {
+                        SourcePageNumber = templatePage,
+                        ContinuationElementId = element.Id,
+                        StartRowIndex = currentRowIndex,
+                        RowCount = pageRowCount,
+                        DataRowStartIndex = pageDataRowStart,
+                        IsLastContinuationPage = currentRowIndex + pageRowCount >= tableData.Rows.Count,
+                        EffectivePageNumber = 0 // assigned below
+                    });
+
+                    currentRowIndex += pageRowCount;
+                }
+            }
+        }
+
+        // Assign effective page numbers
+        for (int i = 0; i < plan.Pages.Count; i++)
+        {
+            plan.Pages[i].EffectivePageNumber = i + 1;
+        }
+
+        _continuationPlan = plan;
+    }
+
+    /// <summary>
+    /// Renders a single effective page (original or continuation) to a canvas.
+    /// </summary>
+    public void RenderEffectivePageToCanvas(SKCanvas canvas, EffectivePage page, int width, int height)
+    {
+        canvas.Clear(_backgroundPaint.Color);
+
+        if (_config.ShowHeader)
+        {
+            RenderHeader(canvas, width);
+        }
+
+        if (page.IsContinuationPage)
+        {
+            // Continuation page: render only the overflowing accounting table
+            var element = _config.Elements
+                .OfType<AccountingTableReportElement>()
+                .FirstOrDefault(e => e.Id == page.ContinuationElementId);
+
+            if (element != null && _continuationPlan?.CachedTableData.TryGetValue(element.Id, out var tableData) == true)
+            {
+                // Position the table in the full content area
+                var margin = PageDimensions.Margin * _renderScale;
+                var contentTop = PageDimensions.HeaderHeight * _renderScale;
+                var contentBottom = height - PageDimensions.FooterHeight * _renderScale;
+                var overrideRect = new SKRect(margin, contentTop, width - margin, contentBottom);
+
+                RenderAccountingTableSlice(canvas, element, tableData,
+                    page.StartRowIndex, page.RowCount, page.DataRowStartIndex,
+                    showTitle: false, showSubtitle: false,
+                    showFootnote: page.IsLastContinuationPage,
+                    showContinuedIndicator: true,
+                    overrideRect: overrideRect);
+            }
+        }
+        else
+        {
+            // Original template page: render all elements
+            foreach (var element in _config.GetElementsByZOrderForPage(page.SourcePageNumber))
+            {
+                if (!element.IsVisible)
+                    continue;
+
+                if (element is AccountingTableReportElement accounting
+                    && _continuationPlan?.FirstPageRowCounts.TryGetValue(accounting.Id, out var firstPageRowCount) == true
+                    && _continuationPlan.CachedTableData.TryGetValue(accounting.Id, out var tableData))
+                {
+                    // This table overflows — render only the first page's rows
+                    RenderAccountingTableSlice(canvas, accounting, tableData,
+                        startRowIndex: 0, rowCount: firstPageRowCount, dataRowStartIndex: 0,
+                        showTitle: true, showSubtitle: true,
+                        showFootnote: false,
+                        showContinuedIndicator: false);
+                }
+                else if (element is AccountingTableReportElement accounting2
+                    && _continuationPlan?.CachedTableData.TryGetValue(accounting2.Id, out var cachedData) == true)
+                {
+                    // This table doesn't overflow but we have cached data — use it
+                    RenderAccountingTableSlice(canvas, accounting2, cachedData,
+                        startRowIndex: 0, rowCount: cachedData.Rows.Count, dataRowStartIndex: 0,
+                        showTitle: true, showSubtitle: true,
+                        showFootnote: true,
+                        showContinuedIndicator: false);
+                }
+                else
+                {
+                    RenderElement(canvas, element);
+                }
+            }
+        }
+
+        if (_config.ShowFooter)
+        {
+            RenderFooter(canvas, width, height);
+        }
+    }
+
+    /// <summary>
+    /// Renders an effective page to a bitmap.
+    /// </summary>
+    public SKBitmap RenderEffectivePageToBitmap(EffectivePage page)
+    {
+        var (width, height) = PageDimensions.GetDimensions(_config.PageSize, _config.PageOrientation);
+        var scaledWidth = (int)(width * _renderScale);
+        var scaledHeight = (int)(height * _renderScale);
+
+        _config.CurrentPageNumber = page.EffectivePageNumber;
+        _config.TotalPageCount = EffectivePageCount;
+
+        var bitmap = new SKBitmap(scaledWidth, scaledHeight);
+        using var canvas = new SKCanvas(bitmap);
+
+        RenderEffectivePageToCanvas(canvas, page, scaledWidth, scaledHeight);
+
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Creates a preview bitmap for an effective page at the specified scale.
+    /// </summary>
+    public SKBitmap CreateEffectivePagePreview(EffectivePage page, int maxWidth, int maxHeight)
+    {
+        var (width, height) = PageDimensions.GetDimensions(_config.PageSize, _config.PageOrientation);
+
+        var scaleX = (float)maxWidth / width;
+        var scaleY = (float)maxHeight / height;
+        var scale = Math.Min(scaleX, scaleY);
+
+        var previewWidth = (int)(width * scale);
+        var previewHeight = (int)(height * scale);
+
+        _config.CurrentPageNumber = page.EffectivePageNumber;
+        _config.TotalPageCount = EffectivePageCount;
+
+        var bitmap = new SKBitmap(previewWidth, previewHeight);
+        using var canvas = new SKCanvas(bitmap);
+
+        canvas.Scale(scale, scale);
+        RenderEffectivePageToCanvas(canvas, page, width, height);
+
+        return bitmap;
+    }
+
+    #endregion
 
     #region Element Rendering
 
@@ -2622,14 +3014,30 @@ public class ReportRenderer : IDisposable
 
     private void RenderAccountingTable(SKCanvas canvas, AccountingTableReportElement element)
     {
-        var rect = GetScaledRect(element);
+        // Backward-compatible wrapper for designer mode (no continuation plan)
+        var dataService = new AccountingReportDataService(_companyData, _config.Filters);
+        var tableData = dataService.GetReportData(element.ReportType);
+
+        RenderAccountingTableSlice(canvas, element, tableData,
+            startRowIndex: 0, rowCount: tableData.Rows.Count, dataRowStartIndex: 0,
+            showTitle: true, showSubtitle: true, showFootnote: true,
+            showContinuedIndicator: false);
+    }
+
+    /// <summary>
+    /// Renders a slice of an accounting table. Used for both single-page rendering
+    /// and multi-page continuation rendering.
+    /// </summary>
+    private void RenderAccountingTableSlice(
+        SKCanvas canvas, AccountingTableReportElement element, AccountingTableData tableData,
+        int startRowIndex, int rowCount, int dataRowStartIndex,
+        bool showTitle, bool showSubtitle, bool showFootnote, bool showContinuedIndicator,
+        SKRect? overrideRect = null)
+    {
+        var rect = overrideRect ?? GetScaledRect(element);
 
         // Draw white background
         canvas.DrawRect(rect, new SKPaint { Color = SKColors.White, Style = SKPaintStyle.Fill });
-
-        // Get accounting data
-        var dataService = new AccountingReportDataService(_companyData, _config.Filters);
-        var tableData = dataService.GetReportData(element.ReportType);
 
         // Create typefaces and fonts
         var typeface = SKTypeface.FromFamilyName(element.FontFamily) ?? _defaultTypeface;
@@ -2667,17 +3075,33 @@ public class ReportRenderer : IDisposable
         var currentY = rect.Top;
         var contentLeft = rect.Left + cellPadding;
 
-        // --- Draw Title ---
-        var titleBarHeight = headerRowHeight * 1.4f;
-        var titleRect = new SKRect(rect.Left, currentY, rect.Right, currentY + titleBarHeight);
-        canvas.DrawRect(titleRect, new SKPaint { Color = ParseColor(element.HeaderBackgroundColor), Style = SKPaintStyle.Fill });
+        // --- Draw Title (only on first page) ---
+        if (showTitle)
+        {
+            var titleBarHeight = headerRowHeight * 1.4f;
+            var titleRect = new SKRect(rect.Left, currentY, rect.Right, currentY + titleBarHeight);
+            canvas.DrawRect(titleRect, new SKPaint { Color = ParseColor(element.HeaderBackgroundColor), Style = SKPaintStyle.Fill });
 
-        using var titlePaint = new SKPaint { Color = ParseColor(element.HeaderTextColor), IsAntialias = true };
-        canvas.DrawText(tableData.Title, rect.MidX, currentY + titleBarHeight * 0.65f, SKTextAlign.Center, titleFont, titlePaint);
-        currentY += titleBarHeight;
+            using var titlePaint = new SKPaint { Color = ParseColor(element.HeaderTextColor), IsAntialias = true };
+            canvas.DrawText(tableData.Title, rect.MidX, currentY + titleBarHeight * 0.65f, SKTextAlign.Center, titleFont, titlePaint);
+            currentY += titleBarHeight;
+        }
 
-        // --- Draw Subtitle ---
-        if (!string.IsNullOrEmpty(tableData.Subtitle))
+        // --- Draw "(Continued)" indicator (on continuation pages) ---
+        if (showContinuedIndicator)
+        {
+            var continuedHeight = dataRowHeight * 0.8f;
+            var continuedRect = new SKRect(rect.Left, currentY, rect.Right, currentY + continuedHeight);
+            canvas.DrawRect(continuedRect, new SKPaint { Color = ParseColor(element.HeaderBackgroundColor), Style = SKPaintStyle.Fill });
+
+            using var continuedPaint = new SKPaint { Color = ParseColor(element.HeaderTextColor), IsAntialias = true };
+            var continuedText = $"{tableData.Title} ({Tr("Continued")})";
+            canvas.DrawText(continuedText, rect.MidX, currentY + continuedHeight * 0.65f, SKTextAlign.Center, italicFont, continuedPaint);
+            currentY += continuedHeight;
+        }
+
+        // --- Draw Subtitle (only on first page) ---
+        if (showSubtitle && !string.IsNullOrEmpty(tableData.Subtitle))
         {
             var subtitleHeight = dataRowHeight * 1.2f;
             using var subtitlePaint = new SKPaint { Color = ParseColor(element.DataRowTextColor), IsAntialias = true };
@@ -2685,7 +3109,7 @@ public class ReportRenderer : IDisposable
             currentY += subtitleHeight;
         }
 
-        // --- Draw Column Headers ---
+        // --- Draw Column Headers (always shown) ---
         if (tableData.ColumnHeaders.Count > 0)
         {
             var colHeaderRect = new SKRect(rect.Left, currentY, rect.Right, currentY + headerRowHeight);
@@ -2707,12 +3131,16 @@ public class ReportRenderer : IDisposable
                 new SKPaint { Color = ParseColor(element.GridLineColor), StrokeWidth = 1 * _renderScale, Style = SKPaintStyle.Stroke });
         }
 
-        // --- Draw Rows ---
-        int dataRowIndex = 0;
-        foreach (var row in tableData.Rows)
+        // --- Draw Rows (only the assigned slice) ---
+        int dataRowIndex = dataRowStartIndex;
+        var endRowIndex = Math.Min(startRowIndex + rowCount, tableData.Rows.Count);
+
+        for (int rowIdx = startRowIndex; rowIdx < endRowIndex; rowIdx++)
         {
+            var row = tableData.Rows[rowIdx];
+
             if (currentY + dataRowHeight > rect.Bottom - dataRowHeight)
-                break; // Stop if we'd overflow
+                break; // Safety: stop if we'd overflow (shouldn't happen with correct planning)
 
             switch (row.RowType)
             {
@@ -2850,8 +3278,8 @@ public class ReportRenderer : IDisposable
             }
         }
 
-        // --- Draw Footnote ---
-        if (!string.IsNullOrEmpty(tableData.Footnote) && currentY + dataRowHeight <= rect.Bottom)
+        // --- Draw Footnote (only on last page) ---
+        if (showFootnote && !string.IsNullOrEmpty(tableData.Footnote) && currentY + dataRowHeight <= rect.Bottom)
         {
             currentY += dataRowHeight * 0.3f;
             using var footnotePaint = new SKPaint { Color = ParseColor(element.DataRowTextColor), IsAntialias = true };

--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -47,9 +47,14 @@ public partial class SkiaReportDesignCanvas : UserControl
     }
 
     /// <summary>
-    /// Gets the total number of pages to render.
+    /// Gets the total number of pages to render (including continuation pages).
     /// </summary>
-    private int GetPageCount() => Math.Max(1, Configuration?.PageCount ?? 1);
+    private int GetPageCount()
+    {
+        if (_continuationPlan != null && _continuationPlan.TotalPageCount > 0)
+            return _continuationPlan.TotalPageCount;
+        return Math.Max(1, Configuration?.PageCount ?? 1);
+    }
 
     /// <summary>
     /// Gets the total canvas height for all pages stacked vertically.
@@ -212,6 +217,7 @@ public partial class SkiaReportDesignCanvas : UserControl
     // Render state
     private SKBitmap? _renderBitmap;
     private bool _needsRender = true;
+    private PageContinuationPlan? _continuationPlan;
 
     #endregion
 
@@ -359,6 +365,13 @@ public partial class SkiaReportDesignCanvas : UserControl
 
         if (baseWidth <= 0 || baseHeight <= 0) return;
 
+        // Compute continuation plan first to know the correct page count and canvas size
+        var companyData = App.CompanyManager?.CompanyData;
+        Configuration.Use24HourFormat = TimeZoneService.Is24HourFormat;
+        using var renderer = new ReportRenderer(Configuration, companyData, 1f, LanguageServiceTranslationProvider.Instance, App.ErrorLogger);
+        renderer.ComputeContinuationPlan();
+        _continuationPlan = renderer.GetContinuationPlan();
+
         var pageCount = GetPageCount();
         var totalHeight = GetTotalCanvasHeight();
 
@@ -381,42 +394,70 @@ public partial class SkiaReportDesignCanvas : UserControl
         // Clear with gap background color
         canvas.Clear(new SKColor(200, 200, 200)); // Neutral gray for gaps
 
-        var companyData = App.CompanyManager?.CompanyData;
-        Configuration.Use24HourFormat = TimeZoneService.Is24HourFormat;
-        using var renderer = new ReportRenderer(Configuration, companyData, 1f, LanguageServiceTranslationProvider.Instance, App.ErrorLogger);
-
-        // Render each page stacked vertically
-        for (int page = 1; page <= pageCount; page++)
+        // Render effective pages stacked vertically
+        if (_continuationPlan?.Pages.Count > 0)
         {
-            var pageYOffset = GetPageYOffset(page);
+            Configuration.TotalPageCount = _continuationPlan.TotalPageCount;
 
-            canvas.Save();
-            canvas.Translate(0, pageYOffset);
-
-            // Draw page background
-            var bgColor = SKColor.Parse(Configuration.BackgroundColor);
-            canvas.DrawRect(0, 0, baseWidth, baseHeight, new SKPaint { Color = bgColor, Style = SKPaintStyle.Fill });
-
-            // Draw grid if enabled
-            if (ShowGrid)
+            foreach (var effectivePage in _continuationPlan.Pages)
             {
-                DrawGrid(canvas, baseWidth, baseHeight);
-            }
+                var pageYOffset = GetPageYOffset(effectivePage.EffectivePageNumber);
 
-            // Draw header/footer
-            if (Configuration.ShowHeader)
+                canvas.Save();
+                canvas.Translate(0, pageYOffset);
+
+                // Draw page background
+                var bgColor = SKColor.Parse(Configuration.BackgroundColor);
+                canvas.DrawRect(0, 0, baseWidth, baseHeight, new SKPaint { Color = bgColor, Style = SKPaintStyle.Fill });
+
+                // Draw grid if enabled (only on template pages, not continuation)
+                if (ShowGrid && !effectivePage.IsContinuationPage)
+                {
+                    DrawGrid(canvas, baseWidth, baseHeight);
+                }
+
+                // RenderEffectivePageToCanvas handles header/footer/elements internally
+                Configuration.CurrentPageNumber = effectivePage.EffectivePageNumber;
+                renderer.RenderEffectivePageToCanvas(canvas, effectivePage, baseWidth, baseHeight);
+
+                canvas.Restore();
+            }
+        }
+        else
+        {
+            // Fallback: render template pages directly (no continuation needed)
+            for (int page = 1; page <= pageCount; page++)
             {
-                DrawHeader(canvas, baseWidth);
-            }
-            if (Configuration.ShowFooter)
-            {
-                DrawFooter(canvas, baseWidth, baseHeight, page, pageCount);
-            }
+                var pageYOffset = GetPageYOffset(page);
 
-            // Render elements for this page
-            renderer.RenderElementsToCanvas(canvas, page);
+                canvas.Save();
+                canvas.Translate(0, pageYOffset);
 
-            canvas.Restore();
+                // Draw page background
+                var bgColor = SKColor.Parse(Configuration.BackgroundColor);
+                canvas.DrawRect(0, 0, baseWidth, baseHeight, new SKPaint { Color = bgColor, Style = SKPaintStyle.Fill });
+
+                // Draw grid if enabled
+                if (ShowGrid)
+                {
+                    DrawGrid(canvas, baseWidth, baseHeight);
+                }
+
+                // Draw header/footer
+                if (Configuration.ShowHeader)
+                {
+                    DrawHeader(canvas, baseWidth);
+                }
+                if (Configuration.ShowFooter)
+                {
+                    DrawFooter(canvas, baseWidth, baseHeight, page, pageCount);
+                }
+
+                // Render elements for this page
+                renderer.RenderElementsToCanvas(canvas, page);
+
+                canvas.Restore();
+            }
         }
 
         // Draw hover highlight and selection visuals (need page offset translation)

--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -1714,7 +1714,6 @@ public partial class SkiaReportDesignCanvas : UserControl
 
         var pageYOffset = GetPageYOffset(pageNumber);
         var zoom = ZoomLevel;
-        const double margin = 10;
 
         // Calculate the scroll offset to show this page at the top
         var scrollY = pageYOffset * zoom;


### PR DESCRIPTION
## Summary
This PR implements automatic page continuation for accounting tables that overflow their allocated space on a page. When a table's content exceeds the available height, the system now automatically generates continuation pages to display the remaining rows, with proper headers and formatting.

## Key Changes

- **New `PageContinuationPlan` model** (`PageContinuationPlan.cs`): Represents the effective page sequence including both original template pages and auto-generated continuation pages. Tracks which rows belong on each page and caches table data to avoid re-fetching during rendering.

- **Continuation planning algorithm** in `ReportRenderer.ComputeContinuationPlan()`: 
  - Analyzes each accounting table on each template page
  - Calculates how many rows fit on the first page given the table's allocated rectangle
  - Generates continuation pages for remaining rows with proper height calculations
  - Handles footnote placement on the last continuation page
  - Includes safety mechanisms to prevent infinite loops

- **New rendering methods**:
  - `RenderEffectivePageToCanvas()`: Renders either an original template page or a continuation page
  - `RenderEffectivePageToBitmap()`: Converts an effective page to a bitmap
  - `RenderAccountingTableSlice()`: Refactored table rendering to support partial row ranges with configurable headers/footers
  - `ExportEffectivePageToImageAsync()`: Exports individual effective pages to image files
  - `CreateEffectivePagePreview()`: Creates preview bitmaps for effective pages

- **Updated PDF export** (`ExportToPdfAsync()`): Now uses the continuation plan to render all effective pages instead of just template pages.

- **Updated preview and export logic** in `ReportsPageViewModel` and `SkiaReportDesignCanvas`: Both now compute the continuation plan and render effective pages instead of template pages, ensuring the UI accurately reflects the final output.

- **Helper methods** for height calculations:
  - `GetAccountingRowHeight()`: Computes height for each row type (data, subtotal, total, etc.)
  - `GetAccountingTableFirstPageHeaderHeight()`: Calculates header space on first page
  - `GetAccountingTableContinuationHeaderHeight()`: Calculates header space on continuation pages

## Notable Implementation Details

- The continuation plan is computed once before rendering and cached, preventing redundant calculations
- Table data is fetched during planning and cached to avoid re-querying during rendering
- Continuation pages display a "(Continued)" indicator instead of the full title
- Row alternation colors are maintained across continuation pages via `DataRowStartIndex`
- The system gracefully falls back to template page rendering if no continuation is needed
- Grid display in the designer is disabled on continuation pages to avoid visual clutter

https://claude.ai/code/session_01Tr5Lt5MdHAPdUBJ26XJ3J5