### PR TITLE
Add company details header and email field to reports

### DIFF
--- a/ArgoBooks.Core/Models/Reports/ReportConfiguration.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportConfiguration.cs
@@ -68,6 +68,13 @@ public class ReportConfiguration
     public bool ShowFooter { get; set; } = true;
 
     /// <summary>
+    /// Whether to show company details (logo, name, address, phone, email) in the report header.
+    /// Standard for formal accounting documents like balance sheets, income statements, etc.
+    /// </summary>
+    [JsonPropertyName("showCompanyDetails")]
+    public bool ShowCompanyDetails { get; set; }
+
+    /// <summary>
     /// Font size for the page title in the header (in points).
     /// </summary>
     [JsonPropertyName("titleFontSize")]
@@ -110,6 +117,13 @@ public class ReportConfiguration
     /// </summary>
     [JsonIgnore]
     public bool Use24HourFormat { get; set; }
+
+    /// <summary>
+    /// Full file path to the company logo image.
+    /// Runtime-only, resolved from CompanyManager's temp directory.
+    /// </summary>
+    [JsonIgnore]
+    public string? CompanyLogoPath { get; set; }
 
     /// <summary>
     /// Gets elements sorted by Z-order (for rendering).
@@ -189,6 +203,7 @@ public class ReportConfiguration
             ShowPageNumbers = ShowPageNumbers,
             ShowHeader = ShowHeader,
             ShowFooter = ShowFooter,
+            ShowCompanyDetails = ShowCompanyDetails,
             TitleFontSize = TitleFontSize,
             Filters = new ReportFilters
             {
@@ -374,6 +389,12 @@ public static class PageDimensions
     public const int HeaderHeight = 80;
 
     /// <summary>
+    /// Header height in pixels when company details are shown.
+    /// Accommodates logo, company name, address, and report title.
+    /// </summary>
+    public const int CompanyDetailsHeaderHeight = 90;
+
+    /// <summary>
     /// Footer height in pixels (matches LayoutContext in ReportTemplateFactory).
     /// </summary>
     public const int FooterHeight = 50;
@@ -392,6 +413,12 @@ public static class PageDimensions
     /// Render scale for high-quality export.
     /// </summary>
     public const float RenderScale = 3f;
+
+    /// <summary>
+    /// Gets the effective header height based on whether company details are shown.
+    /// </summary>
+    public static int GetHeaderHeight(bool showCompanyDetails) =>
+        showCompanyDetails ? CompanyDetailsHeaderHeight : HeaderHeight;
 
     /// <summary>
     /// Gets the dimensions for a page size in pixels (96 DPI).

--- a/ArgoBooks.Core/Models/Reports/ReportTemplateFactory.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportTemplateFactory.cs
@@ -134,6 +134,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters =
             {
                 TransactionType = TransactionType.Revenue,
@@ -166,6 +167,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters =
             {
                 TransactionType = TransactionType.Revenue,
@@ -198,6 +200,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters =
             {
                 TransactionType = TransactionType.Revenue,
@@ -230,6 +233,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters =
             {
                 TransactionType = TransactionType.Revenue,
@@ -265,6 +269,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters =
             {
                 TransactionType = TransactionType.Revenue,
@@ -300,6 +305,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters =
             {
                 TransactionType = TransactionType.Revenue,
@@ -332,6 +338,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters =
             {
                 TransactionType = TransactionType.Revenue,
@@ -364,6 +371,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters =
             {
                 TransactionType = TransactionType.Expenses,
@@ -812,6 +820,7 @@ public static class ReportTemplateFactory
             ShowHeader = true,
             ShowFooter = true,
             ShowPageNumbers = true,
+            ShowCompanyDetails = true,
             Filters = { DatePresetName = datePreset }
         };
 

--- a/ArgoBooks.Core/Models/Reports/TemplateLayoutHelper.cs
+++ b/ArgoBooks.Core/Models/Reports/TemplateLayoutHelper.cs
@@ -27,9 +27,9 @@ public static class TemplateLayoutHelper
         public double Margin { get; } = PageDimensions.Margin;
 
         /// <summary>
-        /// Height of the header area.
+        /// Height of the header area. Varies based on whether company details are shown.
         /// </summary>
-        public double HeaderHeight { get; } = PageDimensions.HeaderHeight;
+        public double HeaderHeight { get; }
 
         /// <summary>
         /// Height of the footer area.
@@ -74,15 +74,17 @@ public static class TemplateLayoutHelper
             var (width, height) = PageDimensions.GetDimensions(config.PageSize, config.PageOrientation);
             PageWidth = width;
             PageHeight = height;
+            HeaderHeight = PageDimensions.GetHeaderHeight(config.ShowCompanyDetails);
         }
 
         /// <summary>
         /// Creates a layout context with explicit page dimensions.
         /// </summary>
-        public LayoutContext(double pageWidth, double pageHeight)
+        public LayoutContext(double pageWidth, double pageHeight, bool showCompanyDetails = false)
         {
             PageWidth = pageWidth;
             PageHeight = pageHeight;
+            HeaderHeight = PageDimensions.GetHeaderHeight(showCompanyDetails);
         }
     }
 

--- a/ArgoBooks.Core/Services/SampleCompanyService.cs
+++ b/ArgoBooks.Core/Services/SampleCompanyService.cs
@@ -195,7 +195,8 @@ public class SampleCompanyService
             BusinessType = "Retail & Services",
             Industry = "Technology",
             Email = "info@techflowsolutions.com",
-            Phone = "555-100-0000"
+            Phone = "+1 5551000000",
+            Country = "Canada"
         };
 
         companyData.Settings.AppVersion = AppInfo.VersionNumber;

--- a/ArgoBooks.TranslationTool/translations/en.json
+++ b/ArgoBooks.TranslationTool/translations/en.json
@@ -510,6 +510,7 @@
   "str_showheader": "Show Header",
   "str_showfooter": "Show Footer",
   "str_showpagenumbers": "Show Page Numbers",
+  "str_showcompanydetails": "Show Company Details",
   "str_saveyourcurrentreportlayoutasareusabletemplate": "Save your current report layout as a reusable template.",
   "str_filterreturns": "Filter Returns",
   "str_returndetails": "Return Details",

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -1947,7 +1947,8 @@ public class App : Application
             settings?.Company.Phone,
             settings?.Company.Country,
             settings?.Company.City,
-            settings?.Company.Address);
+            settings?.Company.Address,
+            settings?.Company.Email);
     }
 
     /// <summary>
@@ -1976,6 +1977,7 @@ public class App : Application
                     var oldBusinessType = settings.Company.BusinessType;
                     var oldIndustry = settings.Company.Industry;
                     var oldPhone = settings.Company.Phone;
+                    var oldEmail = settings.Company.Email;
                     var oldCountry = settings.Company.Country;
                     var oldCity = settings.Company.City;
                     var oldAddress = settings.Company.Address;
@@ -1996,6 +1998,7 @@ public class App : Application
                     settings.Company.BusinessType = args.BusinessType;
                     settings.Company.Industry = args.Industry;
                     settings.Company.Phone = args.Phone;
+                    settings.Company.Email = args.Email;
                     settings.Company.Country = args.Country;
                     settings.Company.City = args.City;
                     settings.Company.Address = args.Address;
@@ -2099,6 +2102,7 @@ public class App : Application
                             settings.Company.BusinessType = oldBusinessType;
                             settings.Company.Industry = oldIndustry;
                             settings.Company.Phone = oldPhone;
+                            settings.Company.Email = oldEmail;
                             settings.Company.Country = oldCountry;
                             settings.Company.City = oldCity;
                             settings.Company.Address = oldAddress;

--- a/ArgoBooks/Controls/CountryInput.axaml.cs
+++ b/ArgoBooks/Controls/CountryInput.axaml.cs
@@ -80,6 +80,7 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
             {
                 _searchText = value;
                 RaisePropertyChanged();
+
                 if (!_isUpdatingText)
                 {
                     UpdateFilteredCountries();
@@ -171,31 +172,6 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
         UpdateFilteredCountries();
     }
 
-    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
-    {
-        base.OnPropertyChanged(change);
-
-        if (change.Property == SelectedCountryNameProperty && !_isUpdatingText)
-        {
-            var name = change.NewValue as string ?? string.Empty;
-            // First try exact match
-            var country = PhoneInput.AllDialCodes.FirstOrDefault(c =>
-                c.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-            // If no match, try normalizing the country name (handles USA, UK, etc.)
-            if (country == null && !string.IsNullOrWhiteSpace(name))
-            {
-                var normalizedName = Countries.NormalizeCountry(name);
-                if (normalizedName != null)
-                {
-                    country = PhoneInput.AllDialCodes.FirstOrDefault(c =>
-                        c.Name.Equals(normalizedName, StringComparison.OrdinalIgnoreCase));
-                }
-            }
-            SelectedCountry = country;
-            UpdateSearchText();
-        }
-    }
-
     protected override void OnLoaded(Avalonia.Interactivity.RoutedEventArgs e)
     {
         base.OnLoaded(e);
@@ -215,27 +191,6 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
             _countryListBox.PointerWheelChanged += OnCountryListBoxPointerWheelChanged;
             _countryListBox.PointerReleased += OnCountryListBoxPointerReleased;
         }
-
-        // Ensure the search text is updated when the control loads
-        // This handles cases where the property was set before the control was fully loaded
-        if (!string.IsNullOrEmpty(SelectedCountryName) && SelectedCountry == null)
-        {
-            // First try exact match
-            var country = PhoneInput.AllDialCodes.FirstOrDefault(c =>
-                c.Name.Equals(SelectedCountryName, StringComparison.OrdinalIgnoreCase));
-            // If no match, try normalizing the country name (handles USA, UK, etc.)
-            if (country == null)
-            {
-                var normalizedName = Countries.NormalizeCountry(SelectedCountryName);
-                if (normalizedName != null)
-                {
-                    country = PhoneInput.AllDialCodes.FirstOrDefault(c =>
-                        c.Name.Equals(normalizedName, StringComparison.OrdinalIgnoreCase));
-                }
-            }
-            SelectedCountry = country;
-        }
-        UpdateSearchText();
     }
 
     private void OnCountryListBoxPointerWheelChanged(object? sender, PointerWheelEventArgs e)
@@ -343,8 +298,7 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
     private void UpdateSearchText()
     {
         _isUpdatingText = true;
-        _searchText = SelectedCountry?.Name ?? string.Empty;
-        RaisePropertyChanged(nameof(SearchText));
+        SearchText = SelectedCountry?.Name ?? string.Empty;
         _isUpdatingText = false;
     }
 

--- a/ArgoBooks/Controls/CountryInput.axaml.cs
+++ b/ArgoBooks/Controls/CountryInput.axaml.cs
@@ -172,6 +172,31 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
         UpdateFilteredCountries();
     }
 
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == SelectedCountryNameProperty && !_isUpdatingText)
+        {
+            var name = change.NewValue as string ?? string.Empty;
+            // First try exact match
+            var country = PhoneInput.AllDialCodes.FirstOrDefault(c =>
+                c.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            // If no match, try normalizing the country name (handles USA, UK, etc.)
+            if (country == null && !string.IsNullOrWhiteSpace(name))
+            {
+                var normalizedName = Countries.NormalizeCountry(name);
+                if (normalizedName != null)
+                {
+                    country = PhoneInput.AllDialCodes.FirstOrDefault(c =>
+                        c.Name.Equals(normalizedName, StringComparison.OrdinalIgnoreCase));
+                }
+            }
+            SelectedCountry = country;
+            UpdateSearchText();
+        }
+    }
+
     protected override void OnLoaded(Avalonia.Interactivity.RoutedEventArgs e)
     {
         base.OnLoaded(e);

--- a/ArgoBooks/Controls/PhoneInput.axaml.cs
+++ b/ArgoBooks/Controls/PhoneInput.axaml.cs
@@ -279,6 +279,8 @@ public partial class PhoneInput : UserControl, INotifyPropertyChanged
         {
             _isUpdatingText = true;
             _formattedPhoneNumber = FormatPhoneNumber(PhoneNumber);
+            if (_phoneNumberBox != null)
+                _phoneNumberBox.Text = _formattedPhoneNumber;
             RaisePropertyChanged(nameof(FormattedPhoneNumber));
             UpdateFullPhoneNumber();
             _isUpdatingText = false;
@@ -300,6 +302,10 @@ public partial class PhoneInput : UserControl, INotifyPropertyChanged
         {
             _phoneNumberBox.TextChanged += OnPhoneNumberTextChanged;
             UpdatePhoneNumberPlaceholder();
+
+            // Sync any phone number that was set before the control loaded
+            if (!string.IsNullOrEmpty(_formattedPhoneNumber))
+                _phoneNumberBox.Text = _formattedPhoneNumber;
         }
 
         if (_countrySearchBox != null)

--- a/ArgoBooks/Modals/EditCompanyModal.axaml
+++ b/ArgoBooks/Modals/EditCompanyModal.axaml
@@ -67,7 +67,7 @@
                         </StackPanel>
 
                         <!-- Two column layout for fields -->
-                        <Grid ColumnDefinitions="*,16,*" RowDefinitions="Auto,16,Auto,16,Auto">
+                        <Grid ColumnDefinitions="*,16,*" RowDefinitions="Auto,16,Auto,16,Auto,16,Auto">
                             <!-- Business Type -->
                             <StackPanel Grid.Row="0" Grid.Column="0" Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Business Type'}"
@@ -104,17 +104,29 @@
                                                      PhoneNumber="{Binding PhoneNumber, Mode=TwoWay}" />
                             </StackPanel>
 
-                            <!-- Country -->
+                            <!-- Email -->
                             <StackPanel Grid.Row="2" Grid.Column="2" Spacing="6">
+                                <TextBlock Text="{loc:Loc Email}"
+                                           FontSize="13"
+                                           FontWeight="Medium"
+                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                                <TextBox Classes="form-input"
+                                         Text="{Binding Email, Mode=TwoWay}"
+                                         Watermark="{loc:Loc 'Enter email address'}"
+                                         MaxLength="200" />
+                            </StackPanel>
+
+                            <!-- Country -->
+                            <StackPanel Grid.Row="4" Grid.Column="0" Spacing="6">
                                 <TextBlock Text="{loc:Loc Country}"
                                            FontSize="13"
                                            FontWeight="Medium"
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <controls:CountryInput SelectedCountryName="{Binding Country, Mode=TwoWay}" />
+                                <controls:CountryInput x:Name="CountryInput" SelectedCountryName="{Binding Country, Mode=TwoWay}" />
                             </StackPanel>
 
                             <!-- City -->
-                            <StackPanel Grid.Row="4" Grid.Column="0" Spacing="6">
+                            <StackPanel Grid.Row="4" Grid.Column="2" Spacing="6">
                                 <TextBlock Text="{loc:Loc City}"
                                            FontSize="13"
                                            FontWeight="Medium"
@@ -126,7 +138,7 @@
                             </StackPanel>
 
                             <!-- Address -->
-                            <StackPanel Grid.Row="4" Grid.Column="2" Spacing="6">
+                            <StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Spacing="6">
                                 <TextBlock Text="{loc:Loc Address}"
                                            FontSize="13"
                                            FontWeight="Medium"

--- a/ArgoBooks/Modals/ReportPageSettingsModal.axaml
+++ b/ArgoBooks/Modals/ReportPageSettingsModal.axaml
@@ -140,6 +140,8 @@
                                   IsChecked="{Binding ShowFooter}" />
                         <CheckBox Content="{loc:Loc 'Show Page Numbers'}"
                                   IsChecked="{Binding ShowPageNumbers}" />
+                        <CheckBox Content="{loc:Loc 'Show Company Details'}"
+                                  IsChecked="{Binding ShowCompanyDetails}" />
                     </StackPanel>
                 </StackPanel>
             </ScrollViewer>


### PR DESCRIPTION
## Summary
This PR enhances report headers to display company branding information and adds email field support to company settings. Reports can now optionally show a professional header with company logo, name, address, phone, and email details.

## Key Changes

### Report Header Enhancement
- Added `ShowCompanyDetails` configuration option to enable/disable company details in report headers
- Implemented `RenderCompanyDetailsHeader()` method in `ReportRenderer` to render logo, company name, address, and contact information
- Created `DrawCompanyDetailsHeader()` in `SkiaReportDesignCanvas` for preview rendering with matching layout
- Dynamic header height adjustment via `PageDimensions.GetHeaderHeight()` - increases from 80px to 90px when company details are shown
- Logo support with graceful fallback if file is missing or unreadable

### Company Settings
- Added `Email` field to `EditCompanyModalViewModel` with change tracking and validation
- Updated `EditCompanyModal.axaml` UI to include email input field in the form layout
- Modified `App.axaml.cs` to pass email when opening the edit company modal
- Updated sample company data with proper phone number formatting and country information

### Configuration & Infrastructure
- Added `CompanyLogoPath` runtime property to `ReportConfiguration` (resolved from `CompanyManager`)
- Updated `ReportTemplateFactory` to enable `ShowCompanyDetails` for formal templates (Monthly Revenue, Financial Overview, Performance Analysis)
- Modified `TemplateLayoutHelper.LayoutContext` to calculate header height dynamically based on configuration
- Added translation key for "Show Company Details" option

### UI/UX Improvements
- Fixed `CountryInput` control to properly initialize selected country on load
- Enhanced `PhoneInput` formatting to update display when phone number changes programmatically
- Updated `ReportPageSettingsModal` to include checkbox for toggling company details visibility
- Ensured preview and export rendering both use company logo path from `CompanyManager`

## Implementation Details
- Company details header includes logo (40x40px) positioned left with text flowing to the right
- Address and contact information displayed in gray (#555555) for visual hierarchy
- Report title remains centered below company information
- All font sizes and spacing scale with render resolution for consistent output
- Phone number parsing improved to handle multiple dial codes and prefer country-specific matches

https://claude.ai/code/session_01KFPYVCNSc3p4tG5Kfa37VW