### PR TITLE
Multi-page element dragging and page settings undo/redo

### DIFF
--- a/ArgoBooks.Core/Models/Reports/ReportElementBase.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportElementBase.cs
@@ -150,6 +150,16 @@ public abstract class ReportElementBase : INotifyPropertyChanged
     }
 
     /// <summary>
+    /// Gets or sets bounds including page number, for undo/redo of cross-page moves.
+    /// </summary>
+    [JsonIgnore]
+    public (double X, double Y, double Width, double Height, int PageNumber) BoundsWithPage
+    {
+        get => (X, Y, Width, Height, PageNumber);
+        set { (X, Y, Width, Height) = (value.X, value.Y, value.Width, value.Height); PageNumber = value.PageNumber; }
+    }
+
+    /// <summary>
     /// Raises the PropertyChanged event.
     /// </summary>
     protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/ArgoBooks.Core/Models/Reports/TemplateLayoutHelper.cs
+++ b/ArgoBooks.Core/Models/Reports/TemplateLayoutHelper.cs
@@ -22,9 +22,24 @@ public static class TemplateLayoutHelper
         public double PageHeight { get; }
 
         /// <summary>
-        /// Margin from page edges.
+        /// Left margin from page edge.
         /// </summary>
-        public double Margin { get; } = PageDimensions.Margin;
+        public double MarginLeft { get; }
+
+        /// <summary>
+        /// Right margin from page edge.
+        /// </summary>
+        public double MarginRight { get; }
+
+        /// <summary>
+        /// Bottom margin from page edge.
+        /// </summary>
+        public double MarginBottom { get; }
+
+        /// <summary>
+        /// Left margin (alias for positioning calculations).
+        /// </summary>
+        public double Margin => MarginLeft;
 
         /// <summary>
         /// Height of the header area. Varies based on whether company details are shown.
@@ -59,12 +74,12 @@ public static class TemplateLayoutHelper
         /// <summary>
         /// Available width for content (page width minus margins).
         /// </summary>
-        public double ContentWidth => PageWidth - (Margin * 2);
+        public double ContentWidth => PageWidth - MarginLeft - MarginRight;
 
         /// <summary>
         /// Available height for content (from ContentTop to footer area).
         /// </summary>
-        public double ContentHeight => PageHeight - ContentTop - FooterHeight - Margin;
+        public double ContentHeight => PageHeight - ContentTop - FooterHeight - MarginBottom;
 
         /// <summary>
         /// Creates a layout context from a report configuration.
@@ -75,6 +90,9 @@ public static class TemplateLayoutHelper
             PageWidth = width;
             PageHeight = height;
             HeaderHeight = PageDimensions.GetHeaderHeight(config.ShowCompanyDetails);
+            MarginLeft = config.PageMargins.Left;
+            MarginRight = config.PageMargins.Right;
+            MarginBottom = config.PageMargins.Bottom;
         }
 
         /// <summary>
@@ -85,6 +103,9 @@ public static class TemplateLayoutHelper
             PageWidth = pageWidth;
             PageHeight = pageHeight;
             HeaderHeight = PageDimensions.GetHeaderHeight(showCompanyDetails);
+            MarginLeft = PageDimensions.Margin;
+            MarginRight = PageDimensions.Margin;
+            MarginBottom = PageDimensions.Margin;
         }
     }
 

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -697,10 +697,11 @@ public class ReportRenderer : IDisposable
     /// <summary>
     /// Renders a single effective page (original or continuation) to a canvas.
     /// </summary>
-    public void RenderEffectivePageToCanvas(SKCanvas canvas, EffectivePage page, int width, int height)
+    public void RenderEffectivePageToCanvas(SKCanvas canvas, EffectivePage page, int width, int height, bool skipBackground = false)
     {
         // Use DrawRect instead of Clear so stacked pages aren't wiped out
-        canvas.DrawRect(0, 0, width, height, _backgroundPaint);
+        if (!skipBackground)
+            canvas.DrawRect(0, 0, width, height, _backgroundPaint);
 
         if (_config.ShowHeader)
         {

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -718,10 +718,11 @@ public class ReportRenderer : IDisposable
             if (element != null && _continuationPlan?.CachedTableData.TryGetValue(element.Id, out var tableData) == true)
             {
                 // Position the table in the full content area
-                var margin = PageDimensions.Margin * _renderScale;
-                var contentTop = PageDimensions.HeaderHeight * _renderScale;
+                var marginLeft = (float)_config.PageMargins.Left * _renderScale;
+                var marginRight = (float)_config.PageMargins.Right * _renderScale;
+                var contentTop = PageDimensions.GetHeaderHeight(_config.ShowCompanyDetails) * _renderScale;
                 var contentBottom = height - PageDimensions.FooterHeight * _renderScale;
-                var overrideRect = new SKRect(margin, contentTop, width - margin, contentBottom);
+                var overrideRect = new SKRect(marginLeft, contentTop, width - marginRight, contentBottom);
 
                 RenderAccountingTableSlice(canvas, element, tableData,
                     page.StartRowIndex, page.RowCount, page.DataRowStartIndex,
@@ -3300,7 +3301,8 @@ public class ReportRenderer : IDisposable
     private void RenderHeader(SKCanvas canvas, int width)
     {
         var headerHeight = PageDimensions.GetHeaderHeight(_config.ShowCompanyDetails) * _renderScale;
-        var margin = (float)_config.PageMargins.Left * _renderScale;
+        var marginLeft = (float)_config.PageMargins.Left * _renderScale;
+        var marginRight = (float)_config.PageMargins.Right * _renderScale;
 
         // Draw header background
         var headerRect = new SKRect(0, 0, width, headerHeight);
@@ -3308,7 +3310,7 @@ public class ReportRenderer : IDisposable
 
         if (_config.ShowCompanyDetails && _companyData != null)
         {
-            RenderCompanyDetailsHeader(canvas, width, headerHeight, margin);
+            RenderCompanyDetailsHeader(canvas, width, headerHeight, marginLeft);
         }
         else
         {
@@ -3323,7 +3325,7 @@ public class ReportRenderer : IDisposable
             Style = SKPaintStyle.Stroke,
             StrokeWidth = 1 * _renderScale
         };
-        canvas.DrawLine(margin, headerHeight - 5 * _renderScale, width - margin, headerHeight - 5 * _renderScale, separatorPaint);
+        canvas.DrawLine(marginLeft, headerHeight - 5 * _renderScale, width - marginRight, headerHeight - 5 * _renderScale, separatorPaint);
     }
 
     private void RenderCompanyDetailsHeader(SKCanvas canvas, int width, float headerHeight, float margin)
@@ -3424,7 +3426,8 @@ public class ReportRenderer : IDisposable
     {
         var footerHeight = PageDimensions.FooterHeight * _renderScale;
         var footerY = height - footerHeight;
-        var margin = (float)_config.PageMargins.Left * _renderScale;
+        var marginLeft = (float)_config.PageMargins.Left * _renderScale;
+        var marginRight = (float)_config.PageMargins.Right * _renderScale;
 
         // Draw separator line
         var separatorPaint = new SKPaint
@@ -3433,7 +3436,7 @@ public class ReportRenderer : IDisposable
             Style = SKPaintStyle.Stroke,
             StrokeWidth = 1 * _renderScale
         };
-        canvas.DrawLine(margin, footerY + 5 * _renderScale, width - margin, footerY + 5 * _renderScale, separatorPaint);
+        canvas.DrawLine(marginLeft, footerY + 5 * _renderScale, width - marginRight, footerY + 5 * _renderScale, separatorPaint);
 
         // Draw timestamp
         using var footerFont = new SKFont(_defaultTypeface, 10 * _renderScale);
@@ -3443,7 +3446,7 @@ public class ReportRenderer : IDisposable
 
         var timeFormat = _config.Use24HourFormat ? "HH:mm" : "h:mm tt";
         var timestamp = DateTime.Now.ToString($"MMM dd, yyyy {timeFormat}");
-        canvas.DrawText($"{Tr("Generated")}: {timestamp}", margin, footerY + footerHeight / 2 + 4 * _renderScale, SKTextAlign.Left, footerFont, footerPaint);
+        canvas.DrawText($"{Tr("Generated")}: {timestamp}", marginLeft, footerY + footerHeight / 2 + 4 * _renderScale, SKTextAlign.Left, footerFont, footerPaint);
 
         // Draw page number if enabled
         if (_config.ShowPageNumbers)
@@ -3451,7 +3454,7 @@ public class ReportRenderer : IDisposable
             var pageText = _config.TotalPageCount > 1
                 ? $"{Tr("Page")} {_config.CurrentPageNumber} {Tr("of")} {_config.TotalPageCount}"
                 : $"{Tr("Page")} {_config.CurrentPageNumber}";
-            canvas.DrawText(pageText, width - margin, footerY + footerHeight / 2 + 4 * _renderScale, SKTextAlign.Right, footerFont, footerPaint);
+            canvas.DrawText(pageText, width - marginRight, footerY + footerHeight / 2 + 4 * _renderScale, SKTextAlign.Right, footerFont, footerPaint);
         }
     }
 

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -720,8 +720,8 @@ public class ReportRenderer : IDisposable
                 // Position the table in the full content area
                 var marginLeft = (float)_config.PageMargins.Left * _renderScale;
                 var marginRight = (float)_config.PageMargins.Right * _renderScale;
-                var contentTop = PageDimensions.GetHeaderHeight(_config.ShowCompanyDetails) * _renderScale;
-                var contentBottom = height - PageDimensions.FooterHeight * _renderScale;
+                var contentTop = (PageDimensions.GetHeaderHeight(_config.ShowCompanyDetails) + (float)_config.PageMargins.Top) * _renderScale;
+                var contentBottom = height - (PageDimensions.FooterHeight + (float)_config.PageMargins.Bottom) * _renderScale;
                 var overrideRect = new SKRect(marginLeft, contentTop, width - marginRight, contentBottom);
 
                 RenderAccountingTableSlice(canvas, element, tableData,

--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -411,8 +411,8 @@ public partial class SkiaReportDesignCanvas : UserControl
                 var bgColor = SKColor.Parse(Configuration.BackgroundColor);
                 canvas.DrawRect(0, 0, baseWidth, baseHeight, new SKPaint { Color = bgColor, Style = SKPaintStyle.Fill });
 
-                // Draw grid if enabled (only on template pages, not continuation)
-                if (ShowGrid && !effectivePage.IsContinuationPage)
+                // Draw grid if enabled
+                if (ShowGrid)
                 {
                     DrawGrid(canvas, baseWidth, baseHeight);
                 }
@@ -486,12 +486,14 @@ public partial class SkiaReportDesignCanvas : UserControl
         var margins = Configuration?.PageMargins;
         var left = margins?.Left ?? PageDimensions.Margin;
         var right = pageWidth - (margins?.Right ?? PageDimensions.Margin);
+        var marginTop = margins?.Top ?? PageDimensions.Margin;
+        var marginBottom = margins?.Bottom ?? PageDimensions.Margin;
         var top = (Configuration?.ShowHeader ?? false)
-            ? PageDimensions.GetHeaderHeight(Configuration?.ShowCompanyDetails ?? false)
-            : (margins?.Top ?? PageDimensions.Margin);
+            ? PageDimensions.GetHeaderHeight(Configuration?.ShowCompanyDetails ?? false) + marginTop
+            : marginTop;
         var bottom = (Configuration?.ShowFooter ?? false)
-            ? pageHeight - PageDimensions.FooterHeight
-            : pageHeight - (margins?.Bottom ?? PageDimensions.Margin);
+            ? pageHeight - PageDimensions.FooterHeight - marginBottom
+            : pageHeight - marginBottom;
         return (left, top, right, bottom);
     }
 

--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -407,15 +407,19 @@ public partial class SkiaReportDesignCanvas : UserControl
                 canvas.Save();
                 canvas.Translate(0, pageYOffset);
 
-                // RenderEffectivePageToCanvas handles background/header/footer/elements internally
-                Configuration.CurrentPageNumber = effectivePage.EffectivePageNumber;
-                renderer.RenderEffectivePageToCanvas(canvas, effectivePage, baseWidth, baseHeight);
+                // Draw page background
+                var bgColor = SKColor.Parse(Configuration.BackgroundColor);
+                canvas.DrawRect(0, 0, baseWidth, baseHeight, new SKPaint { Color = bgColor, Style = SKPaintStyle.Fill });
 
-                // Draw grid overlay after content (only on template pages, not continuation)
+                // Draw grid if enabled (only on template pages, not continuation)
                 if (ShowGrid && !effectivePage.IsContinuationPage)
                 {
                     DrawGrid(canvas, baseWidth, baseHeight);
                 }
+
+                // Render content (skip background since we already drew it above)
+                Configuration.CurrentPageNumber = effectivePage.EffectivePageNumber;
+                renderer.RenderEffectivePageToCanvas(canvas, effectivePage, baseWidth, baseHeight, skipBackground: true);
 
                 canvas.Restore();
             }
@@ -434,6 +438,12 @@ public partial class SkiaReportDesignCanvas : UserControl
                 var bgColor = SKColor.Parse(Configuration.BackgroundColor);
                 canvas.DrawRect(0, 0, baseWidth, baseHeight, new SKPaint { Color = bgColor, Style = SKPaintStyle.Fill });
 
+                // Draw grid if enabled
+                if (ShowGrid)
+                {
+                    DrawGrid(canvas, baseWidth, baseHeight);
+                }
+
                 // Draw header/footer
                 if (Configuration.ShowHeader)
                 {
@@ -446,12 +456,6 @@ public partial class SkiaReportDesignCanvas : UserControl
 
                 // Render elements for this page
                 renderer.RenderElementsToCanvas(canvas, page);
-
-                // Draw grid overlay after content
-                if (ShowGrid)
-                {
-                    DrawGrid(canvas, baseWidth, baseHeight);
-                }
 
                 canvas.Restore();
             }

--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -1872,7 +1872,7 @@ public partial class SkiaReportDesignCanvas : UserControl
         if (_isScrollingToPage || _scrollViewer == null) return;
 
         // Determine which page is at the center of the viewport
-        var (page, _) = GetViewportCenterOnPage();
+        var (page, _, _) = GetViewportCenterOnPage();
         if (page > 0 && page != CurrentDesignerPage)
         {
             _isScrollingToPage = true; // Prevent feedback loop

--- a/ArgoBooks/Services/ReportUndoRedoManager.cs
+++ b/ArgoBooks/Services/ReportUndoRedoManager.cs
@@ -464,17 +464,17 @@ public class ElementPropertyChangeAction(
 }
 
 /// <summary>
-/// Action for batch operations (alignment, distribution, sizing).
+/// Action for batch operations (alignment, distribution, sizing, cross-page moves).
 /// </summary>
 public class BatchMoveResizeAction(
     ReportConfiguration config,
-    Dictionary<string, (double X, double Y, double Width, double Height)> oldBounds,
-    Dictionary<string, (double X, double Y, double Width, double Height)> newBounds,
+    Dictionary<string, (double X, double Y, double Width, double Height, int PageNumber)> oldBounds,
+    Dictionary<string, (double X, double Y, double Width, double Height, int PageNumber)> newBounds,
     string description)
     : IReportUndoableAction
 {
-    private readonly Dictionary<string, (double X, double Y, double Width, double Height)> _oldBounds = new(oldBounds);
-    private readonly Dictionary<string, (double X, double Y, double Width, double Height)> _newBounds = new(newBounds);
+    private readonly Dictionary<string, (double X, double Y, double Width, double Height, int PageNumber)> _oldBounds = new(oldBounds);
+    private readonly Dictionary<string, (double X, double Y, double Width, double Height, int PageNumber)> _newBounds = new(newBounds);
 
     public string Description { get; } = description;
 
@@ -483,7 +483,8 @@ public class BatchMoveResizeAction(
         foreach (var kvp in _oldBounds)
         {
             var element = config.GetElementById(kvp.Key);
-            element?.Bounds = kvp.Value;
+            if (element == null) continue;
+            element.BoundsWithPage = kvp.Value;
         }
     }
 
@@ -492,7 +493,8 @@ public class BatchMoveResizeAction(
         foreach (var kvp in _newBounds)
         {
             var element = config.GetElementById(kvp.Key);
-            element?.Bounds = kvp.Value;
+            if (element == null) continue;
+            element.BoundsWithPage = kvp.Value;
         }
     }
 }

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -1971,6 +1971,18 @@ public partial class ReportsPageViewModel : ViewModelBase
     [RelayCommand]
     private void ApplyPageSettings()
     {
+        var oldSettings = new PageSettingsSnapshot(
+            _originalPageSize, _originalPageOrientation,
+            _originalMarginTop, _originalMarginRight, _originalMarginBottom, _originalMarginLeft,
+            _originalShowHeader, _originalShowFooter, _originalShowPageNumbers, _originalShowCompanyDetails,
+            _originalBackgroundColor, _originalTitleFontSize, _originalPageSettingsDatePreset);
+
+        var newSettings = new PageSettingsSnapshot(
+            PageSize, PageOrientation,
+            MarginTop, MarginRight, MarginBottom, MarginLeft,
+            ShowHeader, ShowFooter, ShowPageNumbers, ShowCompanyDetails,
+            BackgroundColor, TitleFontSize, PageSettingsDatePreset);
+
         Configuration.PageSize = PageSize;
         Configuration.PageOrientation = PageOrientation;
         Configuration.PageMargins = new ReportMargins(MarginLeft, MarginTop, MarginRight, MarginBottom);
@@ -1989,10 +2001,43 @@ public partial class ReportsPageViewModel : ViewModelBase
             option.IsSelected = option.Name == PageSettingsDatePreset;
         }
 
+        if (oldSettings != newSettings)
+        {
+            UndoRedoManager.RecordAction(new PageSettingsChangeAction(
+                Configuration, oldSettings, newSettings, ApplyPageSettingsSnapshot));
+        }
+
         UpdateCanvasDimensions();
         IsPageSettingsOpen = false;
 
         // Refresh the canvas after modal closes
+        PageSettingsRefreshRequested?.Invoke(this, EventArgs.Empty);
+        OnPropertyChanged(nameof(Configuration));
+    }
+
+    private void ApplyPageSettingsSnapshot(PageSettingsSnapshot s)
+    {
+        PageSize = s.PageSize;
+        PageOrientation = s.PageOrientation;
+        MarginTop = s.MarginTop;
+        MarginRight = s.MarginRight;
+        MarginBottom = s.MarginBottom;
+        MarginLeft = s.MarginLeft;
+        ShowHeader = s.ShowHeader;
+        ShowFooter = s.ShowFooter;
+        ShowPageNumbers = s.ShowPageNumbers;
+        ShowCompanyDetails = s.ShowCompanyDetails;
+        BackgroundColor = s.BackgroundColor;
+        TitleFontSize = s.TitleFontSize;
+        PageSettingsDatePreset = s.DatePreset;
+
+        SelectedDatePreset = s.DatePreset;
+        foreach (var option in DatePresets)
+        {
+            option.IsSelected = option.Name == s.DatePreset;
+        }
+
+        UpdateCanvasDimensions();
         PageSettingsRefreshRequested?.Invoke(this, EventArgs.Empty);
         OnPropertyChanged(nameof(Configuration));
     }

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -1123,7 +1123,7 @@ public partial class ReportsPageViewModel : ViewModelBase
     {
         if (SelectedElements.Count == 0) return;
 
-        var oldBounds = SelectedElements.ToDictionary(e => e.Id, e => e.Bounds);
+        var oldBounds = SelectedElements.ToDictionary(e => e.Id, e => e.BoundsWithPage);
 
         if (SelectedElements.Count == 1)
         {
@@ -1181,7 +1181,7 @@ public partial class ReportsPageViewModel : ViewModelBase
             }
         }
 
-        var newBounds = SelectedElements.ToDictionary(e => e.Id, e => e.Bounds);
+        var newBounds = SelectedElements.ToDictionary(e => e.Id, e => e.BoundsWithPage);
         UndoRedoManager.RecordAction(new BatchMoveResizeAction(Configuration, oldBounds, newBounds, "Align {0}".TranslateFormat(alignment)));
         OnPropertyChanged(nameof(Configuration));
     }
@@ -1191,7 +1191,7 @@ public partial class ReportsPageViewModel : ViewModelBase
     {
         if (SelectedElements.Count < 3) return;
 
-        var oldBounds = SelectedElements.ToDictionary(e => e.Id, e => e.Bounds);
+        var oldBounds = SelectedElements.ToDictionary(e => e.Id, e => e.BoundsWithPage);
 
         var sorted = direction == DistributeDirection.Horizontal
             ? SelectedElements.OrderBy(e => e.X).ToList()
@@ -1226,7 +1226,7 @@ public partial class ReportsPageViewModel : ViewModelBase
             }
         }
 
-        var newBounds = SelectedElements.ToDictionary(e => e.Id, e => e.Bounds);
+        var newBounds = SelectedElements.ToDictionary(e => e.Id, e => e.BoundsWithPage);
         UndoRedoManager.RecordAction(new BatchMoveResizeAction(Configuration, oldBounds, newBounds, "Distribute {0}".TranslateFormat(direction.ToString())));
         OnPropertyChanged(nameof(Configuration));
     }
@@ -1236,7 +1236,7 @@ public partial class ReportsPageViewModel : ViewModelBase
     {
         if (SelectedElements.Count < 2) return;
 
-        var oldBounds = SelectedElements.ToDictionary(e => e.Id, e => e.Bounds);
+        var oldBounds = SelectedElements.ToDictionary(e => e.Id, e => e.BoundsWithPage);
         var reference = SelectedElements[0];
 
         foreach (var element in SelectedElements.Skip(1))
@@ -1256,7 +1256,7 @@ public partial class ReportsPageViewModel : ViewModelBase
             }
         }
 
-        var newBounds = SelectedElements.ToDictionary(e => e.Id, e => e.Bounds);
+        var newBounds = SelectedElements.ToDictionary(e => e.Id, e => e.BoundsWithPage);
         UndoRedoManager.RecordAction(new BatchMoveResizeAction(Configuration, oldBounds, newBounds, "Match {0}".TranslateFormat(mode.ToString())));
         OnPropertyChanged(nameof(Configuration));
     }

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -932,15 +932,22 @@ public partial class ReportsPageViewModel : ViewModelBase
     [RelayCommand]
     private void AddElement(ReportElementType elementType)
     {
+        var margins = Configuration.PageMargins;
+        var headerHeight = Configuration.ShowHeader
+            ? PageDimensions.GetHeaderHeight(Configuration.ShowCompanyDetails)
+            : 0;
+        var defaultX = margins.Left;
+        var defaultY = headerHeight + margins.Top;
+
         ReportElementBase element = elementType switch
         {
-            ReportElementType.Chart => new ChartReportElement { X = 100, Y = 150, Width = 300, Height = 200 },
-            ReportElementType.Table => new TableReportElement { X = 100, Y = 150, Width = 400, Height = 200 },
-            ReportElementType.Label => new LabelReportElement { X = 100, Y = 150, Width = 200, Height = 40 },
-            ReportElementType.Image => new ImageReportElement { X = 100, Y = 150, Width = 150, Height = 150 },
-            ReportElementType.DateRange => new DateRangeReportElement { X = 100, Y = 150, Width = 200, Height = 30 },
-            ReportElementType.Summary => new SummaryReportElement { X = 100, Y = 150, Width = 200, Height = 120 },
-            ReportElementType.AccountingTable => new AccountingTableReportElement { X = 100, Y = 150, Width = 500, Height = 600 },
+            ReportElementType.Chart => new ChartReportElement { X = defaultX, Y = defaultY, Width = 300, Height = 200 },
+            ReportElementType.Table => new TableReportElement { X = defaultX, Y = defaultY, Width = 400, Height = 200 },
+            ReportElementType.Label => new LabelReportElement { X = defaultX, Y = defaultY, Width = 200, Height = 40 },
+            ReportElementType.Image => new ImageReportElement { X = defaultX, Y = defaultY, Width = 150, Height = 150 },
+            ReportElementType.DateRange => new DateRangeReportElement { X = defaultX, Y = defaultY, Width = 200, Height = 30 },
+            ReportElementType.Summary => new SummaryReportElement { X = defaultX, Y = defaultY, Width = 200, Height = 120 },
+            ReportElementType.AccountingTable => new AccountingTableReportElement { X = defaultX, Y = defaultY, Width = 500, Height = 600 },
             _ => new LabelReportElement()
         };
 

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -2714,14 +2714,16 @@ public partial class ReportsPageViewModel : ViewModelBase
 
         // Calculate layout for charts using a grid layout
         var (pageWidth, pageHeight) = PageDimensions.GetDimensions(Configuration.PageSize, Configuration.PageOrientation);
-        const double margin = PageDimensions.Margin;
+        var marginLeft = Configuration.PageMargins.Left;
+        var marginRight = Configuration.PageMargins.Right;
+        var marginBottom = Configuration.PageMargins.Bottom;
         double headerHeight = PageDimensions.GetHeaderHeight(Configuration.ShowCompanyDetails);
         const double footerHeight = PageDimensions.FooterHeight;
         const double spacing = 10;
 
-        var contentWidth = pageWidth - (margin * 2);
-        var contentHeight = pageHeight - headerHeight - footerHeight - (margin * 2);
-        var startY = headerHeight + margin;
+        var contentWidth = pageWidth - marginLeft - marginRight;
+        var contentHeight = pageHeight - headerHeight - footerHeight - marginBottom;
+        var startY = headerHeight;
 
         // Determine grid dimensions based on number of charts
         var chartCount = chartElements.Count;
@@ -2737,7 +2739,7 @@ public partial class ReportsPageViewModel : ViewModelBase
             int row = i / columns;
             int col = i % columns;
 
-            chartElements[i].X = margin + (col * (cellWidth + spacing));
+            chartElements[i].X = marginLeft + (col * (cellWidth + spacing));
             chartElements[i].Y = startY + (row * (cellHeight + spacing));
             chartElements[i].Width = cellWidth;
             chartElements[i].Height = cellHeight;

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -941,7 +941,7 @@
                                                         ShowGrid="{Binding ShowGrid}"
                                                         GridSize="{Binding GridSize}"
                                                         SnapToGrid="{Binding SnapToGrid}"
-                                                        CurrentDesignerPage="{Binding CurrentDesignerPage}"
+                                                        CurrentDesignerPage="{Binding CurrentDesignerPage, Mode=TwoWay}"
                                                         UndoRedoManager="{Binding UndoRedoManager}" />
 
                         <!-- Save Confirmation Overlay -->

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -732,20 +732,20 @@
                                     <TextBlock Text="{loc:Loc 'Summary'}" VerticalAlignment="Center" />
                                 </StackPanel>
                             </Button>
-                            <Button Classes="toolbox-button" Command="{Binding AddElementCommand}" CommandParameter="{x:Static enums:ReportElementType.Table}" ToolTip.Tip="{loc:Loc 'Add Table'}">
-                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <PathIcon Data="{x:Static icons:Icons.Grid2x2}"
-                                              Width="18" Height="18"
-                                              Foreground="{DynamicResource PrimaryBrush}" />
-                                    <TextBlock Text="{loc:Loc 'Table'}" VerticalAlignment="Center" />
-                                </StackPanel>
-                            </Button>
                             <Button Classes="toolbox-button" Command="{Binding AddElementCommand}" CommandParameter="{x:Static enums:ReportElementType.Image}" ToolTip.Tip="{loc:Loc 'Add Image'}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <PathIcon Data="{x:Static icons:Icons.Image}"
                                               Width="18" Height="18"
                                               Foreground="{DynamicResource PrimaryBrush}" />
                                     <TextBlock Text="{loc:Loc 'Image'}" VerticalAlignment="Center" />
+                                </StackPanel>
+                            </Button>
+                            <Button Classes="toolbox-button" Command="{Binding AddElementCommand}" CommandParameter="{x:Static enums:ReportElementType.Table}" ToolTip.Tip="{loc:Loc 'Add Table'}">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <PathIcon Data="{x:Static icons:Icons.Grid2x2}"
+                                              Width="18" Height="18"
+                                              Foreground="{DynamicResource PrimaryBrush}" />
+                                    <TextBlock Text="{loc:Loc 'Table'}" VerticalAlignment="Center" />
                                 </StackPanel>
                             </Button>
                             <Button Classes="toolbox-button" Command="{Binding AddElementCommand}" CommandParameter="{x:Static enums:ReportElementType.AccountingTable}" ToolTip.Tip="{loc:Loc 'Add Accounting Table'}">
@@ -785,13 +785,13 @@
                                           Width="18" Height="18"
                                           Foreground="{DynamicResource PrimaryBrush}" />
                             </Button>
-                            <Button Classes="icon-button" Margin="4,6,0,6" Width="32" Height="32" Command="{Binding AddElementCommand}" CommandParameter="{x:Static enums:ReportElementType.Table}" ToolTip.Tip="{loc:Loc 'Add Table'}">
-                                <PathIcon Data="{x:Static icons:Icons.Grid2x2}"
+                            <Button Classes="icon-button" Margin="4,6,0,6" Width="32" Height="32" Command="{Binding AddElementCommand}" CommandParameter="{x:Static enums:ReportElementType.Image}" ToolTip.Tip="{loc:Loc 'Add Image'}">
+                                <PathIcon Data="{x:Static icons:Icons.Image}"
                                           Width="18" Height="18"
                                           Foreground="{DynamicResource PrimaryBrush}" />
                             </Button>
-                            <Button Classes="icon-button" Margin="4,6,0,6" Width="32" Height="32" Command="{Binding AddElementCommand}" CommandParameter="{x:Static enums:ReportElementType.Image}" ToolTip.Tip="{loc:Loc 'Add Image'}">
-                                <PathIcon Data="{x:Static icons:Icons.Image}"
+                            <Button Classes="icon-button" Margin="4,6,0,6" Width="32" Height="32" Command="{Binding AddElementCommand}" CommandParameter="{x:Static enums:ReportElementType.Table}" ToolTip.Tip="{loc:Loc 'Add Table'}">
+                                <PathIcon Data="{x:Static icons:Icons.Grid2x2}"
                                           Width="18" Height="18"
                                           Foreground="{DynamicResource PrimaryBrush}" />
                             </Button>

--- a/ArgoBooks/Views/ReportsPage.axaml.cs
+++ b/ArgoBooks/Views/ReportsPage.axaml.cs
@@ -79,6 +79,10 @@ public partial class ReportsPage : UserControl
             _designCanvas.PointerReleased += OnCanvasPointerReleased;
             _designCanvas.SelectionChanged += OnCanvasSelectionChanged;
             _designCanvas.ContextMenuRequested += OnCanvasContextMenuRequested;
+
+            // Provide viewport center callback to ViewModel for element placement
+            if (DataContext is ReportsPageViewModel vm)
+                vm.GetViewportCenter = _designCanvas.GetViewportCenterOnPage;
         }
 
         // Wire up keyboard shortcuts
@@ -106,6 +110,10 @@ public partial class ReportsPage : UserControl
             vm.TemplateLoaded += OnTemplateLoaded;
             vm.PreviewFitToWindowRequested += OnPreviewFitToWindowRequested;
             vm.CanvasRefreshRequested += OnCanvasRefreshRequested;
+
+            // Ensure viewport center callback is wired (may have missed it if DataContext wasn't ready earlier)
+            if (_designCanvas != null)
+                vm.GetViewportCenter = _designCanvas.GetViewportCenterOnPage;
 
             // Subscribe to UndoRedoManager state changes to update asterisk visibility
             vm.UndoRedoManager.StateChanged += OnUndoRedoStateChanged;

--- a/ArgoBooks/Views/ReportsPage.axaml.cs
+++ b/ArgoBooks/Views/ReportsPage.axaml.cs
@@ -81,8 +81,8 @@ public partial class ReportsPage : UserControl
             _designCanvas.ContextMenuRequested += OnCanvasContextMenuRequested;
 
             // Provide viewport center callback to ViewModel for element placement
-            if (DataContext is ReportsPageViewModel vm)
-                vm.GetViewportCenter = _designCanvas.GetViewportCenterOnPage;
+            if (DataContext is ReportsPageViewModel vm2)
+                vm2.GetViewportCenter = _designCanvas.GetViewportCenterOnPage;
         }
 
         // Wire up keyboard shortcuts


### PR DESCRIPTION
## Summary
This PR enhances the report designer with support for dragging elements across multiple pages and adds comprehensive undo/redo support for page settings changes. It also improves grid alignment, content bounds handling, and element placement logic.

## Key Changes

### Multi-Page Element Dragging
- Elements can now be dragged across page boundaries; the element automatically transfers to the page where the cursor is located
- Added `_dragOriginalBounds` dictionary to track original element state (including page number) for accurate undo/redo
- Updated `_multiDragStartBounds` to include `PageNumber` field
- Implemented page detection logic in `HandleDrag()` that determines which page the cursor is over, including handling of gaps between pages
- When an element transfers pages, its position is adjusted to the top or bottom of the content area depending on drag direction, then rebased for smooth continued dragging

### Grid and Content Bounds
- Added `GetContentBounds()` method that calculates the actual content area (inside margins, between header/footer)
- Grid is now drawn only within the content bounds, aligned to the content area origin
- Grid snapping during drag and resize operations now aligns to the content area origin instead of page origin
- Header and footer separator lines now respect page margins instead of using hardcoded values

### Element Placement
- New elements are now placed at the center of the user's current viewport instead of a fixed position
- Added `GetViewportCenterOnPage()` method to determine which page and position is at the center of the visible area
- Added `OnScrollChanged()` handler to update `CurrentDesignerPage` as the user scrolls
- Added `_isScrollingToPage` flag to prevent feedback loops when programmatically scrolling

### Page Settings Undo/Redo
- Created `PageSettingsSnapshot` record to capture all page settings state
- Added `PageSettingsChangeAction` class to enable undo/redo for page settings changes
- Page settings changes now record a complete snapshot for proper restoration
- Added `ApplyPageSettingsSnapshot()` method to restore settings from a snapshot

### Element Bounds Tracking
- Added `BoundsWithPage` property to `ReportElementBase` for tracking bounds including page number
- Updated `BatchMoveResizeAction` to include `PageNumber` in old/new bounds tuples
- Alignment, distribution, and sizing operations now preserve page numbers during undo/redo

### Other Improvements
- Fixed element deletion to use undo/redo manager instead of direct removal
- Updated `RenderEffectivePageToCanvas()` to support skipping background rendering when pages are stacked
- Improved margin handling throughout rendering code to use actual configured margins
- Swapped Image and Table buttons in the toolbox UI for better logical ordering
- Added scroll change event handler registration/cleanup in `OnLoaded()`/`OnUnloaded()`

## Implementation Details
- Grid snapping formula changed from `Math.Round(value / GridSize) * GridSize` to `contentOrigin + Math.Round((value - contentOrigin) / GridSize) * GridSize` to align with content area
- Page transfer detection uses gap midpoint calculation to determine which page is closer when cursor is in a gap
- Viewport center calculation accounts for scroll viewer centering offset and zoom level
- Element placement clamps to content bounds to prevent elements from being placed outside valid areas

https://claude.ai/code/session_01MDuYfz4GGYVNcDLazwPe61