### PR TITLE
Fix sidebar collapsed state restoration during app startup

### DIFF
--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -825,6 +825,18 @@ public class App : Application
                 ErrorLogger?.LogWarning($"Failed to load settings/recent companies during startup: {ex.Message}", "Startup");
             }
 
+            // Apply saved sidebar collapsed state after settings are loaded from disk.
+            // The SidebarViewModel was created before settings were loaded, so its constructor
+            // read the default value. Re-apply the persisted state now.
+            if (_appShellViewModel != null && SettingsService != null)
+            {
+                var savedCollapsed = SettingsService.GlobalSettings.Ui.SidebarCollapsed;
+                if (savedCollapsed)
+                {
+                    _appShellViewModel.SidebarViewModel.IsCollapsed = true;
+                }
+            }
+
             desktop.MainWindow = new MainWindow
             {
                 DataContext = _mainWindowViewModel

--- a/ArgoBooks/ViewModels/SidebarViewModel.cs
+++ b/ArgoBooks/ViewModels/SidebarViewModel.cs
@@ -134,13 +134,6 @@ public partial class SidebarViewModel : ViewModelBase
         _navigationService = navigationService;
 
         InitializeNavigationItems();
-
-        // Restore persisted collapsed state from settings
-        var savedCollapsed = App.SettingsService?.GlobalSettings.Ui.SidebarCollapsed ?? false;
-        if (savedCollapsed)
-        {
-            IsCollapsed = true;
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Moved the sidebar collapsed state restoration logic from the `SidebarViewModel` constructor to the `App.OnFrameworkInitializationCompleted()` method to ensure settings are fully loaded before applying the persisted state.

## Key Changes
- Removed sidebar collapsed state restoration from `SidebarViewModel` constructor, which was attempting to read settings before they were loaded from disk
- Added sidebar state restoration in `App.OnFrameworkInitializationCompleted()` after settings have been successfully loaded, ensuring the persisted `SidebarCollapsed` value is properly applied to the view model

## Implementation Details
The issue was a timing problem: the `SidebarViewModel` was being instantiated before the application settings were loaded from disk, causing it to always use the default value. By deferring the state restoration until after settings are loaded in the app initialization flow, the saved sidebar state is now correctly applied on startup.

https://claude.ai/code/session_01Sm5bEqQL2qqMUPW2Z9eTaS