### PR TITLE
Fix template card styling and clear date range on template deletion

### DIFF
--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -2240,10 +2240,18 @@ public partial class ReportsPageViewModel : ViewModelBase
         var success = _templateStorage.DeleteTemplate(TemplateToDelete);
         if (success)
         {
-            // If we're deleting the currently selected template, switch to blank
+            // If we're deleting the currently selected template, clear selection state
             if (SelectedTemplateName == TemplateToDelete)
             {
                 SelectedTemplateName = ReportTemplateFactory.TemplateNames.Custom;
+
+                // Clear date range selection since the selected template was deleted
+                foreach (var option in DatePresets)
+                    option.IsSelected = false;
+                SelectedDatePreset = string.Empty;
+                IsCustomDateRange = false;
+                CustomStartDate = null;
+                CustomEndDate = null;
             }
 
             // Refresh custom templates list

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -393,14 +393,15 @@
                                                             HorizontalContentAlignment="Stretch"
                                                             Command="{Binding $parent[ItemsControl].((vm:ReportsPageViewModel)DataContext).SelectTemplateCommand}"
                                                             CommandParameter="{Binding Name}"
+                                                            Classes="template-card"
                                                             Classes.selected="{Binding IsSelected}">
                                                         <Button.Styles>
-                                                            <Style Selector="Button">
+                                                            <Style Selector="Button.template-card">
                                                                 <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
                                                                 <Setter Property="BorderThickness" Value="2" />
                                                                 <Setter Property="BorderBrush" Value="Transparent" />
                                                             </Style>
-                                                            <Style Selector="Button /template/ ContentPresenter#PART_ContentPresenter">
+                                                            <Style Selector="Button.template-card /template/ ContentPresenter#PART_ContentPresenter">
                                                                 <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
                                                                 <Setter Property="Transitions">
                                                                     <Transitions>
@@ -408,21 +409,25 @@
                                                                     </Transitions>
                                                                 </Setter>
                                                             </Style>
-                                                            <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                                                            <Style Selector="Button.template-card:pointerover /template/ ContentPresenter#PART_ContentPresenter">
                                                                 <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
                                                             </Style>
-                                                            <Style Selector="Button.selected">
+                                                            <Style Selector="Button.template-card.selected">
                                                                 <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
                                                             </Style>
-                                                            <Style Selector="Button.selected /template/ ContentPresenter#PART_ContentPresenter">
+                                                            <Style Selector="Button.template-card.selected /template/ ContentPresenter#PART_ContentPresenter">
                                                                 <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
                                                             </Style>
-                                                            <Style Selector="Button.selected:pointerover">
+                                                            <Style Selector="Button.template-card.selected:pointerover">
                                                                 <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
                                                             </Style>
-                                                            <Style Selector="Button.selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                                                            <Style Selector="Button.template-card.selected:pointerover /template/ ContentPresenter#PART_ContentPresenter">
                                                                 <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
                                                                 <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
+                                                            </Style>
+                                                            <!-- Icon button hover uses SurfacePressedBrush since the card hover is already SurfaceHoverBrush -->
+                                                            <Style Selector="Button.template-card:pointerover Button.icon-button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                                                                <Setter Property="Background" Value="{DynamicResource SurfacePressedBrush}" />
                                                             </Style>
                                                         </Button.Styles>
                                                         <Grid ColumnDefinitions="*,Auto,Auto">


### PR DESCRIPTION
## Summary
This PR improves the template card UI styling specificity and fixes a bug where date range selections were not cleared when deleting the currently selected template.

## Key Changes
- **Template Card Styling**: Added `template-card` class to template button and updated all related style selectors to use this class for better specificity and to prevent unintended style application to other buttons
- **Icon Button Hover State**: Added a new style rule to handle nested icon button hover states within template cards, using `SurfacePressedBrush` to differentiate from the card's `SurfaceHoverBrush`
- **Template Deletion Logic**: When deleting the currently selected template, the date range selection state is now properly cleared:
  - Deselects all date preset options
  - Clears the selected date preset
  - Resets custom date range flag
  - Clears custom start and end dates

## Implementation Details
The styling changes ensure that template card styles only apply to buttons with the `template-card` class, preventing potential style conflicts with other button elements in the UI. The date range clearing on template deletion ensures the UI state remains consistent when a template is removed.

https://claude.ai/code/session_01N9YwGg3W7usbKd9HCKNJUv