### PR TITLE
Fix balance sheet date preset radio button reappearing after back navigation

### DIFF
--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -170,6 +170,15 @@ public partial class ReportsPageViewModel : ViewModelBase
                 // Clear undo history and reload the template to discard layout changes
                 UndoRedoManager.Clear();
                 LoadTemplate(SelectedTemplateName);
+
+                // Clear radio button selection for point-in-time reports where date range is disabled
+                // (mirrors the logic in OnSelectedTemplateNameChanged, which doesn't fire here
+                // because SelectedTemplateName didn't change)
+                if (!IsDateRangeEnabled)
+                {
+                    foreach (var option in DatePresets)
+                        option.IsSelected = false;
+                }
             }
 
             CurrentStep--;


### PR DESCRIPTION
When navigating Next then Back with Balance Sheet selected, the date preset radio button blue dot would reappear because LoadTemplate restores presets via ApplyConfigurationToPageSettings, but OnSelectedTemplateNameChanged (which clears them) doesn't fire since the template name didn't change. Clear the selections explicitly after LoadTemplate when date range is disabled.