### PR TITLE
Refactor accounting reports to use pre-tax amounts and improve structure

### DIFF
--- a/ArgoBooks.Core/Models/Reports/ReportTemplateFactory.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportTemplateFactory.cs
@@ -824,15 +824,23 @@ public static class ReportTemplateFactory
 
         var context = new LayoutContext(config);
 
-        // Date range element at the top
-        var dateRangeBounds = GetDateRangeBounds(context);
-        config.AddElement(new DateRangeReportElement
+        // Skip period date range for point-in-time reports (aging reports) since
+        // they show "As of [date]" in the table subtitle and don't filter by period.
+        var isPointInTime = reportType == AccountingReportType.AccountsReceivableAging
+                            || reportType == AccountingReportType.AccountsPayableAging;
+
+        if (!isPointInTime)
         {
-            X = dateRangeBounds.X,
-            Y = dateRangeBounds.Y,
-            Width = dateRangeBounds.Width,
-            Height = dateRangeBounds.Height
-        });
+            // Date range element at the top
+            var dateRangeBounds = GetDateRangeBounds(context);
+            config.AddElement(new DateRangeReportElement
+            {
+                X = dateRangeBounds.X,
+                Y = dateRangeBounds.Y,
+                Width = dateRangeBounds.Width,
+                Height = dateRangeBounds.Height
+            });
+        }
 
         // Accounting table filling the content area
         config.AddElement(new AccountingTableReportElement

--- a/ArgoBooks.Core/Models/Transactions/Transaction.cs
+++ b/ArgoBooks.Core/Models/Transactions/Transaction.cs
@@ -182,6 +182,13 @@ public abstract class Transaction
     public decimal EffectiveTotalUSD => TotalUSD > 0 ? TotalUSD : Total;
 
     /// <summary>
+    /// Gets the effective pre-tax subtotal in USD (excludes tax).
+    /// Tax is a liability, not revenue/expense, so this matches Income Statement treatment.
+    /// </summary>
+    [JsonIgnore]
+    public decimal EffectiveSubtotalUSD => EffectiveTotalUSD - (TaxAmountUSD > 0 ? TaxAmountUSD : TaxAmount);
+
+    /// <summary>
     /// Gets the effective unit price in USD, falling back to UnitPrice for legacy data.
     /// </summary>
     [JsonIgnore]

--- a/ArgoBooks.Core/Services/ForecastAccuracyService.cs
+++ b/ArgoBooks.Core/Services/ForecastAccuracyService.cs
@@ -65,11 +65,11 @@ public class ForecastAccuracyService : IForecastAccuracyService
             // Calculate actual values for the forecast period
             var actualRevenue = companyData.Revenues
                 .Where(s => s.Date >= record.PeriodStartDate && s.Date <= record.PeriodEndDate)
-                .Sum(s => s.EffectiveTotalUSD);
+                .Sum(s => s.EffectiveSubtotalUSD);
 
             var actualExpenses = companyData.Expenses
                 .Where(p => p.Date >= record.PeriodStartDate && p.Date <= record.PeriodEndDate)
-                .Sum(p => p.EffectiveTotalUSD);
+                .Sum(p => p.EffectiveSubtotalUSD);
 
             var actualProfit = actualRevenue - actualExpenses;
 
@@ -326,12 +326,12 @@ public class ForecastAccuracyService : IForecastAccuracyService
         // Aggregate sales by month
         var salesByMonth = companyData.Revenues
             .GroupBy(s => new DateTime(s.Date.Year, s.Date.Month, 1))
-            .ToDictionary(g => g.Key, g => g.Sum(s => s.EffectiveTotalUSD));
+            .ToDictionary(g => g.Key, g => g.Sum(s => s.EffectiveSubtotalUSD));
 
         // Aggregate purchases by month
         var purchasesByMonth = companyData.Expenses
             .GroupBy(p => new DateTime(p.Date.Year, p.Date.Month, 1))
-            .ToDictionary(g => g.Key, g => g.Sum(p => p.EffectiveTotalUSD));
+            .ToDictionary(g => g.Key, g => g.Sum(p => p.EffectiveSubtotalUSD));
 
         // Get all months with any data
         var allMonths = salesByMonth.Keys

--- a/ArgoBooks.Core/Services/ReportChartDataService.cs
+++ b/ArgoBooks.Core/Services/ReportChartDataService.cs
@@ -58,7 +58,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             .Select(g => new ChartDataPoint
             {
                 Label = g.Key.ToString("MMM dd"),
-                Value = (double)g.Sum(s => s.EffectiveTotalUSD),
+                Value = (double)g.Sum(s => s.EffectiveSubtotalUSD),
                 Date = g.Key
             })
             .ToList();
@@ -90,7 +90,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
                 return new ChartDataPoint
                 {
                     Label = categoryName,
-                    Value = (double)g.Sum(s => s.EffectiveTotalUSD)
+                    Value = (double)g.Sum(s => s.EffectiveSubtotalUSD)
                 };
             })
             .OrderByDescending(p => p.Value)
@@ -110,7 +110,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
 
         return companyData.Revenues
             .Where(s => s.Date >= startDate && s.Date <= endDate)
-            .Sum(s => s.EffectiveTotalUSD);
+            .Sum(s => s.EffectiveSubtotalUSD);
     }
 
     #endregion
@@ -134,7 +134,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             .Select(g => new ChartDataPoint
             {
                 Label = g.Key.ToString("MMM dd"),
-                Value = (double)g.Sum(p => p.EffectiveTotalUSD),
+                Value = (double)g.Sum(p => p.EffectiveSubtotalUSD),
                 Date = g.Key
             })
             .ToList();
@@ -164,7 +164,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
                 return new ChartDataPoint
                 {
                     Label = categoryName,
-                    Value = (double)g.Sum(p => p.EffectiveTotalUSD)
+                    Value = (double)g.Sum(p => p.EffectiveSubtotalUSD)
                 };
             })
             .OrderByDescending(p => p.Value)
@@ -184,7 +184,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
 
         return companyData.Expenses
             .Where(p => p.Date >= startDate && p.Date <= endDate)
-            .Sum(p => p.EffectiveTotalUSD);
+            .Sum(p => p.EffectiveSubtotalUSD);
     }
 
     #endregion
@@ -204,12 +204,12 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
         var revenueByDate = companyData.Revenues
             .Where(s => s.Date >= startDate && s.Date <= endDate)
             .GroupBy(s => s.Date.Date)
-            .ToDictionary(g => g.Key, g => g.Sum(s => s.EffectiveTotalUSD));
+            .ToDictionary(g => g.Key, g => g.Sum(s => s.EffectiveSubtotalUSD));
 
         var expensesByDate = companyData.Expenses
             .Where(p => p.Date >= startDate && p.Date <= endDate)
             .GroupBy(p => p.Date.Date)
-            .ToDictionary(g => g.Key, g => g.Sum(p => p.EffectiveTotalUSD));
+            .ToDictionary(g => g.Key, g => g.Sum(p => p.EffectiveSubtotalUSD));
 
         var allDates = revenueByDate.Keys.Union(expensesByDate.Keys).OrderBy(d => d);
 
@@ -256,7 +256,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
                 Label = month.ToString("MMM yyyy"),
                 Value = (double)companyData.Revenues
                     .Where(s => s.Date >= monthStart && s.Date <= monthEnd)
-                    .Sum(s => s.EffectiveTotalUSD),
+                    .Sum(s => s.EffectiveSubtotalUSD),
                 Date = month
             };
         }).ToList();
@@ -271,7 +271,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
                 Label = month.ToString("MMM yyyy"),
                 Value = (double)companyData.Expenses
                     .Where(p => p.Date >= monthStart && p.Date <= monthEnd)
-                    .Sum(p => p.EffectiveTotalUSD),
+                    .Sum(p => p.EffectiveSubtotalUSD),
                 Date = month
             };
         }).ToList();
@@ -297,12 +297,12 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
         var salesByDate = companyData.Revenues
             .Where(s => s.Date >= startDate && s.Date <= endDate)
             .GroupBy(s => s.Date.Date)
-            .ToDictionary(g => g.Key, g => (double)g.Sum(s => s.EffectiveTotalUSD));
+            .ToDictionary(g => g.Key, g => (double)g.Sum(s => s.EffectiveSubtotalUSD));
 
         var purchasesByDate = companyData.Expenses
             .Where(p => p.Date >= startDate && p.Date <= endDate)
             .GroupBy(p => p.Date.Date)
-            .ToDictionary(g => g.Key, g => (double)g.Sum(p => p.EffectiveTotalUSD));
+            .ToDictionary(g => g.Key, g => (double)g.Sum(p => p.EffectiveSubtotalUSD));
 
         // Combine all dates
         var allDates = salesByDate.Keys.Union(purchasesByDate.Keys).OrderBy(d => d).ToList();
@@ -369,7 +369,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
 
             var transactions = companyData.Revenues
                 .Where(s => s.Date >= monthStart && s.Date <= monthEnd)
-                .Select(s => s.EffectiveTotalUSD)
+                .Select(s => s.EffectiveSubtotalUSD)
                 .ToList();
 
             return new ChartDataPoint
@@ -387,7 +387,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
 
             var transactions = companyData.Expenses
                 .Where(p => p.Date >= monthStart && p.Date <= monthEnd)
-                .Select(p => p.EffectiveTotalUSD)
+                .Select(p => p.EffectiveSubtotalUSD)
                 .ToList();
 
             return new ChartDataPoint
@@ -483,7 +483,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             var date = revenue.Date.Date;
             if (!revenueValuesByDate.ContainsKey(date))
                 revenueValuesByDate[date] = [];
-            revenueValuesByDate[date].Add(revenue.EffectiveTotalUSD);
+            revenueValuesByDate[date].Add(revenue.EffectiveSubtotalUSD);
         }
 
         foreach (var expense in companyData.Expenses.Where(p => p.Date >= startDate && p.Date <= endDate))
@@ -491,7 +491,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             var date = expense.Date.Date;
             if (!expenseValuesByDate.ContainsKey(date))
                 expenseValuesByDate[date] = [];
-            expenseValuesByDate[date].Add(expense.EffectiveTotalUSD);
+            expenseValuesByDate[date].Add(expense.EffectiveSubtotalUSD);
         }
 
         // Combine all dates
@@ -606,7 +606,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             .Select(g => new ChartDataPoint
             {
                 Label = g.Key,
-                Value = (double)g.Sum(s => s.EffectiveTotalUSD)
+                Value = (double)g.Sum(s => s.EffectiveSubtotalUSD)
             })
             // Filter out "Unknown" entries with zero or negligible value
             .Where(p => p.Label != "Unknown" || p.Value > 0.01)
@@ -634,7 +634,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
                 return customer?.Address.Country;
             })
             .Where(g => g.Key != null)
-            .ToDictionary(g => g.Key!, g => (double)g.Sum(s => s.EffectiveTotalUSD));
+            .ToDictionary(g => g.Key!, g => (double)g.Sum(s => s.EffectiveSubtotalUSD));
     }
 
     /// <summary>
@@ -656,7 +656,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
                 return supplier?.Address.Country;
             })
             .Where(g => g.Key != null && !string.IsNullOrEmpty(g.Key))
-            .ToDictionary(g => g.Key!, g => (double)g.Sum(p => p.EffectiveTotalUSD));
+            .ToDictionary(g => g.Key!, g => (double)g.Sum(p => p.EffectiveSubtotalUSD));
     }
 
     /// <summary>
@@ -679,7 +679,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             .Select(g => new ChartDataPoint
             {
                 Label = g.Key,
-                Value = (double)g.Sum(p => p.EffectiveTotalUSD)
+                Value = (double)g.Sum(p => p.EffectiveSubtotalUSD)
             })
             .OrderByDescending(p => p.Value)
             .Take(10)
@@ -703,7 +703,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             .Select(g => new ChartDataPoint
             {
                 Label = g.Key,
-                Value = (double)g.Sum(p => p.EffectiveTotalUSD)
+                Value = (double)g.Sum(p => p.EffectiveSubtotalUSD)
             })
             .OrderByDescending(p => p.Value)
             .Take(10)
@@ -726,7 +726,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             .Select(g => new ChartDataPoint
             {
                 Label = g.Key,
-                Value = (double)g.Sum(s => s.EffectiveTotalUSD)
+                Value = (double)g.Sum(s => s.EffectiveSubtotalUSD)
             })
             .OrderByDescending(p => p.Value)
             .Take(10)
@@ -752,7 +752,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             .Select(g => new ChartDataPoint
             {
                 Label = g.Key!,
-                Value = (double)g.Sum(x => x.Revenue.EffectiveTotalUSD)
+                Value = (double)g.Sum(x => x.Revenue.EffectiveSubtotalUSD)
             })
             .OrderByDescending(p => p.Value)
             .Take(10)
@@ -908,7 +908,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
                 return new ChartDataPoint
                 {
                     Label = customerName,
-                    Value = (double)g.Sum(s => s.Total)
+                    Value = (double)g.Sum(s => s.EffectiveSubtotalUSD)
                 };
             })
             .OrderByDescending(p => p.Value)
@@ -991,7 +991,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
             .Select(g => new
             {
                 CustomerId = g.Key,
-                TotalRevenue = g.Sum(s => s.Total)
+                TotalRevenue = g.Sum(s => s.EffectiveSubtotalUSD)
             })
             .ToList();
 

--- a/ArgoBooks/Modals/CreateCompanyWizard.axaml
+++ b/ArgoBooks/Modals/CreateCompanyWizard.axaml
@@ -158,10 +158,11 @@
 
                                 <!-- Country -->
                                 <StackPanel Grid.Row="2" Grid.Column="2" Spacing="6">
-                                    <TextBlock Text="{loc:Loc Country}"
-                                               FontSize="13"
+                                    <TextBlock FontSize="13"
                                                FontWeight="Medium"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                               Foreground="{DynamicResource TextSecondaryBrush}">
+                                        <Run Text="{loc:Loc Country}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
+                                    </TextBlock>
                                     <controls:CountryInput SelectedCountryName="{Binding Country, Mode=TwoWay}" />
                                 </StackPanel>
 

--- a/ArgoBooks/Modals/EditCompanyModal.axaml
+++ b/ArgoBooks/Modals/EditCompanyModal.axaml
@@ -118,10 +118,11 @@
 
                             <!-- Country -->
                             <StackPanel Grid.Row="4" Grid.Column="0" Spacing="6">
-                                <TextBlock Text="{loc:Loc Country}"
-                                           FontSize="13"
+                                <TextBlock FontSize="13"
                                            FontWeight="Medium"
-                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                                           Foreground="{DynamicResource TextSecondaryBrush}">
+                                    <Run Text="{loc:Loc Country}" /><Run Text=" *" Foreground="{DynamicResource ErrorBrush}" />
+                                </TextBlock>
                                 <controls:CountryInput x:Name="CountryInput" SelectedCountryName="{Binding Country, Mode=TwoWay}" />
                             </StackPanel>
 

--- a/ArgoBooks/ViewModels/CreateCompanyViewModel.cs
+++ b/ArgoBooks/ViewModels/CreateCompanyViewModel.cs
@@ -130,7 +130,7 @@ public partial class CreateCompanyViewModel : ViewModelBase
 
     #region Validation
 
-    public bool IsStep1Valid => !string.IsNullOrWhiteSpace(CompanyName);
+    public bool IsStep1Valid => !string.IsNullOrWhiteSpace(CompanyName) && !string.IsNullOrWhiteSpace(Country);
 
     public bool IsStep2Valid => !EnablePassword || (PasswordsMatch && !string.IsNullOrWhiteSpace(Password));
 
@@ -303,6 +303,12 @@ public partial class CreateCompanyViewModel : ViewModelBase
         OnPropertyChanged(nameof(PasswordsMatch));
         OnPropertyChanged(nameof(ShowPasswordError));
         OnPropertyChanged(nameof(IsStep2Valid));
+        OnPropertyChanged(nameof(CanCreate));
+    }
+
+    partial void OnCountryChanged(string? value)
+    {
+        OnPropertyChanged(nameof(IsStep1Valid));
         OnPropertyChanged(nameof(CanCreate));
     }
 

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -774,29 +774,29 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
         // Calculate comparison period based on selected date range
         var (prevStartDate, prevEndDate) = GetComparisonPeriod();
 
-        // Calculate current period revenue (using USD for consistent calculations)
+        // Calculate current period revenue (pre-tax, since tax is a liability not revenue)
         var currentRevenueUSD = data.Revenues
             .Where(s => s.Date >= StartDate && s.Date <= EndDate)
-            .Sum(s => s.EffectiveTotalUSD);
+            .Sum(s => s.EffectiveSubtotalUSD);
 
         // Calculate previous period revenue for comparison
         var prevRevenueUSD = data.Revenues
             .Where(s => s.Date >= prevStartDate && s.Date <= prevEndDate)
-            .Sum(s => s.EffectiveTotalUSD);
+            .Sum(s => s.EffectiveSubtotalUSD);
 
         TotalRevenue = FormatCurrencyFromUSD(currentRevenueUSD, DateTime.Now);
         RevenueChangeValue = CalculatePercentageChange(prevRevenueUSD, currentRevenueUSD);
         RevenueChangeText = FormatPercentageChange(RevenueChangeValue);
 
-        // Calculate current period expenses (using USD for consistent calculations)
+        // Calculate current period expenses (pre-tax, since tax is a liability not expense)
         var currentExpensesUSD = data.Expenses
             .Where(p => p.Date >= StartDate && p.Date <= EndDate)
-            .Sum(p => p.EffectiveTotalUSD);
+            .Sum(p => p.EffectiveSubtotalUSD);
 
         // Calculate previous period expenses for comparison
         var prevExpensesUSD = data.Expenses
             .Where(p => p.Date >= prevStartDate && p.Date <= prevEndDate)
-            .Sum(p => p.EffectiveTotalUSD);
+            .Sum(p => p.EffectiveSubtotalUSD);
 
         TotalExpenses = FormatCurrencyFromUSD(currentExpensesUSD, DateTime.Now);
         ExpenseChangeValue = CalculatePercentageChange(prevExpensesUSD, currentExpensesUSD);
@@ -840,8 +840,8 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
                 Id = s.Id,
                 Type = "Revenue",
                 Description = string.IsNullOrEmpty(s.Description) ? "Revenue Transaction" : s.Description,
-                Amount = FormatCurrencyFromUSD(s.EffectiveTotalUSD, s.Date),
-                AmountValue = CurrencyService.GetDisplayAmount(s.EffectiveTotalUSD, s.Date),
+                Amount = FormatCurrencyFromUSD(s.EffectiveSubtotalUSD, s.Date),
+                AmountValue = CurrencyService.GetDisplayAmount(s.EffectiveSubtotalUSD, s.Date),
                 Date = s.Date,
                 DateFormatted = FormatDate(s.Date),
                 Status = string.Empty,
@@ -861,8 +861,8 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
                 Id = p.Id,
                 Type = "Expense",
                 Description = string.IsNullOrEmpty(p.Description) ? "Purchase Transaction" : p.Description,
-                Amount = FormatCurrencyFromUSD(p.EffectiveTotalUSD, p.Date),
-                AmountValue = CurrencyService.GetDisplayAmount(p.EffectiveTotalUSD, p.Date),
+                Amount = FormatCurrencyFromUSD(p.EffectiveSubtotalUSD, p.Date),
+                AmountValue = CurrencyService.GetDisplayAmount(p.EffectiveSubtotalUSD, p.Date),
                 Date = p.Date,
                 DateFormatted = FormatDate(p.Date),
                 Status = string.Empty,

--- a/ArgoBooks/ViewModels/EditCompanyModalViewModel.cs
+++ b/ArgoBooks/ViewModels/EditCompanyModalViewModel.cs
@@ -111,7 +111,7 @@ public partial class EditCompanyModalViewModel : ViewModelBase
     /// <summary>
     /// Whether the form is valid for saving.
     /// </summary>
-    public bool CanSave => !string.IsNullOrWhiteSpace(CompanyName);
+    public bool CanSave => !string.IsNullOrWhiteSpace(CompanyName) && !string.IsNullOrWhiteSpace(Country);
 
     /// <summary>
     /// Default constructor.
@@ -344,7 +344,11 @@ public partial class EditCompanyModalViewModel : ViewModelBase
     partial void OnIndustryChanged(string? value) => OnPropertyChanged(nameof(HasChanges));
     partial void OnPhoneNumberChanged(string value) => OnPropertyChanged(nameof(HasChanges));
     partial void OnSelectedPhoneCountryChanged(CountryDialCode? value) => OnPropertyChanged(nameof(HasChanges));
-    partial void OnCountryChanged(string? value) => OnPropertyChanged(nameof(HasChanges));
+    partial void OnCountryChanged(string? value)
+    {
+        OnPropertyChanged(nameof(CanSave));
+        OnPropertyChanged(nameof(HasChanges));
+    }
     partial void OnCityChanged(string? value) => OnPropertyChanged(nameof(HasChanges));
     partial void OnAddressChanged(string? value) => OnPropertyChanged(nameof(HasChanges));
     partial void OnEmailChanged(string value) => OnPropertyChanged(nameof(HasChanges));

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -58,28 +58,28 @@ public partial class ReportsPageViewModel : ViewModelBase
     /// </summary>
     public ObservableCollection<ReportTemplateOption> AccountingTemplateOptions { get; } =
     [
-        new(ReportTemplateFactory.TemplateNames.IncomeStatement, "Income Statement", "Profit & Loss report",
+        new(ReportTemplateFactory.TemplateNames.IncomeStatement, "Income Statement", "Shows if your business made or lost money",
             "M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm-1 7V3.5L18.5 9H13zM7 17h5v-1H7v1zm0-2h10v-1H7v1zm0-2h10v-1H7v1z",
             "#27AE60", "#E8F8F5"),
-        new(ReportTemplateFactory.TemplateNames.BalanceSheet, "Balance Sheet", "Assets, liabilities & equity",
+        new(ReportTemplateFactory.TemplateNames.BalanceSheet, "Balance Sheet", "Snapshot of what you own and owe",
             "M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H8V4h12v12zM10 9h8v1.5h-8V9zm0 3h4v1.5h-4V12zm0-6h8v1.5h-8V6z",
             "#2980B9", "#EBF5FB"),
-        new(ReportTemplateFactory.TemplateNames.CashFlowStatement, "Cash Flow", "Track money in and out",
+        new(ReportTemplateFactory.TemplateNames.CashFlowStatement, "Cash Flow", "Where your cash came from and went",
             "M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z",
             "#8E44AD", "#F5EEF8"),
-        new(ReportTemplateFactory.TemplateNames.TrialBalance, "Trial Balance", "Verify debit/credit balances",
+        new(ReportTemplateFactory.TemplateNames.TrialBalance, "Trial Balance", "Checks that all your books add up",
             "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM12 6v2h5v2h-5v2l-4-3 4-3zm-1 6v2H6v-2h5v-2l4 3-4 3v-2H6v-2h5z",
             "#E67E22", "#FDF2E9"),
-        new(ReportTemplateFactory.TemplateNames.GeneralLedger, "General Ledger", "Complete transaction record",
+        new(ReportTemplateFactory.TemplateNames.GeneralLedger, "General Ledger", "Full list of every transaction",
             "M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9h-4v4h-2v-4H9V9h4V5h2v4h4v2z",
             "#2C3E50", "#EBEDEF"),
-        new(ReportTemplateFactory.TemplateNames.ARaging, "AR Aging", "Receivables by age",
+        new(ReportTemplateFactory.TemplateNames.ARaging, "AR Aging", "Who owes you and for how long",
             "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.94s4.18 1.36 4.18 3.85c0 1.89-1.44 2.96-3.12 3.19z",
             "#16A085", "#E8F6F3"),
-        new(ReportTemplateFactory.TemplateNames.APaging, "AP Aging", "Payables by age",
+        new(ReportTemplateFactory.TemplateNames.APaging, "AP Aging", "What you owe and when it's due",
             "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm.31-8.86c-1.77-.45-2.34-.94-2.34-1.67 0-.84.79-1.43 2.1-1.43 1.38 0 1.9.66 1.94 1.64h1.71c-.05-1.34-.87-2.57-2.49-2.97V5H11.5v1.69c-1.51.32-2.72 1.3-2.72 2.81 0 1.79 1.49 2.69 3.66 3.21 1.95.46 2.34 1.15 2.34 1.87 0 .53-.39 1.39-2.1 1.39-1.6 0-2.23-.72-2.32-1.64H8.65c.09 1.71 1.37 2.66 2.85 2.97V19h1.72v-1.67c1.52-.29 2.72-1.16 2.72-2.74 0-2.22-1.9-2.97-3.63-3.45z",
             "#C0392B", "#FDEDEC"),
-        new(ReportTemplateFactory.TemplateNames.TaxSummary, "Tax Summary", "Tax collected & owed",
+        new(ReportTemplateFactory.TemplateNames.TaxSummary, "Tax Summary", "Tax you collected vs. tax you paid",
             "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z",
             "#D35400", "#FBEEE6")
     ];
@@ -273,6 +273,19 @@ public partial class ReportsPageViewModel : ViewModelBase
 
     [ObservableProperty]
     private string _reportName = "Untitled Report";
+
+    partial void OnReportNameChanged(string value)
+    {
+        // Keep export file path in sync with report name so switching templates
+        // doesn't overwrite a previously exported file.
+        if (!string.IsNullOrEmpty(ExportFilePath))
+        {
+            var dir = Path.GetDirectoryName(ExportFilePath) ?? "";
+            var ext = Path.GetExtension(ExportFilePath);
+            var newName = string.IsNullOrWhiteSpace(value) ? "Report" : value;
+            ExportFilePath = Path.Combine(dir, $"{newName}{ext}");
+        }
+    }
 
     /// <summary>
     /// Chart types to preserve during template reload (when going back from step 2).
@@ -1487,6 +1500,37 @@ public partial class ReportsPageViewModel : ViewModelBase
     private string _exportFilePath = string.Empty;
 
     [ObservableProperty]
+    private string _exportFileName = "Report";
+
+    partial void OnExportFilePathChanged(string value)
+    {
+        // Sync file name from file path (without triggering a loop)
+        var nameFromPath = Path.GetFileNameWithoutExtension(value);
+        if (!string.IsNullOrEmpty(nameFromPath) && nameFromPath != _exportFileName)
+        {
+            _exportFileName = nameFromPath;
+            OnPropertyChanged(nameof(ExportFileName));
+        }
+    }
+
+    partial void OnExportFileNameChanged(string value)
+    {
+        // Sync file path from file name (without triggering a loop)
+        if (!string.IsNullOrEmpty(ExportFilePath))
+        {
+            var dir = Path.GetDirectoryName(ExportFilePath) ?? "";
+            var ext = Path.GetExtension(ExportFilePath);
+            var newName = string.IsNullOrWhiteSpace(value) ? "Report" : value;
+            var newPath = Path.Combine(dir, $"{newName}{ext}");
+            if (newPath != _exportFilePath)
+            {
+                _exportFilePath = newPath;
+                OnPropertyChanged(nameof(ExportFilePath));
+            }
+        }
+    }
+
+    [ObservableProperty]
     private bool _openAfterExport = true;
 
     [ObservableProperty]
@@ -1726,59 +1770,39 @@ public partial class ReportsPageViewModel : ViewModelBase
     [RelayCommand]
     private async Task BrowseExportPathAsync()
     {
-        var defaultName = string.IsNullOrWhiteSpace(ReportName) ? "Report" : ReportName;
-        var extension = SelectedExportFormat switch
-        {
-            ExportFormat.PDF => ".pdf",
-            ExportFormat.PNG => ".png",
-            ExportFormat.JPEG => ".jpg",
-            _ => ".pdf"
-        };
-
         // Use last export directory, or default to Desktop
         var lastDir = App.SettingsService?.GlobalSettings.ReportExport.LastExportDirectory;
         var defaultPath = !string.IsNullOrEmpty(lastDir) && Directory.Exists(lastDir)
             ? lastDir
             : Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
 
-        // Try to use the storage provider for a native save dialog
         var topLevel = Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
             ? desktop.MainWindow
             : null;
 
         if (topLevel?.StorageProvider != null)
         {
-            var filters = SelectedExportFormat switch
+            var startFolder = await topLevel.StorageProvider.TryGetFolderFromPathAsync(defaultPath);
+            var result = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
             {
-                ExportFormat.PDF => new[] { new FilePickerFileType("PDF Document") { Patterns =
-                    ["*.pdf"]
-                } },
-                ExportFormat.PNG => new[] { new FilePickerFileType("PNG Image") { Patterns =
-                    ["*.png"]
-                } },
-                ExportFormat.JPEG => new[] { new FilePickerFileType("JPEG Image") { Patterns =
-                    ["*.jpg", "*.jpeg"]
-                } },
-                _ => new[] { new FilePickerFileType("PDF Document") { Patterns = ["*.pdf"] } }
-            };
-
-            var result = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
-            {
-                Title = "Save Report As",
-                SuggestedFileName = $"{defaultName}{extension}",
-                FileTypeChoices = filters,
-                DefaultExtension = extension.TrimStart('.')
+                Title = "Select Export Folder",
+                SuggestedStartLocation = startFolder,
+                AllowMultiple = false
             });
 
-            if (result != null)
+            if (result is { Count: > 0 })
             {
-                ExportFilePath = result.Path.LocalPath;
+                var selectedDir = result[0].Path.LocalPath;
+                var fileName = string.IsNullOrWhiteSpace(ExportFileName) ? "Report" : ExportFileName;
+                var extension = SelectedExportFormat switch
+                {
+                    ExportFormat.PDF => ".pdf",
+                    ExportFormat.PNG => ".png",
+                    ExportFormat.JPEG => ".jpg",
+                    _ => ".pdf"
+                };
+                ExportFilePath = Path.Combine(selectedDir, $"{fileName}{extension}");
             }
-        }
-        else
-        {
-            // Fallback to default path
-            ExportFilePath = Path.Combine(defaultPath, $"{defaultName}{extension}");
         }
     }
 
@@ -2378,7 +2402,8 @@ public partial class ReportsPageViewModel : ViewModelBase
             ExportFormat.JPEG => ".jpg",
             _ => ".pdf"
         };
-        ExportFilePath = Path.Combine(desktopPath, $"Report{extension}");
+        var defaultName = string.IsNullOrWhiteSpace(ReportName) ? "Report" : ReportName;
+        ExportFilePath = Path.Combine(desktopPath, $"{defaultName}{extension}");
     }
 
     private void InitializeCollections()

--- a/ArgoBooks/Views/AnalyticsPage.axaml
+++ b/ArgoBooks/Views/AnalyticsPage.axaml
@@ -78,14 +78,14 @@
                             IsVisible="{Binding IsDashboardTabSelected}">
                     <!-- Statistics Cards Row -->
                     <controls:StatCardsRow>
-                        <controls:StatCard Label="{loc:Loc 'Total Purchases'}"
+                        <controls:StatCard Label="{loc:Loc 'Total Expenses'}"
                                            Value="{Binding TotalPurchases}"
                                            Icon="M19 14V6c0-1.1-.9-2-2-2H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zm-9-1c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm13-6v11c0 1.1-.9 2-2 2H4v-2h17V7h2z"
                                            IconColor="Danger"
                                            ChangeValue="{Binding PurchasesChangeValue}"
                                            ChangeText="{Binding PurchasesChangeText}"
                                            ChangeLabel="{Binding ComparisonPeriodLabel}" />
-                        <controls:StatCard Label="{loc:Loc 'Total Sales'}"
+                        <controls:StatCard Label="{loc:Loc 'Total Revenue'}"
                                            Value="{Binding TotalRevenue}"
                                            Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.91s4.18 1.39 4.18 3.91c-.01 1.83-1.38 2.83-3.12 3.16z"
                                            IconColor="Success"

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -618,7 +618,7 @@
                                         <DataTemplate DataType="vm:DatePresetOption">
                                             <RadioButton Content="{Binding Name, Converter={StaticResource TranslateConverter}}"
                                                          GroupName="DateRange"
-                                                         IsChecked="{Binding IsSelected}"
+                                                         IsChecked="{Binding IsSelected, Mode=OneWay}"
                                                          Command="{Binding $parent[ItemsControl].((vm:ReportsPageViewModel)DataContext).SelectDatePresetCommand}"
                                                          CommandParameter="{Binding}"
                                                          Margin="0,3"
@@ -1799,6 +1799,17 @@
                                     Maximum="100"
                                     TickFrequency="5"
                                     IsSnapToTickEnabled="True" />
+                        </StackPanel>
+
+                        <!-- File Name -->
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{loc:Loc 'File Name'}"
+                                       FontSize="14"
+                                       FontWeight="Medium"
+                                       Foreground="{DynamicResource TextSecondaryBrush}" />
+                            <TextBox Text="{Binding ExportFileName}"
+                                     Watermark="{loc:Loc 'Enter file name...'}"
+                                     Padding="12,10" />
                         </StackPanel>
 
                         <!-- File Path -->


### PR DESCRIPTION
## Summary
This PR refactors the accounting report generation system to consistently use pre-tax (subtotal) amounts instead of total amounts including tax, and restructures the Income Statement to properly separate Cost of Goods Sold from Operating Expenses. It also improves invoice-to-revenue linking and fixes several related issues across reports and analytics.

## Key Changes

### Accounting Report Structure
- **Income Statement**: Restructured to show Revenue → COGS → Gross Profit → Operating Expenses → Net Income, replacing the previous simple Revenue/Expenses model
- Added `IsInventoryRelatedExpense()` method to classify expenses as COGS (inventory-linked) vs. Operating Expenses
- Split expense categorization into `cogsByCategory` and `opexByCategory`
- Updated empty statement templates to reflect the new structure with Gross Profit line item

### Pre-Tax Amount Usage
- Changed all revenue/expense calculations to use `Subtotal` (pre-tax) instead of `Total` (post-tax) throughout:
  - `GroupTransactionsByCategory()` now uses `lineItem.Subtotal` and `txn.Amount`
  - Balance Sheet cash calculations use `EffectiveSubtotalUSD` instead of `EffectiveTotalUSD`
  - Chart data services (`RevenueOverTime`, `RevenueDistribution`, `ExpensesOverTime`, etc.) updated to use pre-tax amounts
  - Dashboard and analytics statistics use pre-tax amounts for consistency
- Rationale: Sales tax is a liability, not revenue/expense, so pre-tax amounts better represent actual business performance

### Date Range Handling
- Replaced `GetPeriodSubtitle()` and `GetAsOfSubtitle()` methods with `GetEffectiveStartDate()` and `GetEarliestTransactionDate()`
- Handles the "All Time" sentinel (year 2000) by replacing it with the actual earliest transaction date from company data
- Removed hardcoded subtitle generation; subtitles now set to empty string (handled elsewhere)

### Invoice-to-Revenue Linking
- Enhanced `SampleCompanyService.LinkInvoicesToRevenues()` to match invoices with existing revenues or auto-create them
- Added `CreateRevenueFromInvoice()` in `InvoiceModalsViewModel` to automatically create Revenue transactions when invoices are sent
- Added `RemoveAutoCreatedRevenue()` to clean up auto-created revenues when invoices are deleted
- Ensures the revenue table is the single source of truth for all financial data

### Balance Sheet Improvements
- Removed Inventory line item from Balance Sheet (inventory is not tracked as a balance sheet asset in this system)
- Changed Retained Earnings calculation to use balancing equation: `Assets - Liabilities` instead of cumulative revenue minus expenses
- This aligns with simplified bookkeeping where the balance sheet must balance

### Cash Flow Statement
- Removed Investing Activities section (inventory purchases)
- Simplified to show only Operating Activities
- Updated to exclude invoice-linked revenue to avoid double-counting with Payments

### Report Rendering
- Fixed null reference issue in `ReportRenderer.cs` with proper null-coalescing checks
- Enhanced section header rendering to extend fill upward and properly display column headers (e.g., "Amount")

### UI/UX Updates
- Updated report template descriptions in `ReportsPageViewModel` to be more user-friendly
- Fixed `AnalyticsPageViewModel` to update profit chart title with total profit amount
- Improved empty state handling for accounting reports

### Data Model
- Added `EffectiveSubtotalUSD` property to Transaction model for consistent pre-tax amount access

## Implementation Details
- All changes maintain backward compatibility with existing data structures
- Pre-tax calculations are applied consistently across all reporting modules (charts, tables, statistics, insights)
- The refactoring ensures that tax amounts are properly excluded from financial metrics while remaining available for tax reporting
- Invoice linking now supports both "Revenue → Invoice" (existing revenue matched to invoice) and "Invoice → Revenue" (auto-create revenue from invoice) paths

https://claude.ai/code/session_01BgVfvi9FAwzdqQ1RmDJa1f