### PR TITLE
Fix language download URL to match server directory structure

### DIFF
--- a/ArgoBooks/Services/LanguageService.cs
+++ b/ArgoBooks/Services/LanguageService.cs
@@ -48,7 +48,7 @@ public partial class LanguageService
     private readonly string _englishFilePath;
 
     // Download URL template (version will be inserted)
-    private const string DownloadUrlTemplate = "https://argorobots.com/resources/downloads/versions/{0}/languages/{1}.json";
+    private const string DownloadUrlTemplate = "https://argorobots.com/resources/downloads/{0}/languages/{1}.json";
 
     /// <summary>
     /// Gets the current language name (e.g., "English", "French").


### PR DESCRIPTION
The download URL template included an extra "/versions/" path segment that doesn't exist on the server. The server hosts language files at resources/downloads/{version}/languages/ not
resources/downloads/versions/{version}/languages/.