### PR TITLE
Refactor date handling and use Id instead of ReferenceNumber

### DIFF
--- a/ArgoBooks.Core/Data/CompanyData.cs
+++ b/ArgoBooks.Core/Data/CompanyData.cs
@@ -245,8 +245,9 @@ public class CompanyData
     #region Helper Methods
 
     /// <summary>
-    /// Gets the earliest transaction date across all data (revenues, expenses, payments).
+    /// Gets the earliest transaction date across revenues, expenses, and payments only.
     /// Returns DateTime.Today if no transactions exist.
+    /// Prefer <see cref="GetEarliestDate"/> when you need the earliest date across all data.
     /// </summary>
     public DateTime GetEarliestTransactionDate()
     {
@@ -254,6 +255,25 @@ public class CompanyData
         if (Revenues.Count > 0) dates.Add(Revenues.Min(r => r.Date));
         if (Expenses.Count > 0) dates.Add(Expenses.Min(e => e.Date));
         if (Payments.Count > 0) dates.Add(Payments.Min(p => p.Date));
+
+        return dates.Count > 0 ? dates.Min() : DateTime.Today;
+    }
+
+    /// <summary>
+    /// Gets the earliest date across all dated collections (revenues, expenses, payments,
+    /// invoices, stock adjustments, purchase orders, and rental records).
+    /// Returns DateTime.Today if no dated records exist.
+    /// </summary>
+    public DateTime GetEarliestDate()
+    {
+        var dates = new List<DateTime>();
+        if (Revenues.Count > 0) dates.Add(Revenues.Min(r => r.Date));
+        if (Expenses.Count > 0) dates.Add(Expenses.Min(e => e.Date));
+        if (Payments.Count > 0) dates.Add(Payments.Min(p => p.Date));
+        if (Invoices.Count > 0) dates.Add(Invoices.Min(i => i.IssueDate));
+        if (StockAdjustments.Count > 0) dates.Add(StockAdjustments.Min(s => s.Timestamp));
+        if (PurchaseOrders.Count > 0) dates.Add(PurchaseOrders.Min(p => p.OrderDate));
+        if (Rentals.Count > 0) dates.Add(Rentals.Min(r => r.StartDate));
 
         return dates.Count > 0 ? dates.Min() : DateTime.Today;
     }

--- a/ArgoBooks.Core/Models/Transactions/Transaction.cs
+++ b/ArgoBooks.Core/Models/Transactions/Transaction.cs
@@ -93,7 +93,9 @@ public abstract class Transaction
     public decimal Total { get; set; }
 
     /// <summary>
-    /// Reference number (e.g., invoice number, receipt number).
+    /// External reference number imported from spreadsheets or payment portals.
+    /// This is an internal/system field used for data import/export round-tripping
+    /// and should not be displayed to users. Use <see cref="TransactionBase.Id"/> for display purposes.
     /// </summary>
     [JsonPropertyName("referenceNumber")]
     public string ReferenceNumber { get; set; } = string.Empty;

--- a/ArgoBooks.Core/Services/AccountingReportDataService.cs
+++ b/ArgoBooks.Core/Services/AccountingReportDataService.cs
@@ -973,7 +973,7 @@ public class AccountingReportDataService
                     {
                         Date = rev.Date,
                         Description = li.Description.Length > 0 ? li.Description : rev.Description,
-                        Reference = rev.ReferenceNumber,
+                        Reference = rev.Id,
                         Debit = 0,
                         Credit = li.Subtotal
                     });
@@ -985,7 +985,7 @@ public class AccountingReportDataService
                 {
                     Date = rev.Date,
                     Description = rev.Description,
-                    Reference = rev.ReferenceNumber,
+                    Reference = rev.Id,
                     Debit = 0,
                     Credit = rev.EffectiveSubtotalUSD
                 });
@@ -1004,7 +1004,7 @@ public class AccountingReportDataService
                     {
                         Date = exp.Date,
                         Description = li.Description.Length > 0 ? li.Description : exp.Description,
-                        Reference = exp.ReferenceNumber,
+                        Reference = exp.Id,
                         Debit = li.Subtotal,
                         Credit = 0
                     });
@@ -1016,7 +1016,7 @@ public class AccountingReportDataService
                 {
                     Date = exp.Date,
                     Description = exp.Description,
-                    Reference = exp.ReferenceNumber,
+                    Reference = exp.Id,
                     Debit = exp.EffectiveSubtotalUSD,
                     Credit = 0
                 });
@@ -1031,7 +1031,7 @@ public class AccountingReportDataService
             {
                 Date = pmt.Date,
                 Description = $"Payment from {customerName}",
-                Reference = pmt.ReferenceNumber ?? "",
+                Reference = pmt.Id,
                 Debit = pmt.EffectiveAmountUSD,
                 Credit = 0
             });

--- a/ArgoBooks.Core/Services/AccountingReportDataService.cs
+++ b/ArgoBooks.Core/Services/AccountingReportDataService.cs
@@ -156,8 +156,7 @@ public class AccountingReportDataService
                 foreach (var lineItem in txn.LineItems)
                 {
                     var categoryName = GetCategoryNameForProduct(lineItem.ProductId);
-                    if (!result.ContainsKey(categoryName))
-                        result[categoryName] = 0;
+                    result.TryAdd(categoryName, 0);
                     result[categoryName] += lineItem.Subtotal;
                 }
             }
@@ -165,8 +164,7 @@ public class AccountingReportDataService
             {
                 // No line items — use the transaction amount (pre-tax) and try to infer category
                 var categoryName = "Uncategorized";
-                if (!result.ContainsKey(categoryName))
-                    result[categoryName] = 0;
+                result.TryAdd(categoryName, 0);
                 result[categoryName] += txn.Amount;
             }
         }
@@ -606,7 +604,6 @@ public class AccountingReportDataService
     /// </summary>
     private AccountingTableData GetCashFlowData()
     {
-        var t = GetAccountingTerms();
         var data = new AccountingTableData
         {
             Title = "Cash Flow Statement",
@@ -617,7 +614,7 @@ public class AccountingReportDataService
 
         if (_companyData == null)
         {
-            AddEmptyCashFlow(data, t);
+            AddEmptyCashFlow(data);
             return data;
         }
 
@@ -730,7 +727,7 @@ public class AccountingReportDataService
         return data;
     }
 
-    private void AddEmptyCashFlow(AccountingTableData data, AccountingTerms t)
+    private void AddEmptyCashFlow(AccountingTableData data)
     {
         data.Rows.Add(new AccountingRow { Label = "OPERATING ACTIVITIES", RowType = AccountingRowType.SectionHeader, Values = ["Amount"] });
         data.Rows.Add(new AccountingRow { Label = "Cash from Sales", Values = [FormatCurrency(0)], IndentLevel = 1, RowType = AccountingRowType.DataRow });
@@ -1553,8 +1550,7 @@ public class AccountingReportDataService
                     if (li.TaxRate > 0)
                     {
                         var rate = Math.Round(li.TaxRate, 2);
-                        if (!taxCollectedByRate.ContainsKey(rate))
-                            taxCollectedByRate[rate] = 0;
+                        taxCollectedByRate.TryAdd(rate, 0);
                         taxCollectedByRate[rate] += li.TaxAmount;
                     }
                 }
@@ -1562,8 +1558,7 @@ public class AccountingReportDataService
             else if (rev.TaxRate > 0)
             {
                 var rate = Math.Round(rev.TaxRate, 2);
-                if (!taxCollectedByRate.ContainsKey(rate))
-                    taxCollectedByRate[rate] = 0;
+                taxCollectedByRate.TryAdd(rate, 0);
                 taxCollectedByRate[rate] += rev.TaxAmount;
             }
         }
@@ -1583,8 +1578,7 @@ public class AccountingReportDataService
                     if (li.TaxRate > 0)
                     {
                         var rate = Math.Round(li.TaxRate, 2);
-                        if (!taxPaidByRate.ContainsKey(rate))
-                            taxPaidByRate[rate] = 0;
+                        taxPaidByRate.TryAdd(rate, 0);
                         taxPaidByRate[rate] += li.TaxAmount;
                     }
                 }
@@ -1592,8 +1586,7 @@ public class AccountingReportDataService
             else if (exp.TaxRate > 0)
             {
                 var rate = Math.Round(exp.TaxRate, 2);
-                if (!taxPaidByRate.ContainsKey(rate))
-                    taxPaidByRate[rate] = 0;
+                taxPaidByRate.TryAdd(rate, 0);
                 taxPaidByRate[rate] += exp.TaxAmount;
             }
         }

--- a/ArgoBooks.Core/Services/AccountingReportDataService.cs
+++ b/ArgoBooks.Core/Services/AccountingReportDataService.cs
@@ -106,27 +106,6 @@ public class AccountingReportDataService
     }
 
     /// <summary>
-    /// Gets the earliest transaction date across all data in the company.
-    /// Delegates to CompanyData.GetEarliestTransactionDate().
-    /// </summary>
-    private DateTime GetEarliestTransactionDate()
-    {
-        return _companyData?.GetEarliestTransactionDate() ?? DateTime.Today;
-    }
-
-    /// <summary>
-    /// Gets the effective start date, replacing the "All Time" sentinel (year 2000) with
-    /// the actual earliest transaction date from the company data.
-    /// </summary>
-    private DateTime GetEffectiveStartDate()
-    {
-        if (_filters.StartDate.HasValue && _filters.StartDate.Value.Year <= 2000)
-            return GetEarliestTransactionDate();
-        return _filters.StartDate ?? DateTime.Today;
-    }
-
-
-    /// <summary>
     /// Dispatches to the appropriate report generation method based on report type.
     /// </summary>
     public AccountingTableData GetReportData(AccountingReportType reportType)

--- a/ArgoBooks.Core/Services/ReportChartDataService.cs
+++ b/ArgoBooks.Core/Services/ReportChartDataService.cs
@@ -17,28 +17,6 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
     /// </summary>
     private (DateTime Start, DateTime End) GetDateRange() => filters.GetDateRange(companyData?.GetEarliestTransactionDate());
 
-    /// <summary>
-    /// Gets the effective date range, constrained by actual sales data.
-    /// For unbounded ranges (like All Time), uses the actual min/max dates from sales.
-    /// </summary>
-    private (DateTime Start, DateTime End) GetEffectiveDateRange()
-    {
-        var (start, end) = GetDateRange();
-
-        if (companyData?.Revenues == null || !companyData.Revenues.Any())
-            return (start, end);
-
-        // If date range is very large (e.g., All Time), constrain to actual data range
-        var minDataDate = companyData.Revenues.Min(s => s.Date).Date;
-        var maxDataDate = companyData.Revenues.Max(s => s.Date).Date;
-
-        // Use the intersection of requested range and actual data range
-        var effectiveStart = start < minDataDate ? minDataDate : start;
-        var effectiveEnd = end > maxDataDate ? maxDataDate : end;
-
-        return (effectiveStart, effectiveEnd);
-    }
-
     #region Revenue Charts
 
     /// <summary>

--- a/ArgoBooks.Core/Services/ReportChartDataService.cs
+++ b/ArgoBooks.Core/Services/ReportChartDataService.cs
@@ -15,7 +15,7 @@ public class ReportChartDataService(CompanyData? companyData, ReportFilters filt
     /// <summary>
     /// Gets the date range based on filters (delegates to shared ReportFilters.GetDateRange).
     /// </summary>
-    private (DateTime Start, DateTime End) GetDateRange() => filters.GetDateRange(companyData?.GetEarliestTransactionDate());
+    private (DateTime Start, DateTime End) GetDateRange() => filters.GetDateRange(companyData?.GetEarliestDate());
 
     #region Revenue Charts
 

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -2440,7 +2440,7 @@ public class ReportRenderer : IDisposable
                         "Company" => r.CustomerName,
                         "Total" => FormatCurrency(r.Amount),
                         "Method" => r.PaymentMethod,
-                        "ID" => r.ReferenceNumber,
+                        "ID" => r.Id,
                         "Invoice" => r.InvoiceId,
                         _ => ""
                     }).ToList());

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -3682,7 +3682,7 @@ public class ReportRenderer : IDisposable
             var effectiveStart = start.Value;
             if (effectiveStart.Year <= 2000 && _companyData != null)
             {
-                effectiveStart = _companyData.GetEarliestTransactionDate();
+                effectiveStart = _companyData.GetEarliestDate();
             }
 
             return $"{Tr("Period")}: {effectiveStart.ToString(dateFormat)} {Tr("to")} {end.Value.ToString(dateFormat)}";
@@ -3903,7 +3903,7 @@ public class ReportRenderer : IDisposable
         if (!string.IsNullOrEmpty(_config.Filters.DatePresetName) &&
             _config.Filters.DatePresetName != DatePresetNames.Custom)
         {
-            var (start, end) = DatePresetNames.GetDateRange(_config.Filters.DatePresetName, _companyData?.GetEarliestTransactionDate());
+            var (start, end) = DatePresetNames.GetDateRange(_config.Filters.DatePresetName, _companyData?.GetEarliestDate());
             return (start, end);
         }
 

--- a/ArgoBooks.Core/Services/ReportTableDataService.cs
+++ b/ArgoBooks.Core/Services/ReportTableDataService.cs
@@ -17,7 +17,7 @@ public class ReportTableDataService(CompanyData? companyData, ReportFilters filt
     /// <summary>
     /// Gets the date range based on filters (delegates to shared ReportFilters.GetDateRange).
     /// </summary>
-    private (DateTime Start, DateTime End) GetDateRange() => filters.GetDateRange(companyData?.GetEarliestTransactionDate());
+    private (DateTime Start, DateTime End) GetDateRange() => filters.GetDateRange(companyData?.GetEarliestDate());
 
     #region Sales Data
 

--- a/ArgoBooks.Core/Services/ReportTableDataService.cs
+++ b/ArgoBooks.Core/Services/ReportTableDataService.cs
@@ -71,7 +71,7 @@ public class ReportTableDataService(CompanyData? companyData, ReportFilters filt
         return new TransactionTableRow
         {
             Id = revenue.Id,
-            TransactionId = revenue.ReferenceNumber,
+            TransactionId = revenue.Id,
             Date = revenue.Date,
             TransactionType = "Revenue",
             CompanyName = customer?.Name ?? "Unknown",
@@ -139,7 +139,7 @@ public class ReportTableDataService(CompanyData? companyData, ReportFilters filt
         return new TransactionTableRow
         {
             Id = expense.Id,
-            TransactionId = expense.ReferenceNumber,
+            TransactionId = expense.Id,
             Date = expense.Date,
             TransactionType = "Expense",
             CompanyName = supplier?.Name ?? "Unknown",

--- a/ArgoBooks.Core/Services/SampleCompanyService.cs
+++ b/ArgoBooks.Core/Services/SampleCompanyService.cs
@@ -216,7 +216,7 @@ public class SampleCompanyService
         companyData.Settings.Localization = new LocalizationSettings
         {
             Language = "English",
-            Currency = "USD",
+            Currency = "CAD",
             DateFormat = "MM/DD/YYYY"
         };
 

--- a/ArgoBooks.Core/Services/SpreadsheetExportService.cs
+++ b/ArgoBooks.Core/Services/SpreadsheetExportService.cs
@@ -325,7 +325,7 @@ public class SpreadsheetExportService
 
     private (string[] Headers, List<object[]> Rows) GetExpensesData(CompanyData data, DateTime? startDate, DateTime? endDate)
     {
-        var headers = new[] { "ID", "Date", "Supplier ID", "Product", "Unit Price", "Tax", "Total", "Reference", "Payment Method" };
+        var headers = new[] { "ID", "Date", "Supplier ID", "Product", "Unit Price", "Tax", "Total", "Payment Method" };
         var filtered = data.Expenses.Where(p => IsInDateRange(p.Date, startDate, endDate));
         var rows = filtered.Select(p => new object[]
         {
@@ -336,7 +336,6 @@ public class SpreadsheetExportService
             p.Amount,
             p.TaxAmount,
             p.Total,
-            p.ReferenceNumber,
             p.PaymentMethod.ToString()
         }).ToList();
         return (headers, rows);
@@ -430,7 +429,7 @@ public class SpreadsheetExportService
 
     private (string[] Headers, List<object[]> Rows) GetRevenueData(CompanyData data, DateTime? startDate, DateTime? endDate)
     {
-        var headers = new[] { "ID", "Date", "Customer ID", "Product", "Unit Price", "Tax", "Total", "Reference", "Payment Status" };
+        var headers = new[] { "ID", "Date", "Customer ID", "Product", "Unit Price", "Tax", "Total", "Payment Status" };
         var filtered = data.Revenues.Where(s => IsInDateRange(s.Date, startDate, endDate));
         var rows = filtered.Select(s => new object[]
         {
@@ -441,7 +440,6 @@ public class SpreadsheetExportService
             s.Amount,
             s.TaxAmount,
             s.Total,
-            s.ReferenceNumber,
             s.PaymentStatus
         }).ToList();
         return (headers, rows);

--- a/ArgoBooks/Services/ChartSettingsService.cs
+++ b/ArgoBooks/Services/ChartSettingsService.cs
@@ -327,7 +327,7 @@ public partial class ChartSettingsService : ObservableObject
                 break;
 
             case "All Time":
-                StartDate = App.CompanyManager?.CompanyData?.GetEarliestTransactionDate() ?? DateTime.Today;
+                StartDate = App.CompanyManager?.CompanyData?.GetEarliestDate() ?? DateTime.Today;
                 EndDate = now;
                 break;
 

--- a/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
@@ -257,7 +257,7 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
             _previousDateRange = SelectedDateRange;
         }
 
-        var earliestDate = _companyManager?.CompanyData?.GetEarliestTransactionDate() ?? StartDate;
+        var earliestDate = _companyManager?.CompanyData?.GetEarliestDate() ?? StartDate;
         var modalStartDate = HasAppliedCustomRange ? StartDate : earliestDate;
 
         App.CustomDateRangeModal?.Open(modalStartDate, EndDate,

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -193,7 +193,7 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
             _previousDateRange = SelectedDateRange;
         }
 
-        var earliestDate = _companyManager?.CompanyData?.GetEarliestTransactionDate() ?? StartDate;
+        var earliestDate = _companyManager?.CompanyData?.GetEarliestDate() ?? StartDate;
         var modalStartDate = HasAppliedCustomRange ? StartDate : earliestDate;
 
         App.CustomDateRangeModal?.Open(modalStartDate, EndDate,

--- a/ArgoBooks/ViewModels/ExportAsModalViewModel.cs
+++ b/ArgoBooks/ViewModels/ExportAsModalViewModel.cs
@@ -148,7 +148,7 @@ public partial class ExportAsModalViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Refreshes the record counts from the current company data.
+    /// Refreshes the record counts and start date from the current company data.
     /// </summary>
     public void RefreshRecordCounts(CompanyData? companyData)
     {
@@ -160,6 +160,8 @@ public partial class ExportAsModalViewModel : ViewModelBase
             }
             return;
         }
+
+        StartDate = new DateTimeOffset(companyData.GetEarliestDate());
 
         foreach (var item in DataItems)
         {
@@ -221,8 +223,6 @@ public partial class ExportAsModalViewModel : ViewModelBase
     private void Open()
     {
         SelectedTabIndex = 0;
-        // Reset date range to last month
-        StartDate = DateTimeOffset.Now.AddMonths(-1);
         EndDate = DateTimeOffset.Now;
         // Request record count refresh from the hosting code
         RefreshRecordCountsRequested?.Invoke(this, EventArgs.Empty);

--- a/ArgoBooks/ViewModels/InsightsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InsightsPageViewModel.cs
@@ -537,7 +537,7 @@ public partial class InsightsPageViewModel : ViewModelBase
             await RunBacktestIfNeededAsync(companyData, companySettings);
 
             // Use the selected historical date range for insights
-            var (insightsStartDate, insightsEndDate) = DatePresetNames.GetDateRange(SelectedInsightsDateRange, companyData.GetEarliestTransactionDate());
+            var (insightsStartDate, insightsEndDate) = DatePresetNames.GetDateRange(SelectedInsightsDateRange, companyData.GetEarliestDate());
             var insightsDateRange = AnalysisDateRange.Custom(insightsStartDate, insightsEndDate);
 
             // Update the analysis period description

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -2801,7 +2801,7 @@ public partial class ReportsPageViewModel : ViewModelBase
         }
         else if (!string.IsNullOrEmpty(SelectedDatePreset))
         {
-            var (start, end) = DatePresetNames.GetDateRange(SelectedDatePreset, App.CompanyManager?.CompanyData?.GetEarliestTransactionDate());
+            var (start, end) = DatePresetNames.GetDateRange(SelectedDatePreset, App.CompanyManager?.CompanyData?.GetEarliestDate());
             Configuration.Filters.StartDate = start;
             Configuration.Filters.EndDate = end;
         }


### PR DESCRIPTION
## Summary
This PR consolidates date range handling logic and standardizes transaction identification across the application by using the `Id` field instead of `ReferenceNumber` for display purposes.

## Key Changes

### Date Range Handling
- Removed duplicate `GetEarliestTransactionDate()` and `GetEffectiveStartDate()` methods from `AccountingReportDataService`
- Removed `GetEffectiveDateRange()` method from `ReportChartDataService` that was constraining date ranges to actual data
- Added new `GetEarliestDate()` method to `CompanyData` that checks all dated collections (revenues, expenses, payments, invoices, stock adjustments, purchase orders, and rentals)
- Updated all callers throughout the application to use `GetEarliestDate()` instead of `GetEarliestTransactionDate()` for comprehensive date range calculations

### Transaction Identification
- Changed all references from `ReferenceNumber` to `Id` in:
  - General ledger report generation (revenues, expenses, payments)
  - Report table data service (revenue and expense rows)
  - Report renderer (payment table display)
  - Spreadsheet export service (removed ReferenceNumber column from revenue and expense exports)
- Updated `ReferenceNumber` documentation to clarify it's for internal import/export round-tripping only

### Code Quality Improvements
- Replaced manual dictionary key existence checks with `TryAdd()` in:
  - `GroupTransactionsByCategory()` method
  - Tax summary data aggregation (multiple locations)
- Removed unused `AccountingTerms` parameter from `AddEmptyCashFlow()` method
- Updated `ExportAsModalViewModel` to set start date from earliest company data instead of hardcoded month offset

### Sample Data
- Changed default currency in sample company from USD to CAD

## Implementation Details
The refactoring maintains backward compatibility by keeping `ReferenceNumber` as an internal field while using `Id` for all user-facing displays. The new `GetEarliestDate()` method provides a more comprehensive view of company data history by including all dated records, not just transactions.

https://claude.ai/code/session_012oWitsv1hntYDWFbPi6vXG