### PR TITLE
Fix binding null-reference errors and spurious undo entries

### DIFF
--- a/ArgoBooks.Tests/Services/ReportUndoRedoManagerTests.cs
+++ b/ArgoBooks.Tests/Services/ReportUndoRedoManagerTests.cs
@@ -1,3 +1,4 @@
+using ArgoBooks.Core.Models.Reports;
 using ArgoBooks.Services;
 using Xunit;
 
@@ -366,6 +367,63 @@ public class ReportUndoRedoManagerTests
         manager.RecordAction(new MockAction("Test"));
 
         Assert.Contains(nameof(ReportUndoRedoManager.CanUndo), changedProps);
+    }
+
+    #endregion
+
+    #region Add/Remove Element Action Integration Tests
+
+    [Fact]
+    public void AddThenDelete_UndoBoth_ElementIsRemoved()
+    {
+        // Regression test: add element, delete it, undo both → element should be gone
+        var config = new ReportConfiguration();
+        var manager = new ReportUndoRedoManager();
+
+        // Step 1: Add element
+        var element = new LabelReportElement { X = 10, Y = 20, Width = 100, Height = 50 };
+        config.AddElement(element);
+        manager.RecordAction(new AddElementAction(config, element));
+        Assert.Single(config.Elements);
+
+        // Step 2: Delete element
+        manager.RecordAction(new RemoveElementAction(config, element));
+        config.RemoveElement(element.Id);
+        Assert.Empty(config.Elements);
+
+        // Step 3: Undo delete → element should reappear
+        manager.Undo();
+        Assert.Single(config.Elements);
+
+        // Step 4: Undo add → element should be gone
+        manager.Undo();
+        Assert.Empty(config.Elements);
+    }
+
+    [Fact]
+    public void AddThenDelete_UndoBoth_RedoBoth_ElementIsRemoved()
+    {
+        // Full round-trip: add, delete, undo×2, redo×2
+        var config = new ReportConfiguration();
+        var manager = new ReportUndoRedoManager();
+
+        var element = new LabelReportElement { X = 10, Y = 20, Width = 100, Height = 50 };
+        config.AddElement(element);
+        manager.RecordAction(new AddElementAction(config, element));
+
+        manager.RecordAction(new RemoveElementAction(config, element));
+        config.RemoveElement(element.Id);
+
+        // Undo both
+        manager.Undo(); // undo delete
+        manager.Undo(); // undo add
+        Assert.Empty(config.Elements);
+
+        // Redo both
+        manager.Redo(); // redo add
+        Assert.Single(config.Elements);
+        manager.Redo(); // redo delete
+        Assert.Empty(config.Elements);
     }
 
     #endregion

--- a/ArgoBooks/Controls/ArgoNumericUpDown.axaml.cs
+++ b/ArgoBooks/Controls/ArgoNumericUpDown.axaml.cs
@@ -140,6 +140,13 @@ public partial class ArgoNumericUpDown : UserControl
     {
         if (_inputTextBox == null) return;
 
+        // Skip if the text matches the formatted current value — the user didn't
+        // actually edit anything.  Without this check, the integer display format
+        // ("0") causes a lossy round-trip (e.g. 253.7 → "254" → 254) that writes
+        // back a different value and creates spurious undo actions.
+        if (_inputTextBox.Text == Value.ToString("0"))
+            return;
+
         if (double.TryParse(_inputTextBox.Text, NumberStyles.Any, CultureInfo.CurrentCulture, out var newValue))
         {
             Value = Math.Clamp(newValue, Minimum, Maximum);

--- a/ArgoBooks/Modals/PurchaseOrdersModals.axaml
+++ b/ArgoBooks/Modals/PurchaseOrdersModals.axaml
@@ -262,7 +262,8 @@
                     BorderBrush="{DynamicResource BorderBrush}"
                     BorderThickness="1" CornerRadius="12" Width="600"
                     MaxHeight="650"
-                    HorizontalAlignment="Center" VerticalAlignment="Center">
+                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                    DataContext="{Binding ViewingOrder}" x:CompileBindings="False">
                 <Grid RowDefinitions="Auto,*,Auto">
                     <!-- Modal Header -->
                     <Border Grid.Row="0" Padding="24,20" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
@@ -271,12 +272,12 @@
                                 <TextBlock Text="{loc:Loc 'Order Details'}"
                                            FontSize="18" FontWeight="SemiBold"
                                            Foreground="{DynamicResource TextPrimaryBrush}" />
-                                <TextBlock Text="{Binding ViewingOrder.PoNumber}"
+                                <TextBlock Text="{Binding PoNumber}"
                                            FontSize="13"
                                            FontFamily="Consolas, monospace"
                                            Foreground="{DynamicResource PrimaryBrush}" />
                             </StackPanel>
-                            <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseViewModalCommand}">
+                            <Button Grid.Column="1" Classes="icon-button" Command="{Binding $parent[UserControl].DataContext.CloseViewModalCommand}">
                                 <PathIcon Data="{x:Static icons:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -286,20 +287,20 @@
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Margin="24" Spacing="20">
                             <!-- Status Badge -->
-                            <Border Background="{Binding ViewingOrder.StatusBackground}"
+                            <Border Background="{Binding StatusBackground}"
                                     CornerRadius="6"
                                     Padding="12,8"
                                     HorizontalAlignment="Left">
-                                <TextBlock Text="{Binding ViewingOrder.StatusDisplay}"
+                                <TextBlock Text="{Binding StatusDisplay}"
                                            FontSize="14"
                                            FontWeight="SemiBold"
-                                           Foreground="{Binding ViewingOrder.StatusColor}" />
+                                           Foreground="{Binding StatusColor}" />
                             </Border>
 
                             <!-- Supplier Info -->
                             <StackPanel Spacing="4">
                                 <TextBlock Text="{loc:Loc 'Supplier'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                <TextBlock Text="{Binding ViewingOrder.SupplierName}"
+                                <TextBlock Text="{Binding SupplierName}"
                                            FontSize="16" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" />
                             </StackPanel>
@@ -308,13 +309,13 @@
                             <Grid ColumnDefinitions="*,*">
                                 <StackPanel Grid.Column="0" Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Order Date'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <TextBlock Text="{Binding ViewingOrder.DateDisplay}"
+                                    <TextBlock Text="{Binding DateDisplay}"
                                                FontSize="14"
                                                Foreground="{DynamicResource TextPrimaryBrush}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="1" Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Expected Delivery'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <TextBlock Text="{Binding ViewingOrder.ExpectedDisplay}"
+                                    <TextBlock Text="{Binding ExpectedDisplay}"
                                                FontSize="14"
                                                Foreground="{DynamicResource TextPrimaryBrush}" />
                                 </StackPanel>
@@ -334,7 +335,7 @@
                                             <TextBlock Grid.Column="2" Text="{loc:Loc 'Unit Cost'}" FontSize="12" FontWeight="Medium" Foreground="{DynamicResource TextTertiaryBrush}" />
                                             <TextBlock Grid.Column="3" Text="{loc:Loc 'Total'}" FontSize="12" FontWeight="Medium" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         </Grid>
-                                        <ItemsControl ItemsSource="{Binding ViewLineItems}">
+                                        <ItemsControl ItemsSource="{Binding $parent[UserControl].DataContext.ViewLineItems}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate DataType="vm:ViewLineItemDisplay">
                                                     <Border Margin="0,4" Padding="8" Background="{DynamicResource SurfaceBrush}" CornerRadius="6">
@@ -361,14 +362,14 @@
                                     Padding="16">
                                 <Grid ColumnDefinitions="*,Auto">
                                     <TextBlock Grid.Column="0" Text="{loc:Loc 'Total'}" FontWeight="SemiBold" FontSize="16" />
-                                    <TextBlock Grid.Column="1" Text="{Binding ViewingOrder.TotalDisplay}" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource PrimaryBrush}" />
+                                    <TextBlock Grid.Column="1" Text="{Binding TotalDisplay}" FontWeight="Bold" FontSize="16" Foreground="{DynamicResource PrimaryBrush}" />
                                 </Grid>
                             </Border>
 
                             <!-- Notes -->
-                            <StackPanel Spacing="4" IsVisible="{Binding ViewingOrder.Notes, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                            <StackPanel Spacing="4" IsVisible="{Binding Notes, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
                                 <TextBlock Text="{loc:Loc 'Notes'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                <TextBlock Text="{Binding ViewingOrder.Notes}"
+                                <TextBlock Text="{Binding Notes}"
                                            FontSize="14"
                                            Foreground="{DynamicResource TextPrimaryBrush}"
                                            TextWrapping="Wrap" />
@@ -378,7 +379,7 @@
 
                     <!-- Modal Footer -->
                     <Border Grid.Row="2" Padding="24,16" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">
-                        <Button Classes="secondary-button" Content="{loc:Loc 'Close'}" Command="{Binding CloseViewModalCommand}" HorizontalAlignment="Right" />
+                        <Button Classes="secondary-button" Content="{loc:Loc 'Close'}" Command="{Binding $parent[UserControl].DataContext.CloseViewModalCommand}" HorizontalAlignment="Right" />
                     </Border>
                 </Grid>
                 </Border>
@@ -401,7 +402,8 @@
                                 <TextBlock Text="{loc:Loc 'Receive Items'}"
                                            FontSize="18" FontWeight="SemiBold"
                                            Foreground="{DynamicResource TextPrimaryBrush}" />
-                                <TextBlock Text="{Binding ReceivingOrder.PoNumber}"
+                                <TextBlock DataContext="{Binding ReceivingOrder}" x:CompileBindings="False"
+                                           Text="{Binding PoNumber}"
                                            FontSize="13"
                                            FontFamily="Consolas, monospace"
                                            Foreground="{DynamicResource PrimaryBrush}" />

--- a/ArgoBooks/Modals/ReportModals.axaml
+++ b/ArgoBooks/Modals/ReportModals.axaml
@@ -17,28 +17,29 @@
 
     <Panel>
         <!-- ======================= PAGE SETTINGS MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsPageSettingsOpen}"
-                               ClosingCommand="{Binding ReportsPageViewModel.ClosePageSettingsCommand}">
+        <controls:ModalOverlay DataContext="{Binding ReportsPageViewModel}" x:CompileBindings="False"
+                               IsOpen="{Binding $parent[UserControl].DataContext.IsPageSettingsOpen}"
+                               ClosingCommand="{Binding ClosePageSettingsCommand}">
             <controls:ModalOverlay.ModalContent>
-                <modals:ReportPageSettingsModal DataContext="{Binding ReportsPageViewModel}"
-                                             HorizontalAlignment="Center"
+                <modals:ReportPageSettingsModal HorizontalAlignment="Center"
                                              VerticalAlignment="Center" />
             </controls:ModalOverlay.ModalContent>
         </controls:ModalOverlay>
 
         <!-- ======================= SAVE TEMPLATE MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsSaveTemplateOpen}"
-                               ClosingCommand="{Binding ReportsPageViewModel.CloseSaveTemplateCommand}">
+        <controls:ModalOverlay DataContext="{Binding ReportsPageViewModel}" x:CompileBindings="False"
+                               IsOpen="{Binding $parent[UserControl].DataContext.IsSaveTemplateOpen}"
+                               ClosingCommand="{Binding CloseSaveTemplateCommand}">
             <controls:ModalOverlay.ModalContent>
-                <modals:ReportSaveTemplateModal DataContext="{Binding ReportsPageViewModel}"
-                                             HorizontalAlignment="Center"
+                <modals:ReportSaveTemplateModal HorizontalAlignment="Center"
                                              VerticalAlignment="Center" />
             </controls:ModalOverlay.ModalContent>
         </controls:ModalOverlay>
 
         <!-- ======================= DELETE TEMPLATE MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsDeleteTemplateOpen}"
-                               ClosingCommand="{Binding ReportsPageViewModel.CloseDeleteTemplateCommand}">
+        <controls:ModalOverlay DataContext="{Binding ReportsPageViewModel}" x:CompileBindings="False"
+                               IsOpen="{Binding $parent[UserControl].DataContext.IsDeleteTemplateOpen}"
+                               ClosingCommand="{Binding CloseDeleteTemplateCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                     VerticalAlignment="Center"
@@ -61,7 +62,7 @@
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1"
                                     Classes="icon-button"
-                                    Command="{Binding ReportsPageViewModel.CloseDeleteTemplateCommand}">
+                                    Command="{Binding CloseDeleteTemplateCommand}">
                                 <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="16" Height="16" />
                             </Button>
@@ -74,7 +75,7 @@
                                    FontSize="14"
                                    Foreground="{DynamicResource TextSecondaryBrush}">
                             <Run Text="{loc:Loc 'Are you sure you want to delete the template'}" />
-                            <Run Text="{Binding ReportsPageViewModel.TemplateToDelete}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
+                            <Run Text="{Binding TemplateToDelete}" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Run Text="{loc:Loc '? This action cannot be undone.'}" />
                         </TextBlock>
                     </StackPanel>
@@ -91,10 +92,10 @@
                                     Spacing="12">
                             <Button Classes="secondary-button"
                                     Content="{loc:Loc 'Cancel'}"
-                                    Command="{Binding ReportsPageViewModel.CloseDeleteTemplateCommand}" />
+                                    Command="{Binding CloseDeleteTemplateCommand}" />
                             <Button Classes="danger-button"
                                     Content="{loc:Loc 'Delete'}"
-                                    Command="{Binding ReportsPageViewModel.ConfirmDeleteTemplateCommand}" />
+                                    Command="{Binding ConfirmDeleteTemplateCommand}" />
                         </StackPanel>
                     </Border>
                 </Grid>
@@ -103,8 +104,9 @@
         </controls:ModalOverlay>
 
         <!-- ======================= RENAME TEMPLATE MODAL ======================= -->
-        <controls:ModalOverlay IsOpen="{Binding IsRenameTemplateOpen}"
-                               ClosingCommand="{Binding ReportsPageViewModel.CloseRenameTemplateCommand}">
+        <controls:ModalOverlay DataContext="{Binding ReportsPageViewModel}" x:CompileBindings="False"
+                               IsOpen="{Binding $parent[UserControl].DataContext.IsRenameTemplateOpen}"
+                               ClosingCommand="{Binding CloseRenameTemplateCommand}">
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                     VerticalAlignment="Center"
@@ -127,7 +129,7 @@
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <Button Grid.Column="1"
                                     Classes="icon-button"
-                                    Command="{Binding ReportsPageViewModel.CloseRenameTemplateCommand}">
+                                    Command="{Binding CloseRenameTemplateCommand}">
                                 <PathIcon Data="{x:Static icons:Icons.Close}"
                                           Width="16" Height="16" />
                             </Button>
@@ -139,7 +141,7 @@
                         <TextBlock Text="{loc:Loc 'Enter a new name for the template:'}"
                                    FontSize="14"
                                    Foreground="{DynamicResource TextSecondaryBrush}" />
-                        <TextBox Text="{Binding ReportsPageViewModel.RenameTemplateNewName}"
+                        <TextBox Text="{Binding RenameTemplateNewName}"
                                  Watermark="{loc:Loc 'Template name...'}"
                                  Padding="12,10"
                                  x:Name="RenameTemplateTextBox"
@@ -159,10 +161,10 @@
                                     Spacing="12">
                             <Button Classes="secondary-button"
                                     Content="{loc:Loc 'Cancel'}"
-                                    Command="{Binding ReportsPageViewModel.CloseRenameTemplateCommand}" />
+                                    Command="{Binding CloseRenameTemplateCommand}" />
                             <Button Classes="primary-button"
                                     Content="{loc:Loc 'Rename'}"
-                                    Command="{Binding ReportsPageViewModel.ConfirmRenameTemplateCommand}" />
+                                    Command="{Binding ConfirmRenameTemplateCommand}" />
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/ArgoBooks/Modals/StockAdjustmentsModals.axaml
+++ b/ArgoBooks/Modals/StockAdjustmentsModals.axaml
@@ -169,7 +169,8 @@
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
                     BorderThickness="1" CornerRadius="12" Width="500"
-                    HorizontalAlignment="Center" VerticalAlignment="Center">
+                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                    DataContext="{Binding ViewingAdjustment}" x:CompileBindings="False">
                 <Grid RowDefinitions="Auto,*,Auto">
                     <!-- Modal Header -->
                     <Border Grid.Row="0" Padding="24,20" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
@@ -178,12 +179,12 @@
                                 <TextBlock Text="{loc:Loc 'Adjustment Details'}"
                                            FontSize="18" FontWeight="SemiBold"
                                            Foreground="{DynamicResource TextPrimaryBrush}" />
-                                <TextBlock Text="{Binding ViewingAdjustment.Id}"
+                                <TextBlock Text="{Binding Id}"
                                            FontSize="13"
                                            FontFamily="Consolas, monospace"
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                             </StackPanel>
-                            <Button Grid.Column="1" Classes="icon-button" Command="{Binding CloseViewModalCommand}">
+                            <Button Grid.Column="1" Classes="icon-button" Command="{Binding $parent[UserControl].DataContext.CloseViewModalCommand}">
                                 <PathIcon Data="{x:Static local:Icons.Close}" Width="20" Height="20" />
                             </Button>
                         </Grid>
@@ -193,29 +194,29 @@
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Margin="24" Spacing="20">
                             <!-- Type Badge -->
-                            <Border Background="{Binding ViewingAdjustment.TypeBackground}"
+                            <Border Background="{Binding TypeBackground}"
                                     CornerRadius="6"
                                     Padding="12,8"
                                     HorizontalAlignment="Left">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <TextBlock Text="{Binding ViewingAdjustment.TypeDisplay}"
+                                    <TextBlock Text="{Binding TypeDisplay}"
                                                FontSize="14"
                                                FontWeight="SemiBold"
-                                               Foreground="{Binding ViewingAdjustment.TypeColor}" />
-                                    <TextBlock Text="{Binding ViewingAdjustment.QuantityDisplay}"
+                                               Foreground="{Binding TypeColor}" />
+                                    <TextBlock Text="{Binding QuantityDisplay}"
                                                FontSize="14"
                                                FontWeight="Bold"
-                                               Foreground="{Binding ViewingAdjustment.QuantityColor}" />
+                                               Foreground="{Binding QuantityColor}" />
                                 </StackPanel>
                             </Border>
 
                             <!-- Product Info -->
                             <StackPanel Spacing="4">
                                 <TextBlock Text="{loc:Loc Product}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                <TextBlock Text="{Binding ViewingAdjustment.ProductName}"
+                                <TextBlock Text="{Binding ProductName}"
                                            FontSize="16" FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}" />
-                                <TextBlock Text="{Binding ViewingAdjustment.ProductSku}"
+                                <TextBlock Text="{Binding ProductSku}"
                                            FontSize="13"
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                             </StackPanel>
@@ -223,7 +224,7 @@
                             <!-- Location -->
                             <StackPanel Spacing="4">
                                 <TextBlock Text="{loc:Loc Location}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                <TextBlock Text="{Binding ViewingAdjustment.LocationName}"
+                                <TextBlock Text="{Binding LocationName}"
                                            FontSize="14"
                                            Foreground="{DynamicResource TextPrimaryBrush}" />
                             </StackPanel>
@@ -232,7 +233,7 @@
                             <Grid ColumnDefinitions="*,Auto,*">
                                 <StackPanel Grid.Column="0" Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Previous Stock'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <TextBlock Text="{Binding ViewingAdjustment.PreviousStock}"
+                                    <TextBlock Text="{Binding PreviousStock}"
                                                FontSize="20" FontWeight="SemiBold"
                                                Foreground="{DynamicResource TextSecondaryBrush}" />
                                 </StackPanel>
@@ -243,7 +244,7 @@
                                           Margin="16,0" />
                                 <StackPanel Grid.Column="2" Spacing="4">
                                     <TextBlock Text="{loc:Loc 'New Stock'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <TextBlock Text="{Binding ViewingAdjustment.NewStock}"
+                                    <TextBlock Text="{Binding NewStock}"
                                                FontSize="20" FontWeight="SemiBold"
                                                Foreground="{DynamicResource TextPrimaryBrush}" />
                                 </StackPanel>
@@ -253,10 +254,10 @@
                             <StackPanel Spacing="4">
                                 <TextBlock Text="{loc:Loc 'Date &amp; Time'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <TextBlock Text="{Binding ViewingAdjustment.DateDisplay}"
+                                    <TextBlock Text="{Binding DateDisplay}"
                                                FontSize="14"
                                                Foreground="{DynamicResource TextPrimaryBrush}" />
-                                    <TextBlock Text="{Binding ViewingAdjustment.TimeDisplay}"
+                                    <TextBlock Text="{Binding TimeDisplay}"
                                                FontSize="14"
                                                Foreground="{DynamicResource TextSecondaryBrush}" />
                                 </StackPanel>
@@ -265,7 +266,7 @@
                             <!-- Reason -->
                             <StackPanel Spacing="4">
                                 <TextBlock Text="{loc:Loc Reason}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                <TextBlock Text="{Binding ViewingAdjustment.Reason}"
+                                <TextBlock Text="{Binding Reason}"
                                            FontSize="14"
                                            Foreground="{DynamicResource TextPrimaryBrush}"
                                            TextWrapping="Wrap" />
@@ -275,7 +276,7 @@
 
                     <!-- Modal Footer -->
                     <Border Grid.Row="2" Padding="24,16" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">
-                        <Button Classes="secondary-button" Content="{loc:Loc Close}" Command="{Binding CloseViewModalCommand}" HorizontalAlignment="Right" />
+                        <Button Classes="secondary-button" Content="{loc:Loc Close}" Command="{Binding $parent[UserControl].DataContext.CloseViewModalCommand}" HorizontalAlignment="Right" />
                     </Border>
                 </Grid>
                 </Border>

--- a/ArgoBooks/Services/ReportUndoRedoManager.cs
+++ b/ArgoBooks/Services/ReportUndoRedoManager.cs
@@ -251,22 +251,31 @@ public class AddElementAction(ReportConfiguration config, ReportElementBase elem
 /// <summary>
 /// Action for removing an element.
 /// </summary>
-public class RemoveElementAction(ReportConfiguration config, ReportElementBase element) : IReportUndoableAction
+public class RemoveElementAction : IReportUndoableAction
 {
-    private readonly ReportElementBase _element = element.Clone();
-    private readonly int _originalZOrder = element.ZOrder;
+    private readonly ReportConfiguration _config;
+    private readonly ReportElementBase _element;
+    private readonly int _originalZOrder;
+
+    public RemoveElementAction(ReportConfiguration config, ReportElementBase element)
+    {
+        _config = config;
+        _element = element.Clone();
+        _element.Id = element.Id; // Preserve original ID so undo/redo pairs stay consistent
+        _originalZOrder = element.ZOrder;
+    }
 
     public string Description => "Remove {0}".TranslateFormat(_element.DisplayName);
 
     public void Undo()
     {
         _element.ZOrder = _originalZOrder;
-        config.AddElement(_element);
+        _config.AddElement(_element);
     }
 
     public void Redo()
     {
-        config.RemoveElement(_element.Id);
+        _config.RemoveElement(_element.Id);
     }
 }
 

--- a/ArgoBooks/ViewModels/LoginModalViewModel.cs
+++ b/ArgoBooks/ViewModels/LoginModalViewModel.cs
@@ -83,7 +83,7 @@ public partial class LoginModalViewModel : ViewModelBase
         AccountName = account.Name;
         AccountDescription = account.Description;
         AccountInitials = account.Initials;
-        AccountColor = Color.Parse(account.Color);
+        AccountColor = account.Color;
         Password = string.Empty;
         ErrorMessage = string.Empty;
         HasError = false;

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -520,6 +520,11 @@ public partial class ReportsPageViewModel : ViewModelBase
             if (e.PropertyName is "ZOrder" or "Bounds")
                 return;
 
+            // Skip no-op changes (can happen during binding round-trips, e.g. when
+            // NumericUpDown writes back the same value it just received)
+            if (Equals(e.OldValue, e.NewValue))
+                return;
+
             // For position/size changes, create a coalescing move/resize action.
             // Rapid changes (e.g., scrolling spinner controls) will be merged into
             // a single undo entry by the undo manager's coalescing logic.
@@ -563,18 +568,28 @@ public partial class ReportsPageViewModel : ViewModelBase
         }
     }
 
-    // Typed accessors for element-specific properties
-    public ChartReportElement? SelectedChartElement => SelectedElement as ChartReportElement;
-    public LabelReportElement? SelectedLabelElement => SelectedElement as LabelReportElement;
-    public ImageReportElement? SelectedImageElement => SelectedElement as ImageReportElement;
+    // Static empty instances to prevent null-traversal binding errors when no element is selected.
+    // These are never added to Configuration, so PropertyChanging subscriptions won't fire on them.
+    private static readonly ChartReportElement EmptyChart = new();
+    private static readonly LabelReportElement EmptyLabel = new();
+    private static readonly ImageReportElement EmptyImage = new();
+    private static readonly TableReportElement EmptyTable = new();
+    private static readonly DateRangeReportElement EmptyDateRange = new();
+    private static readonly SummaryReportElement EmptySummary = new();
+    private static readonly AccountingTableReportElement EmptyAccountingTable = new();
+
+    // Typed accessors for element-specific properties (never null to avoid binding errors)
+    public ChartReportElement SelectedChartElement => (SelectedElement as ChartReportElement) ?? EmptyChart;
+    public LabelReportElement SelectedLabelElement => (SelectedElement as LabelReportElement) ?? EmptyLabel;
+    public ImageReportElement SelectedImageElement => (SelectedElement as ImageReportElement) ?? EmptyImage;
     public string SelectedImageFileName => string.IsNullOrEmpty(SelectedImageElement?.ImagePath)
         ? string.Empty
         : Path.GetFileName(SelectedImageElement.ImagePath);
     public bool HasSelectedImage => !string.IsNullOrEmpty(SelectedImageElement?.ImagePath);
-    public TableReportElement? SelectedTableElement => SelectedElement as TableReportElement;
-    public DateRangeReportElement? SelectedDateRangeElement => SelectedElement as DateRangeReportElement;
-    public SummaryReportElement? SelectedSummaryElement => SelectedElement as SummaryReportElement;
-    public AccountingTableReportElement? SelectedAccountingTableElement => SelectedElement as AccountingTableReportElement;
+    public TableReportElement SelectedTableElement => (SelectedElement as TableReportElement) ?? EmptyTable;
+    public DateRangeReportElement SelectedDateRangeElement => (SelectedElement as DateRangeReportElement) ?? EmptyDateRange;
+    public SummaryReportElement SelectedSummaryElement => (SelectedElement as SummaryReportElement) ?? EmptySummary;
+    public AccountingTableReportElement SelectedAccountingTableElement => (SelectedElement as AccountingTableReportElement) ?? EmptyAccountingTable;
 
     /// <summary>
     /// Gets or sets the selected chart style as a ChartStyleOption for the ComboBox binding.
@@ -1042,11 +1057,23 @@ public partial class ReportsPageViewModel : ViewModelBase
         element.PageNumber = pageNumber;
         Configuration.AddElement(element);
         UndoRedoManager.RecordAction(new AddElementAction(Configuration, element));
-        SelectedElement = element;
-        SelectedElements.Clear();
-        SelectedElements.Add(element);
-        NotifySelectionChanged();
-        OnPropertyChanged(nameof(Configuration));
+
+        // Suppress recording while setting up selection — binding updates from the
+        // properties panel can write back rounded values (e.g. the NumericUpDown
+        // integer display format) which would create a spurious "Move element" action.
+        UndoRedoManager.SuppressRecording = true;
+        try
+        {
+            SelectedElement = element;
+            SelectedElements.Clear();
+            SelectedElements.Add(element);
+            NotifySelectionChanged();
+            OnPropertyChanged(nameof(Configuration));
+        }
+        finally
+        {
+            UndoRedoManager.SuppressRecording = false;
+        }
     }
 
     [RelayCommand]
@@ -1086,15 +1113,24 @@ public partial class ReportsPageViewModel : ViewModelBase
             newElements.Add(clone);
         }
 
-        // Select the duplicated elements
-        SelectedElements.Clear();
-        foreach (var element in newElements)
+        // Select the duplicated elements — suppress recording to avoid spurious
+        // undo entries from binding write-backs during selection setup.
+        UndoRedoManager.SuppressRecording = true;
+        try
         {
-            SelectedElements.Add(element);
+            SelectedElements.Clear();
+            foreach (var element in newElements)
+            {
+                SelectedElements.Add(element);
+            }
+            SelectedElement = newElements.FirstOrDefault();
+            NotifySelectionChanged();
+            OnPropertyChanged(nameof(Configuration));
         }
-        SelectedElement = newElements.FirstOrDefault();
-        NotifySelectionChanged();
-        OnPropertyChanged(nameof(Configuration));
+        finally
+        {
+            UndoRedoManager.SuppressRecording = false;
+        }
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/SwitchAccountModalViewModel.cs
+++ b/ArgoBooks/ViewModels/SwitchAccountModalViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Utilities;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -23,7 +24,7 @@ public partial class AccountItem : ObservableObject
     private string _initials = string.Empty;
 
     [ObservableProperty]
-    private string _color = "#3B82F6";
+    private Color _color = Color.Parse("#3B82F6");
 
     [ObservableProperty]
     private bool _isSelected;
@@ -65,7 +66,7 @@ public partial class SwitchAccountModalViewModel : ViewModelBase
             Name = "Acme Corporation",
             Description = "Main business account",
             Initials = "AC",
-            Color = "#3B82F6",
+            Color = Color.Parse("#3B82F6"),
             IsCurrent = true
         });
         _allAccounts.Add(new AccountItem
@@ -74,7 +75,7 @@ public partial class SwitchAccountModalViewModel : ViewModelBase
             Name = "Smith Consulting LLC",
             Description = "Consulting services",
             Initials = "SC",
-            Color = "#10B981"
+            Color = Color.Parse("#10B981")
         });
         _allAccounts.Add(new AccountItem
         {
@@ -82,7 +83,7 @@ public partial class SwitchAccountModalViewModel : ViewModelBase
             Name = "Personal Finances",
             Description = "Personal accounting",
             Initials = "PF",
-            Color = "#8B5CF6"
+            Color = Color.Parse("#8B5CF6")
         });
         _allAccounts.Add(new AccountItem
         {
@@ -90,7 +91,7 @@ public partial class SwitchAccountModalViewModel : ViewModelBase
             Name = "Johnson & Partners",
             Description = "Investment portfolio",
             Initials = "JP",
-            Color = "#F97316"
+            Color = Color.Parse("#F97316")
         });
 
         RefreshFilteredAccounts();

--- a/ArgoBooks/Views/MainWindow.axaml
+++ b/ArgoBooks/Views/MainWindow.axaml
@@ -92,9 +92,9 @@
         </DockPanel>
 
         <!-- Welcome Screen (full-screen overlay when no company is open) -->
-        <views:WelcomeScreen DataContext="{Binding WelcomeScreenViewModel}"
-                             IsVisible="{Binding $parent[Window].((vm:MainWindowViewModel)DataContext).ShowWelcomeScreen}"
-                             ZIndex="150" />
+        <Panel IsVisible="{Binding ShowWelcomeScreen}" ZIndex="150">
+            <views:WelcomeScreen DataContext="{Binding WelcomeScreenViewModel}" />
+        </Panel>
 
         <!-- Password Prompt Modal (above WelcomeScreen so it can be shown when opening encrypted files) -->
         <modals:PasswordPromptModal DataContext="{Binding PasswordPromptModalViewModel}"

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -16,6 +16,7 @@
 
     <UserControl.Resources>
         <converters:EqualConverter x:Key="EqualConverter" />
+        <converters:EqualityConverter x:Key="EqualityConverter" />
         <converters:EnumDisplayNameConverter x:Key="EnumDisplayNameConverter" />
         <converters:TransactionTypeSupportsReturnsConverter x:Key="TransactionTypeSupportsReturnsConverter" />
     </UserControl.Resources>
@@ -1027,22 +1028,23 @@
                                            FontWeight="Medium"
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
 
-                                <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,8,Auto">
+                                <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,8,Auto"
+                                      DataContext="{Binding SelectedElement}" x:CompileBindings="False">
                                     <StackPanel Grid.Column="0" Grid.Row="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'X'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedElement.X}" Minimum="0" />
+                                        <controls:ArgoNumericUpDown Value="{Binding X}" Minimum="0" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" Grid.Row="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Y'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedElement.Y}" Minimum="0" />
+                                        <controls:ArgoNumericUpDown Value="{Binding Y}" Minimum="0" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="0" Grid.Row="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Width'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedElement.Width}" Minimum="20" />
+                                        <controls:ArgoNumericUpDown Value="{Binding Width}" Minimum="20" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" Grid.Row="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Height'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedElement.Height}" Minimum="20" />
+                                        <controls:ArgoNumericUpDown Value="{Binding Height}" Minimum="20" />
                                     </StackPanel>
                                 </Grid>
                             </StackPanel>
@@ -1064,43 +1066,43 @@
                                               SelectedItem="{Binding SelectedChartStyleOption}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
-                                <CheckBox Content="{loc:Loc 'Show Title'}" IsChecked="{Binding SelectedChartElement.ShowTitle}" />
-                                <CheckBox Content="{loc:Loc 'Show Legend'}" IsChecked="{Binding SelectedChartElement.ShowLegend}" IsVisible="{Binding IsDistributionChartSelected}" />
+                                <CheckBox Content="{loc:Loc 'Show Title'}" IsChecked="{Binding SelectedChartElement.ShowTitle, FallbackValue=False}" />
+                                <CheckBox Content="{loc:Loc 'Show Legend'}" IsChecked="{Binding SelectedChartElement.ShowLegend, FallbackValue=False}" IsVisible="{Binding IsDistributionChartSelected}" />
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Title Font'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding FontFamilies}"
-                                              SelectedItem="{Binding SelectedChartElement.TitleFontFamily}"
+                                              SelectedItem="{Binding SelectedChartElement.TitleFontFamily, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
                                 <StackPanel Spacing="4" IsVisible="{Binding !IsDistributionChartSelected}">
                                     <TextBlock Text="{loc:Loc 'Axis Font'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding FontFamilies}"
-                                              SelectedItem="{Binding SelectedChartElement.FontFamily}"
+                                              SelectedItem="{Binding SelectedChartElement.FontFamily, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Title Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.TitleFontSize}" Minimum="6" Maximum="36" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.TitleFontSize, FallbackValue=0}" Minimum="6" Maximum="36" />
                                 </StackPanel>
                                 <StackPanel Spacing="4" IsVisible="{Binding !IsDistributionChartSelected}">
                                     <TextBlock Text="{loc:Loc 'Axis Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.AxisFontSize}" Minimum="6" Maximum="24" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.AxisFontSize, FallbackValue=0}" Minimum="6" Maximum="24" />
                                 </StackPanel>
                                 <StackPanel Spacing="4" IsVisible="{Binding IsDistributionChartSelected}">
                                     <TextBlock Text="{loc:Loc 'Legend Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.LegendFontSize}" Minimum="6" Maximum="24" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.LegendFontSize, FallbackValue=0}" Minimum="6" Maximum="24" />
                                 </StackPanel>
                                 <StackPanel Spacing="4" IsVisible="{Binding IsDistributionChartSelected}">
                                     <TextBlock Text="{loc:Loc 'Legend Max Characters'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.LegendMaxCharacters}" Minimum="5" Maximum="50" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.LegendMaxCharacters, FallbackValue=0}" Minimum="5" Maximum="50" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Border Color'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedChartElement.BorderColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedChartElement.BorderColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Border Thickness'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.BorderThickness}" Minimum="0" Maximum="10" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedChartElement.BorderThickness, FallbackValue=0}" Minimum="0" Maximum="10" />
                                 </StackPanel>
                             </StackPanel>
 
@@ -1112,38 +1114,38 @@
                                            Foreground="{DynamicResource TextSecondaryBrush}" />
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Text'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <TextBox Text="{Binding SelectedLabelElement.Text}" />
+                                    <TextBox Text="{Binding SelectedLabelElement.Text, FallbackValue=''}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Font Family'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding FontFamilies}"
-                                              SelectedItem="{Binding SelectedLabelElement.FontFamily}"
+                                              SelectedItem="{Binding SelectedLabelElement.FontFamily, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Font Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedLabelElement.FontSize}" Minimum="6" Maximum="72" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedLabelElement.FontSize, FallbackValue=0}" Minimum="6" Maximum="72" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Text Color'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedLabelElement.TextColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedLabelElement.TextColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Spacing="16">
-                                    <CheckBox Content="{loc:Loc 'Bold'}" IsChecked="{Binding SelectedLabelElement.IsBold}" />
-                                    <CheckBox Content="{loc:Loc 'Italic'}" IsChecked="{Binding SelectedLabelElement.IsItalic}" />
-                                    <CheckBox Content="{loc:Loc 'Underline'}" IsChecked="{Binding SelectedLabelElement.IsUnderline}" />
+                                    <CheckBox Content="{loc:Loc 'Bold'}" IsChecked="{Binding SelectedLabelElement.IsBold, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Italic'}" IsChecked="{Binding SelectedLabelElement.IsItalic, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Underline'}" IsChecked="{Binding SelectedLabelElement.IsUnderline, FallbackValue=False}" />
                                 </StackPanel>
                                 <Grid ColumnDefinitions="*,8,*">
                                     <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'H Align'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding HorizontalAlignments}"
-                                                  SelectedItem="{Binding SelectedLabelElement.HorizontalAlignment}"
+                                                  SelectedItem="{Binding SelectedLabelElement.HorizontalAlignment, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'V Align'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding VerticalAlignments}"
-                                                  SelectedItem="{Binding SelectedLabelElement.VerticalAlignment}"
+                                                  SelectedItem="{Binding SelectedLabelElement.VerticalAlignment, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                 </Grid>
@@ -1184,7 +1186,7 @@
                                                    Foreground="{DynamicResource TextPrimaryBrush}"
                                                    TextTrimming="CharacterEllipsis"
                                                    VerticalAlignment="Center"
-                                                   ToolTip.Tip="{Binding SelectedImageElement.ImagePath}" />
+                                                   ToolTip.Tip="{Binding SelectedImageElement.ImagePath, FallbackValue=''}" />
                                     </Grid>
                                     <StackPanel Orientation="Horizontal" Spacing="8">
                                         <Button Classes="secondary-button"
@@ -1200,18 +1202,18 @@
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Scale Mode'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding ImageScaleModes}"
-                                              SelectedItem="{Binding SelectedImageElement.ScaleMode}"
+                                              SelectedItem="{Binding SelectedImageElement.ScaleMode, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Opacity (%)'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <Grid ColumnDefinitions="*,Auto">
                                         <Slider Grid.Column="0"
-                                                Value="{Binding SelectedImageElement.Opacity}"
+                                                Value="{Binding SelectedImageElement.Opacity, FallbackValue=0}"
                                                 Minimum="0" Maximum="100"
                                                 VerticalAlignment="Center" />
                                         <TextBox Grid.Column="1"
-                                                 Text="{Binding SelectedImageElement.Opacity}"
+                                                 Text="{Binding SelectedImageElement.Opacity, FallbackValue=''}"
                                                  Width="50"
                                                  Margin="8,0,0,0"
                                                  VerticalAlignment="Center" />
@@ -1219,19 +1221,19 @@
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Corner Radius (%)'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedImageElement.CornerRadiusPercent}" Minimum="0" Maximum="50" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedImageElement.CornerRadiusPercent, FallbackValue=0}" Minimum="0" Maximum="50" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Background Color'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedImageElement.BackgroundColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedImageElement.BackgroundColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Border Color'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedImageElement.BorderColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedImageElement.BorderColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Border Thickness'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedImageElement.BorderThickness}" Minimum="0" Maximum="20" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedImageElement.BorderThickness, FallbackValue=0}" Minimum="0" Maximum="20" />
                                 </StackPanel>
                             </StackPanel>
 
@@ -1244,39 +1246,39 @@
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Date Format'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding DateFormats}"
-                                              SelectedItem="{Binding SelectedDateRangeElement.DateFormat}"
+                                              SelectedItem="{Binding SelectedDateRangeElement.DateFormat, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Font Family'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding FontFamilies}"
-                                              SelectedItem="{Binding SelectedDateRangeElement.FontFamily}"
+                                              SelectedItem="{Binding SelectedDateRangeElement.FontFamily, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Font Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedDateRangeElement.FontSize}" Minimum="6" Maximum="72" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedDateRangeElement.FontSize, FallbackValue=0}" Minimum="6" Maximum="72" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Text Color'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedDateRangeElement.TextColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedDateRangeElement.TextColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Orientation="Horizontal" Spacing="16">
-                                    <CheckBox Content="{loc:Loc 'Bold'}" IsChecked="{Binding SelectedDateRangeElement.IsBold}" />
-                                    <CheckBox Content="{loc:Loc 'Italic'}" IsChecked="{Binding SelectedDateRangeElement.IsItalic}" />
-                                    <CheckBox Content="{loc:Loc 'Underline'}" IsChecked="{Binding SelectedDateRangeElement.IsUnderline}" />
+                                    <CheckBox Content="{loc:Loc 'Bold'}" IsChecked="{Binding SelectedDateRangeElement.IsBold, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Italic'}" IsChecked="{Binding SelectedDateRangeElement.IsItalic, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Underline'}" IsChecked="{Binding SelectedDateRangeElement.IsUnderline, FallbackValue=False}" />
                                 </StackPanel>
                                 <Grid ColumnDefinitions="*,8,*">
                                     <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'H Align'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding HorizontalAlignments}"
-                                                  SelectedItem="{Binding SelectedDateRangeElement.HorizontalAlignment}"
+                                                  SelectedItem="{Binding SelectedDateRangeElement.HorizontalAlignment, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'V Align'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding VerticalAlignments}"
-                                                  SelectedItem="{Binding SelectedDateRangeElement.VerticalAlignment}"
+                                                  SelectedItem="{Binding SelectedDateRangeElement.VerticalAlignment, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                 </Grid>
@@ -1291,7 +1293,7 @@
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Transaction Type'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding TransactionTypes}"
-                                              SelectedItem="{Binding SelectedSummaryElement.TransactionType}"
+                                              SelectedItem="{Binding SelectedSummaryElement.TransactionType, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch">
                                         <ComboBox.ItemTemplate>
                                             <DataTemplate>
@@ -1300,14 +1302,14 @@
                                         </ComboBox.ItemTemplate>
                                     </ComboBox>
                                 </StackPanel>
-                                <CheckBox Content="{loc:Loc 'Show Total Revenue'}" IsChecked="{Binding SelectedSummaryElement.ShowTotalRevenue}" />
-                                <CheckBox Content="{loc:Loc 'Show Total Transactions'}" IsChecked="{Binding SelectedSummaryElement.ShowTotalTransactions}" />
-                                <CheckBox Content="{loc:Loc 'Show Average Value'}" IsChecked="{Binding SelectedSummaryElement.ShowAverageValue}" />
-                                <CheckBox Content="{loc:Loc 'Show Growth Rate'}" IsChecked="{Binding SelectedSummaryElement.ShowGrowthRate}" />
-                                <CheckBox Content="{loc:Loc 'Include Returns'}" IsChecked="{Binding SelectedSummaryElement.IncludeReturns}"
-                                          IsVisible="{Binding SelectedSummaryElement.TransactionType, Converter={StaticResource TransactionTypeSupportsReturnsConverter}}" />
-                                <CheckBox Content="{loc:Loc 'Include Losses'}" IsChecked="{Binding SelectedSummaryElement.IncludeLosses}"
-                                          IsVisible="{Binding SelectedSummaryElement.TransactionType, Converter={StaticResource TransactionTypeSupportsReturnsConverter}}" />
+                                <CheckBox Content="{loc:Loc 'Show Total Revenue'}" IsChecked="{Binding SelectedSummaryElement.ShowTotalRevenue, FallbackValue=False}" />
+                                <CheckBox Content="{loc:Loc 'Show Total Transactions'}" IsChecked="{Binding SelectedSummaryElement.ShowTotalTransactions, FallbackValue=False}" />
+                                <CheckBox Content="{loc:Loc 'Show Average Value'}" IsChecked="{Binding SelectedSummaryElement.ShowAverageValue, FallbackValue=False}" />
+                                <CheckBox Content="{loc:Loc 'Show Growth Rate'}" IsChecked="{Binding SelectedSummaryElement.ShowGrowthRate, FallbackValue=False}" />
+                                <CheckBox Content="{loc:Loc 'Include Returns'}" IsChecked="{Binding SelectedSummaryElement.IncludeReturns, FallbackValue=False}"
+                                          IsVisible="{Binding SelectedSummaryElement.TransactionType, Converter={StaticResource TransactionTypeSupportsReturnsConverter}, FallbackValue=False}" />
+                                <CheckBox Content="{loc:Loc 'Include Losses'}" IsChecked="{Binding SelectedSummaryElement.IncludeLosses, FallbackValue=False}"
+                                          IsVisible="{Binding SelectedSummaryElement.TransactionType, Converter={StaticResource TransactionTypeSupportsReturnsConverter}, FallbackValue=False}" />
 
                                 <TextBlock Text="{loc:Loc 'Formatting'}"
                                            FontSize="12"
@@ -1317,36 +1319,36 @@
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Font Family'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding FontFamilies}"
-                                              SelectedItem="{Binding SelectedSummaryElement.FontFamily}"
+                                              SelectedItem="{Binding SelectedSummaryElement.FontFamily, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Font Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedSummaryElement.FontSize}" Minimum="6" Maximum="24" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedSummaryElement.FontSize, FallbackValue=0}" Minimum="6" Maximum="24" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Background Color'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedSummaryElement.BackgroundColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedSummaryElement.BackgroundColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Border Color'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedSummaryElement.BorderColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedSummaryElement.BorderColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Border Thickness'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ArgoNumericUpDown Value="{Binding SelectedSummaryElement.BorderThickness}" Minimum="0" Maximum="10" />
+                                    <controls:ArgoNumericUpDown Value="{Binding SelectedSummaryElement.BorderThickness, FallbackValue=0}" Minimum="0" Maximum="10" />
                                 </StackPanel>
                                 <Grid ColumnDefinitions="*,8,*">
                                     <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'H Align'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding HorizontalAlignments}"
-                                                  SelectedItem="{Binding SelectedSummaryElement.HorizontalAlignment}"
+                                                  SelectedItem="{Binding SelectedSummaryElement.HorizontalAlignment, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'V Align'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding VerticalAlignments}"
-                                                  SelectedItem="{Binding SelectedSummaryElement.VerticalAlignment}"
+                                                  SelectedItem="{Binding SelectedSummaryElement.VerticalAlignment, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                 </Grid>
@@ -1389,7 +1391,7 @@
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Transaction Type'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding TransactionTypes}"
-                                                  SelectedItem="{Binding SelectedTableElement.TransactionType}"
+                                                  SelectedItem="{Binding SelectedTableElement.TransactionType, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch">
                                             <ComboBox.ItemTemplate>
                                                 <DataTemplate>
@@ -1398,14 +1400,14 @@
                                             </ComboBox.ItemTemplate>
                                         </ComboBox>
                                     </StackPanel>
-                                    <CheckBox Content="{loc:Loc 'Include Returns'}" IsChecked="{Binding SelectedTableElement.IncludeReturns}"
-                                              IsVisible="{Binding SelectedTableElement.TransactionType, Converter={StaticResource TransactionTypeSupportsReturnsConverter}}" />
-                                    <CheckBox Content="{loc:Loc 'Include Losses'}" IsChecked="{Binding SelectedTableElement.IncludeLosses}"
-                                              IsVisible="{Binding SelectedTableElement.TransactionType, Converter={StaticResource TransactionTypeSupportsReturnsConverter}}" />
+                                    <CheckBox Content="{loc:Loc 'Include Returns'}" IsChecked="{Binding SelectedTableElement.IncludeReturns, FallbackValue=False}"
+                                              IsVisible="{Binding SelectedTableElement.TransactionType, Converter={StaticResource TransactionTypeSupportsReturnsConverter}, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Include Losses'}" IsChecked="{Binding SelectedTableElement.IncludeLosses, FallbackValue=False}"
+                                              IsVisible="{Binding SelectedTableElement.TransactionType, Converter={StaticResource TransactionTypeSupportsReturnsConverter}, FallbackValue=False}" />
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Sort Order'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding TableSortOrders}"
-                                                  SelectedItem="{Binding SelectedTableElement.SortOrder}"
+                                                  SelectedItem="{Binding SelectedTableElement.SortOrder, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch">
                                             <ComboBox.ItemTemplate>
                                                 <DataTemplate>
@@ -1416,7 +1418,7 @@
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Max Rows'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.MaxRows}" Minimum="1" Maximum="50" />
+                                        <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.MaxRows, FallbackValue=0}" Minimum="1" Maximum="50" />
                                     </StackPanel>
                                 </StackPanel>
 
@@ -1426,12 +1428,12 @@
                                                FontSize="11"
                                                FontWeight="Medium"
                                                Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <CheckBox Content="{loc:Loc 'Show Title'}" IsChecked="{Binding SelectedTableElement.ShowTitle}" />
-                                    <CheckBox Content="{loc:Loc 'Show Headers'}" IsChecked="{Binding SelectedTableElement.ShowHeaders}" />
-                                    <CheckBox Content="{loc:Loc 'Show Grid Lines'}" IsChecked="{Binding SelectedTableElement.ShowGridLines}" />
-                                    <CheckBox Content="{loc:Loc 'Show Totals Row'}" IsChecked="{Binding SelectedTableElement.ShowTotalsRow}" />
-                                    <CheckBox Content="{loc:Loc 'Alternate Row Colors'}" IsChecked="{Binding SelectedTableElement.AlternateRowColors}" />
-                                    <CheckBox Content="{loc:Loc 'Auto Size Columns'}" IsChecked="{Binding SelectedTableElement.AutoSizeColumns}" />
+                                    <CheckBox Content="{loc:Loc 'Show Title'}" IsChecked="{Binding SelectedTableElement.ShowTitle, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Show Headers'}" IsChecked="{Binding SelectedTableElement.ShowHeaders, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Show Grid Lines'}" IsChecked="{Binding SelectedTableElement.ShowGridLines, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Show Totals Row'}" IsChecked="{Binding SelectedTableElement.ShowTotalsRow, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Alternate Row Colors'}" IsChecked="{Binding SelectedTableElement.AlternateRowColors, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Auto Size Columns'}" IsChecked="{Binding SelectedTableElement.AutoSizeColumns, FallbackValue=False}" />
 
                                     <TextBlock Text="{loc:Loc 'Text Alignment'}"
                                                FontSize="11"
@@ -1439,7 +1441,7 @@
                                                Foreground="{DynamicResource TextTertiaryBrush}"
                                                Margin="0,8,0,0" />
                                     <ComboBox ItemsSource="{Binding HorizontalAlignments}"
-                                              SelectedItem="{Binding SelectedTableElement.TextAlignment}"
+                                              SelectedItem="{Binding SelectedTableElement.TextAlignment, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch" />
 
                                     <TextBlock Text="{loc:Loc 'Title'}"
@@ -1450,12 +1452,12 @@
                                     <Grid ColumnDefinitions="*,8,*">
                                         <StackPanel Grid.Column="0" Spacing="4">
                                             <TextBlock Text="{loc:Loc 'Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.TitleFontSize}" Minimum="6" Maximum="24" />
+                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.TitleFontSize, FallbackValue=0}" Minimum="6" Maximum="24" />
                                         </StackPanel>
                                         <StackPanel Grid.Column="2" Spacing="4">
                                             <TextBlock Text="{loc:Loc 'Family'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                             <ComboBox ItemsSource="{Binding FontFamilies}"
-                                                      SelectedItem="{Binding SelectedTableElement.TitleFontFamily}"
+                                                      SelectedItem="{Binding SelectedTableElement.TitleFontFamily, FallbackValue={x:Null}}"
                                                       HorizontalAlignment="Stretch" />
                                         </StackPanel>
                                     </Grid>
@@ -1468,12 +1470,12 @@
                                     <Grid ColumnDefinitions="*,8,*">
                                         <StackPanel Grid.Column="0" Spacing="4">
                                             <TextBlock Text="{loc:Loc 'Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.HeaderFontSize}" Minimum="6" Maximum="24" />
+                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.HeaderFontSize, FallbackValue=0}" Minimum="6" Maximum="24" />
                                         </StackPanel>
                                         <StackPanel Grid.Column="2" Spacing="4">
                                             <TextBlock Text="{loc:Loc 'Family'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                             <ComboBox ItemsSource="{Binding FontFamilies}"
-                                                      SelectedItem="{Binding SelectedTableElement.HeaderFontFamily}"
+                                                      SelectedItem="{Binding SelectedTableElement.HeaderFontFamily, FallbackValue={x:Null}}"
                                                       HorizontalAlignment="Stretch" />
                                         </StackPanel>
                                     </Grid>
@@ -1486,12 +1488,12 @@
                                     <Grid ColumnDefinitions="*,8,*">
                                         <StackPanel Grid.Column="0" Spacing="4">
                                             <TextBlock Text="{loc:Loc 'Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.FontSize}" Minimum="6" Maximum="24" />
+                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.FontSize, FallbackValue=0}" Minimum="6" Maximum="24" />
                                         </StackPanel>
                                         <StackPanel Grid.Column="2" Spacing="4">
                                             <TextBlock Text="{loc:Loc 'Family'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                             <ComboBox ItemsSource="{Binding FontFamilies}"
-                                                      SelectedItem="{Binding SelectedTableElement.FontFamily}"
+                                                      SelectedItem="{Binding SelectedTableElement.FontFamily, FallbackValue={x:Null}}"
                                                       HorizontalAlignment="Stretch" />
                                         </StackPanel>
                                     </Grid>
@@ -1504,16 +1506,16 @@
                                     <Grid ColumnDefinitions="*,8,*">
                                         <StackPanel Grid.Column="0" Spacing="4">
                                             <TextBlock Text="{loc:Loc 'Header'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.HeaderRowHeight}" Minimum="16" Maximum="50" />
+                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.HeaderRowHeight, FallbackValue=0}" Minimum="16" Maximum="50" />
                                         </StackPanel>
                                         <StackPanel Grid.Column="2" Spacing="4">
                                             <TextBlock Text="{loc:Loc 'Data'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.DataRowHeight}" Minimum="16" Maximum="50" />
+                                            <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.DataRowHeight, FallbackValue=0}" Minimum="16" Maximum="50" />
                                         </StackPanel>
                                     </Grid>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Cell Padding'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.CellPadding}" Minimum="0" Maximum="20" />
+                                        <controls:ArgoNumericUpDown Value="{Binding SelectedTableElement.CellPadding, FallbackValue=0}" Minimum="0" Maximum="20" />
                                     </StackPanel>
 
                                     <TextBlock Text="{loc:Loc 'Colors'}"
@@ -1523,47 +1525,47 @@
                                                Margin="0,8,0,0" />
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Title BG'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.TitleBackgroundColor, Mode=TwoWay}" />
+                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.TitleBackgroundColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Title Text'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.TitleTextColor, Mode=TwoWay}" />
+                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.TitleTextColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Header BG'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.HeaderBackgroundColor, Mode=TwoWay}" />
+                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.HeaderBackgroundColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Header Text'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.HeaderTextColor, Mode=TwoWay}" />
+                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.HeaderTextColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Row Text'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.DataRowTextColor, Mode=TwoWay}" />
+                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.DataRowTextColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Grid Lines'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.GridLineColor, Mode=TwoWay}" />
+                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.GridLineColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Base Row'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.BaseRowColor, Mode=TwoWay}" />
+                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.BaseRowColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                     </StackPanel>
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Alt Row'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.AlternateRowColor, Mode=TwoWay}" />
+                                        <controls:ColorPickerInput ColorValue="{Binding SelectedTableElement.AlternateRowColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                     </StackPanel>
                                 </StackPanel>
 
                                 <!-- Columns Tab -->
                                 <StackPanel Spacing="8" IsVisible="{Binding TablePropertiesTabIndex, Converter={StaticResource EqualConverter}, ConverterParameter=2}">
-                                    <CheckBox Content="{loc:Loc 'Date'}" IsChecked="{Binding SelectedTableElement.ShowDateColumn}" />
-                                    <CheckBox Content="{loc:Loc 'Transaction ID'}" IsChecked="{Binding SelectedTableElement.ShowTransactionIdColumn}" />
-                                    <CheckBox Content="{loc:Loc 'Company'}" IsChecked="{Binding SelectedTableElement.ShowCompanyColumn}" />
-                                    <CheckBox Content="{loc:Loc 'Product'}" IsChecked="{Binding SelectedTableElement.ShowProductColumn}" />
-                                    <CheckBox Content="{loc:Loc 'Quantity'}" IsChecked="{Binding SelectedTableElement.ShowQuantityColumn}" />
-                                    <CheckBox Content="{loc:Loc 'Total'}" IsChecked="{Binding SelectedTableElement.ShowTotalColumn}" />
-                                    <CheckBox Content="{loc:Loc 'Status'}" IsChecked="{Binding SelectedTableElement.ShowStatusColumn}" />
+                                    <CheckBox Content="{loc:Loc 'Date'}" IsChecked="{Binding SelectedTableElement.ShowDateColumn, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Transaction ID'}" IsChecked="{Binding SelectedTableElement.ShowTransactionIdColumn, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Company'}" IsChecked="{Binding SelectedTableElement.ShowCompanyColumn, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Product'}" IsChecked="{Binding SelectedTableElement.ShowProductColumn, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Quantity'}" IsChecked="{Binding SelectedTableElement.ShowQuantityColumn, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Total'}" IsChecked="{Binding SelectedTableElement.ShowTotalColumn, FallbackValue=False}" />
+                                    <CheckBox Content="{loc:Loc 'Status'}" IsChecked="{Binding SelectedTableElement.ShowStatusColumn, FallbackValue=False}" />
                                 </StackPanel>
                             </StackPanel>
 
@@ -1577,7 +1579,7 @@
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Report Type'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                     <ComboBox ItemsSource="{Binding AccountingReportTypes}"
-                                              SelectedItem="{Binding SelectedAccountingTableElement.ReportType}"
+                                              SelectedItem="{Binding SelectedAccountingTableElement.ReportType, FallbackValue={x:Null}}"
                                               HorizontalAlignment="Stretch">
                                         <ComboBox.ItemTemplate>
                                             <DataTemplate>
@@ -1587,9 +1589,9 @@
                                     </ComboBox>
                                 </StackPanel>
 
-                                <CheckBox Content="{loc:Loc 'Show Company Header'}" IsChecked="{Binding SelectedAccountingTableElement.ShowCompanyHeader}" />
-                                <CheckBox Content="{loc:Loc 'Show Grid Lines'}" IsChecked="{Binding SelectedAccountingTableElement.ShowGridLines}" />
-                                <CheckBox Content="{loc:Loc 'Alternate Row Colors'}" IsChecked="{Binding SelectedAccountingTableElement.AlternateRowColors}" />
+                                <CheckBox Content="{loc:Loc 'Show Company Header'}" IsChecked="{Binding SelectedAccountingTableElement.ShowCompanyHeader, FallbackValue=False}" />
+                                <CheckBox Content="{loc:Loc 'Show Grid Lines'}" IsChecked="{Binding SelectedAccountingTableElement.ShowGridLines, FallbackValue=False}" />
+                                <CheckBox Content="{loc:Loc 'Alternate Row Colors'}" IsChecked="{Binding SelectedAccountingTableElement.AlternateRowColors, FallbackValue=False}" />
 
                                 <TextBlock Text="{loc:Loc 'Font'}"
                                            FontSize="11"
@@ -1599,12 +1601,12 @@
                                 <Grid ColumnDefinitions="*,8,*">
                                     <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Size'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedAccountingTableElement.FontSize}" Minimum="6" Maximum="24" />
+                                        <controls:ArgoNumericUpDown Value="{Binding SelectedAccountingTableElement.FontSize, FallbackValue=0}" Minimum="6" Maximum="24" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Family'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <ComboBox ItemsSource="{Binding FontFamilies}"
-                                                  SelectedItem="{Binding SelectedAccountingTableElement.FontFamily}"
+                                                  SelectedItem="{Binding SelectedAccountingTableElement.FontFamily, FallbackValue={x:Null}}"
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                 </Grid>
@@ -1617,11 +1619,11 @@
                                 <Grid ColumnDefinitions="*,8,*">
                                     <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Header'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedAccountingTableElement.HeaderRowHeight}" Minimum="16" Maximum="50" />
+                                        <controls:ArgoNumericUpDown Value="{Binding SelectedAccountingTableElement.HeaderRowHeight, FallbackValue=0}" Minimum="16" Maximum="50" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Data'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <controls:ArgoNumericUpDown Value="{Binding SelectedAccountingTableElement.DataRowHeight}" Minimum="16" Maximum="50" />
+                                        <controls:ArgoNumericUpDown Value="{Binding SelectedAccountingTableElement.DataRowHeight, FallbackValue=0}" Minimum="16" Maximum="50" />
                                     </StackPanel>
                                 </Grid>
 
@@ -1632,27 +1634,27 @@
                                            Margin="0,8,0,0" />
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Header BG'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.HeaderBackgroundColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.HeaderBackgroundColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Header Text'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.HeaderTextColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.HeaderTextColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Section Header BG'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.SectionHeaderBackgroundColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.SectionHeaderBackgroundColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Total BG'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.TotalBackgroundColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.TotalBackgroundColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Total Text'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.TotalTextColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.TotalTextColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                                 <StackPanel Spacing="4">
                                     <TextBlock Text="{loc:Loc 'Grid Lines'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.GridLineColor, Mode=TwoWay}" />
+                                    <controls:ColorPickerInput ColorValue="{Binding SelectedAccountingTableElement.GridLineColor, Mode=TwoWay, FallbackValue={x:Null}}" />
                                 </StackPanel>
                             </StackPanel>
 
@@ -1741,7 +1743,7 @@
 
                             <StackPanel Spacing="4">
                                 <RadioButton GroupName="ExportFormat"
-                                             IsChecked="{Binding SelectedExportFormat, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static enums:ExportFormat.PDF}}"
+                                             IsChecked="{Binding SelectedExportFormat, Converter={StaticResource EqualityConverter}, ConverterParameter={x:Static enums:ExportFormat.PDF}}"
                                              Command="{Binding SelectExportFormatCommand}"
                                              CommandParameter="{x:Static enums:ExportFormat.PDF}">
                                     <StackPanel>
@@ -1754,7 +1756,7 @@
                                     </StackPanel>
                                 </RadioButton>
                                 <RadioButton GroupName="ExportFormat"
-                                             IsChecked="{Binding SelectedExportFormat, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static enums:ExportFormat.PNG}}"
+                                             IsChecked="{Binding SelectedExportFormat, Converter={StaticResource EqualityConverter}, ConverterParameter={x:Static enums:ExportFormat.PNG}}"
                                              Command="{Binding SelectExportFormatCommand}"
                                              CommandParameter="{x:Static enums:ExportFormat.PNG}">
                                     <StackPanel>
@@ -1767,7 +1769,7 @@
                                     </StackPanel>
                                 </RadioButton>
                                 <RadioButton GroupName="ExportFormat"
-                                             IsChecked="{Binding SelectedExportFormat, Converter={x:Static ObjectConverters.Equal}, ConverterParameter={x:Static enums:ExportFormat.JPEG}}"
+                                             IsChecked="{Binding SelectedExportFormat, Converter={StaticResource EqualityConverter}, ConverterParameter={x:Static enums:ExportFormat.JPEG}}"
                                              Command="{Binding SelectExportFormatCommand}"
                                              CommandParameter="{x:Static enums:ExportFormat.JPEG}">
                                     <StackPanel>


### PR DESCRIPTION
## Summary
This PR addresses two interconnected issues in the Reports page and related modals:
1. **Null-reference binding errors** when no element is selected in the properties panel
2. **Spurious undo entries** created by binding write-backs during element selection setup

## Key Changes

### ReportsPageViewModel.cs
- **Empty singleton instances**: Added static empty instances (`EmptyChart`, `EmptyLabel`, `EmptyImage`, etc.) to prevent null-traversal binding errors when no element is selected
- **Non-nullable typed accessors**: Changed `SelectedChartElement`, `SelectedLabelElement`, etc. from nullable to always return a valid instance (either the actual element or an empty singleton)
- **No-op change detection**: Added check in `OnElementPropertyChanging` to skip recording undo actions when a property value doesn't actually change (fixes lossy round-trips from numeric formatting)
- **Suppressed recording during selection**: Wrapped element selection logic in `AddElement` and `DuplicateSelectedElements` with `UndoRedoManager.SuppressRecording` to prevent binding write-backs from creating spurious undo entries

### ReportsPage.axaml
- **DataContext optimization**: Set `DataContext="{Binding SelectedElement}"` on the position/size Grid to simplify bindings from `SelectedElement.X` to just `X`
- **FallbackValue additions**: Added `FallbackValue` parameters to all bindings for element properties (e.g., `FallbackValue=False` for checkboxes, `FallbackValue=0` for numeric inputs) to handle null gracefully
- **EqualityConverter registration**: Added missing converter resource registration

### ReportUndoRedoManager.cs
- **RemoveElementAction refactoring**: Converted from primary constructor to explicit constructor to properly preserve element ID during clone, ensuring undo/redo pairs stay consistent

### Modal XAML files (ReportModals.axaml, StockAdjustmentsModals.axaml, PurchaseOrdersModals.axaml)
- **DataContext restructuring**: Moved `DataContext` binding to `ModalOverlay` level and set `x:CompileBindings="False"` to simplify nested bindings in modal content
- **Binding simplification**: Removed redundant `DataContext` bindings from modal content controls, allowing them to inherit from parent

### ArgoNumericUpDown.axaml.cs
- **Lossy round-trip prevention**: Added check in `ParseAndSetValue` to skip value updates when the parsed text matches the formatted current value, preventing integer display format from creating spurious undo actions

### Supporting Changes
- **SwitchAccountModalViewModel.cs**: Changed `Color` property from string to `Avalonia.Media.Color` type
- **LoginModalViewModel.cs**: Updated color parsing to use `Color.Parse()`
- **MainWindow.axaml**: Simplified WelcomeScreen visibility binding
- **Unit tests**: Added regression tests for add/delete/undo/redo element cycles

## Implementation Details
The core issue was that binding updates during element selection would trigger property-changed events, which were recorded as undo actions even though they represented no actual user change. By:
1. Using empty singletons instead of nulls, bindings can safely traverse properties without errors
2. Detecting no-op changes before recording undo actions
3. Suppressing undo recording during programmatic selection setup
4. Preventing lossy numeric formatting round-trips

The solution maintains backward compatibility while eliminating the binding errors and spurious undo entries that occurred during normal element selection workflows.

https://claude.ai/code/session_017hynbWAgMYbk1UkTsaRJLf