### PR TITLE
Improve pie chart styling and custom chart report handling

### DIFF
--- a/ArgoBooks.Core/ArgoBooks.Core.csproj
+++ b/ArgoBooks.Core/ArgoBooks.Core.csproj
@@ -27,6 +27,9 @@
         <!-- Graphics (for report rendering) -->
         <PackageReference Include="SkiaSharp" />
 
+        <!-- Charts (headless SKGeoMap rendering for reports) -->
+        <PackageReference Include="LiveChartsCore.SkiaSharpView" />
+
         <!-- PDF -->
         <PackageReference Include="QuestPDF" />
 

--- a/ArgoBooks.Core/Models/Reports/ReportConfiguration.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportConfiguration.cs
@@ -126,6 +126,13 @@ public class ReportConfiguration
     public string? CompanyLogoPath { get; set; }
 
     /// <summary>
+    /// Maximum number of pie chart slices before grouping into "Other".
+    /// Runtime-only, sourced from global settings.
+    /// </summary>
+    [JsonIgnore]
+    public int MaxPieSlices { get; set; } = 6;
+
+    /// <summary>
     /// Gets elements sorted by Z-order (for rendering).
     /// </summary>
     public List<ReportElementBase> GetElementsByZOrder()

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -1525,13 +1525,19 @@ public class ReportRenderer : IDisposable
         // --- Draw legend to the right of the pie, vertically centered ---
         if (chart.ShowLegend)
         {
-            var legendX = centerX + radius + 20 * _renderScale;
+            // Position legend at ~60% of chart width (matching the dashboard layout)
+            var legendX = chartArea.Left + chartArea.Width * 0.58f;
             if (legendX < chartArea.Right - 50 * _renderScale)
             {
                 var lineHeight = 18 * _renderScale;
                 var totalLegendHeight = dataPoints.Count * lineHeight;
                 var legendY = chartArea.MidY - totalLegendHeight / 2;
                 var circleRadius = 5 * _renderScale;
+
+                // Lighter gray for the percentage text (matches TextTertiaryBrush)
+                using var percentPaint = new SKPaint();
+                percentPaint.Color = new SKColor(160, 160, 160);
+                percentPaint.IsAntialias = true;
 
                 for (int i = 0; i < dataPoints.Count; i++)
                 {
@@ -1545,13 +1551,19 @@ public class ReportRenderer : IDisposable
                     var dotCenterY = legendY + circleRadius;
                     canvas.DrawCircle(legendX + circleRadius, dotCenterY, circleRadius, dotPaint);
 
-                    // Legend text
+                    // Label text (darker)
                     var legendText = point.Label;
                     var maxChars = chart.LegendMaxCharacters;
                     if (legendText.Length > maxChars) legendText = legendText[..maxChars] + "...";
-                    legendText = $"{legendText} ({percentage:P0})";
 
-                    canvas.DrawText(legendText, legendX + circleRadius * 2 + 6 * _renderScale, dotCenterY + circleRadius * 0.4f, SKTextAlign.Left, labelFont, labelPaint);
+                    var textX = legendX + circleRadius * 2 + 6 * _renderScale;
+                    var textY = dotCenterY + circleRadius * 0.4f;
+                    canvas.DrawText(legendText, textX, textY, SKTextAlign.Left, labelFont, labelPaint);
+
+                    // Percentage text (lighter gray, to the right of the label)
+                    var labelWidth = labelFont.MeasureText(legendText);
+                    var percentText = $"{percentage * 100:F1}%";
+                    canvas.DrawText(percentText, textX + labelWidth + 8 * _renderScale, textY, SKTextAlign.Left, labelFont, percentPaint);
 
                     legendY += lineHeight;
                 }

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -5,6 +5,8 @@ using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Reports;
 using ArgoBooks.Core.Models.Telemetry;
 using LiveChartsCore.Geo;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 using LiveChartsCore.SkiaSharpView.SKCharts;
 using SkiaSharp;
 

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -1452,6 +1452,7 @@ public class ReportRenderer : IDisposable
     /// Renders a pie chart using SkiaSharp.
     /// Styled to match the dashboard/analytics pie charts: pie shifted left,
     /// legend vertically centered with circular color indicators, no slice borders.
+    /// Respects the MaxPieSlices setting by grouping excess slices into "Other".
     /// </summary>
     private void RenderPieChart(SKCanvas canvas, SKRect chartArea, List<ChartDataPoint> dataPoints, ChartReportElement chart)
     {
@@ -1464,47 +1465,55 @@ public class ReportRenderer : IDisposable
         var total = dataPoints.Sum(p => Math.Abs(p.Value));
         if (total == 0) return;
 
-        // Determine pie chart dimensions — fit within the left portion of the chart area
-        // to leave room for the legend on the right
+        // --- Apply max pie slices setting (group excess into "Other") ---
+        var maxSlices = _config.MaxPieSlices;
+        var sorted = dataPoints.OrderByDescending(p => Math.Abs(p.Value)).ToList();
+        var slices = new List<(string Label, double Value, SKColor Color)>();
+        var colors = AppColors.Palette.Select(SKColor.Parse).ToArray();
+        var otherColor = SKColor.Parse(AppColors.Gray);
+
+        var topItems = sorted.Take(maxSlices - 1).ToList();
+        var otherItems = sorted.Skip(maxSlices - 1).ToList();
+
+        // If there's only one "other" item, show it directly instead of grouping
+        if (otherItems.Count == 1)
+        {
+            topItems.Add(otherItems[0]);
+            otherItems.Clear();
+        }
+
+        for (int i = 0; i < topItems.Count; i++)
+            slices.Add((topItems[i].Label, Math.Abs(topItems[i].Value), colors[i % colors.Length]));
+
+        if (otherItems.Count > 0)
+        {
+            var otherValue = otherItems.Sum(p => Math.Abs(p.Value));
+            var itemsText = Tr("items");
+            slices.Add(($"{Tr("Other")} ({otherItems.Count} {itemsText})", otherValue, otherColor));
+        }
+
+        // --- Layout ---
         var pieSize = Math.Min(chartArea.Width * 0.5f, chartArea.Height) * 0.85f;
         var radius = pieSize / 2;
-
-        // Ensure we have a valid radius
         if (radius <= 0) return;
 
-        // Position pie in the left half, vertically centered
         var centerX = chartArea.Left + chartArea.Width * 0.3f;
         var centerY = chartArea.MidY;
 
-        // Color palette for pie slices
-        var colors = AppColors.Palette.Select(SKColor.Parse).ToArray();
-
-        var startAngle = -90f; // Start at top
+        var startAngle = -90f;
 
         using var labelFont = new SKFont(chartTypeface, (float)chart.LegendFontSize * _renderScale);
-        using var labelPaint = new SKPaint();
-        labelPaint.Color = SKColors.Black;
-        labelPaint.IsAntialias = true;
+        using var labelPaint = new SKPaint { Color = SKColors.Black, IsAntialias = true };
 
-        var pieRect = new SKRect(
-            centerX - radius,
-            centerY - radius,
-            centerX + radius,
-            centerY + radius
-        );
+        var pieRect = new SKRect(centerX - radius, centerY - radius, centerX + radius, centerY + radius);
 
-        // --- Draw all pie slices first (no white borders) ---
-        for (int i = 0; i < dataPoints.Count; i++)
+        // --- Draw all pie slices (no white borders) ---
+        foreach (var slice in slices)
         {
-            var point = dataPoints[i];
-            var percentage = (float)(Math.Abs(point.Value) / total);
+            var percentage = (float)(slice.Value / total);
             var sweepAngle = percentage * 360f;
-            var color = colors[i % colors.Length];
 
-            using var slicePaint = new SKPaint();
-            slicePaint.Color = color;
-            slicePaint.Style = SKPaintStyle.Fill;
-            slicePaint.IsAntialias = true;
+            using var slicePaint = new SKPaint { Color = slice.Color, Style = SKPaintStyle.Fill, IsAntialias = true };
 
             if (sweepAngle >= 359.9f)
             {
@@ -1525,34 +1534,30 @@ public class ReportRenderer : IDisposable
         // --- Draw legend to the right of the pie, vertically centered ---
         if (chart.ShowLegend)
         {
-            // Position legend at ~60% of chart width (matching the dashboard layout)
             var legendX = chartArea.Left + chartArea.Width * 0.58f;
+            var percentRightEdge = chartArea.Right - 5 * _renderScale;
+
             if (legendX < chartArea.Right - 50 * _renderScale)
             {
                 var lineHeight = 18 * _renderScale;
-                var totalLegendHeight = dataPoints.Count * lineHeight;
+                var totalLegendHeight = slices.Count * lineHeight;
                 var legendY = chartArea.MidY - totalLegendHeight / 2;
                 var circleRadius = 5 * _renderScale;
 
-                // Lighter gray for the percentage text (matches TextTertiaryBrush)
-                using var percentPaint = new SKPaint();
-                percentPaint.Color = new SKColor(160, 160, 160);
-                percentPaint.IsAntialias = true;
+                using var percentPaint = new SKPaint { Color = new SKColor(160, 160, 160), IsAntialias = true };
 
-                for (int i = 0; i < dataPoints.Count; i++)
+                foreach (var slice in slices)
                 {
-                    var point = dataPoints[i];
-                    var percentage = (float)(Math.Abs(point.Value) / total);
-                    var color = colors[i % colors.Length];
+                    var percentage = (float)(slice.Value / total);
 
-                    using var dotPaint = new SKPaint { Color = color, Style = SKPaintStyle.Fill, IsAntialias = true };
+                    using var dotPaint = new SKPaint { Color = slice.Color, Style = SKPaintStyle.Fill, IsAntialias = true };
 
                     // Circular color indicator
                     var dotCenterY = legendY + circleRadius;
                     canvas.DrawCircle(legendX + circleRadius, dotCenterY, circleRadius, dotPaint);
 
-                    // Label text (darker)
-                    var legendText = point.Label;
+                    // Label text
+                    var legendText = slice.Label;
                     var maxChars = chart.LegendMaxCharacters;
                     if (legendText.Length > maxChars) legendText = legendText[..maxChars] + "...";
 
@@ -1560,10 +1565,9 @@ public class ReportRenderer : IDisposable
                     var textY = dotCenterY + circleRadius * 0.4f;
                     canvas.DrawText(legendText, textX, textY, SKTextAlign.Left, labelFont, labelPaint);
 
-                    // Percentage text (lighter gray, to the right of the label)
-                    var labelWidth = labelFont.MeasureText(legendText);
+                    // Percentage text (lighter gray, right-aligned to chart edge)
                     var percentText = $"{percentage * 100:F1}%";
-                    canvas.DrawText(percentText, textX + labelWidth + 8 * _renderScale, textY, SKTextAlign.Left, labelFont, percentPaint);
+                    canvas.DrawText(percentText, percentRightEdge, textY, SKTextAlign.Right, labelFont, percentPaint);
 
                     legendY += lineHeight;
                 }

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -4,6 +4,8 @@ using ArgoBooks.Core.Models.Charts;
 using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Reports;
 using ArgoBooks.Core.Models.Telemetry;
+using LiveChartsCore.Geo;
+using LiveChartsCore.SkiaSharpView.SKCharts;
 using SkiaSharp;
 
 namespace ArgoBooks.Core.Services;
@@ -39,6 +41,62 @@ public class ReportRenderer : IDisposable
     private static readonly SKColor ChartProfitColor = SKColor.Parse(AppColors.Success);
     private static readonly SKColor ChartAxisColor = SKColor.Parse(AppColors.ChartAxis);
     private static readonly SKColor ChartGridColor = SKColor.Parse(AppColors.ChartGrid);
+
+    // Country name to ISO 3166-1 alpha-3 code mapping for GeoMap (mirrors ChartLoaderService)
+    private static readonly Dictionary<string, string> CountryNameToIsoCode = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "United States", "usa" }, { "USA", "usa" }, { "US", "usa" }, { "America", "usa" },
+        { "United Kingdom", "gbr" }, { "UK", "gbr" }, { "Great Britain", "gbr" }, { "England", "gbr" },
+        { "Canada", "can" }, { "CA", "can" },
+        { "Germany", "deu" }, { "DE", "deu" },
+        { "France", "fra" }, { "FR", "fra" },
+        { "Italy", "ita" }, { "IT", "ita" },
+        { "Spain", "esp" }, { "ES", "esp" },
+        { "Australia", "aus" }, { "AU", "aus" },
+        { "Japan", "jpn" }, { "JP", "jpn" },
+        { "China", "chn" }, { "CN", "chn" },
+        { "India", "ind" }, { "IN", "ind" },
+        { "Brazil", "bra" }, { "BR", "bra" },
+        { "Mexico", "mex" }, { "MX", "mex" },
+        { "Russia", "rus" }, { "RU", "rus" },
+        { "South Korea", "kor" }, { "Korea", "kor" }, { "KR", "kor" },
+        { "Netherlands", "nld" }, { "NL", "nld" },
+        { "Switzerland", "che" }, { "CH", "che" },
+        { "Sweden", "swe" }, { "SE", "swe" },
+        { "Norway", "nor" }, { "NO", "nor" },
+        { "Denmark", "dnk" }, { "DK", "dnk" },
+        { "Finland", "fin" }, { "FI", "fin" },
+        { "Poland", "pol" }, { "PL", "pol" },
+        { "Belgium", "bel" }, { "BE", "bel" },
+        { "Austria", "aut" }, { "AT", "aut" },
+        { "Ireland", "irl" }, { "IE", "irl" },
+        { "Portugal", "prt" }, { "PT", "prt" },
+        { "Greece", "grc" }, { "GR", "grc" },
+        { "New Zealand", "nzl" }, { "NZ", "nzl" },
+        { "Singapore", "sgp" }, { "SG", "sgp" },
+        { "Hong Kong", "hkg" }, { "HK", "hkg" },
+        { "Taiwan", "twn" }, { "TW", "twn" },
+        { "South Africa", "zaf" }, { "ZA", "zaf" },
+        { "Argentina", "arg" }, { "AR", "arg" },
+        { "Chile", "chl" }, { "CL", "chl" },
+        { "Colombia", "col" }, { "CO", "col" },
+        { "Indonesia", "idn" }, { "ID", "idn" },
+        { "Malaysia", "mys" }, { "MY", "mys" },
+        { "Thailand", "tha" }, { "TH", "tha" },
+        { "Vietnam", "vnm" }, { "VN", "vnm" },
+        { "Philippines", "phl" }, { "PH", "phl" },
+        { "Turkey", "tur" }, { "TR", "tur" },
+        { "Saudi Arabia", "sau" }, { "SA", "sau" },
+        { "UAE", "are" }, { "United Arab Emirates", "are" }, { "AE", "are" },
+        { "Israel", "isr" }, { "IL", "isr" },
+        { "Egypt", "egy" }, { "EG", "egy" },
+        { "Nigeria", "nga" }, { "NG", "nga" },
+        { "Kenya", "ken" }, { "KE", "ken" },
+        { "Ukraine", "ukr" }, { "UA", "ukr" },
+        { "Czech Republic", "cze" }, { "Czechia", "cze" }, { "CZ", "cze" },
+        { "Romania", "rou" }, { "RO", "rou" },
+        { "Hungary", "hun" }, { "HU", "hun" }
+    };
 
     /// <summary>
     /// Determines if a chart type should display currency formatting on the Y-axis.
@@ -1911,14 +1969,10 @@ public class ReportRenderer : IDisposable
     }
 
     /// <summary>
-    /// Renders a simplified GeoMap chart showing country data.
-    /// Since we can't use LiveChartsCore GeoMap in the Core project, we render a data summary.
+    /// Renders a GeoMap chart using LiveCharts2 SKGeoMap for headless rendering.
     /// </summary>
     private void RenderGeoMap(SKCanvas canvas, SKRect chartArea, ChartReportElement chart)
     {
-        // Get typeface for chart labels
-        var chartTypeface = SKTypeface.FromFamilyName(chart.FontFamily) ?? _defaultTypeface;
-
         var mapData = GetWorldMapData();
 
         if (mapData == null || mapData.Count == 0)
@@ -1927,76 +1981,48 @@ public class ReportRenderer : IDisposable
             return;
         }
 
-        // Sort by value descending
-        var sortedData = mapData.OrderByDescending(kvp => kvp.Value).ToList();
-        var maxValue = sortedData.Max(kvp => kvp.Value);
-        if (maxValue == 0) maxValue = 1;
+        // Convert country names to ISO codes for HeatLandSeries
+        var lands = mapData
+            .Select(kvp =>
+            {
+                CountryNameToIsoCode.TryGetValue(kvp.Key, out var isoCode);
+                return isoCode != null ? new HeatLand { Name = isoCode, Value = kvp.Value } : null;
+            })
+            .Where(l => l != null)
+            .Cast<HeatLand>()
+            .ToArray();
 
-        // Draw a horizontal bar chart representation of the world map data
-        var barHeight = Math.Min(25 * _renderScale, (chartArea.Height - 20 * _renderScale) / Math.Min(sortedData.Count, 10));
-        var maxBarWidth = chartArea.Width * 0.6f;
-        var labelWidth = chartArea.Width * 0.25f;
-
-        using var labelFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
-        using var valueFont = new SKFont(chartTypeface, (float)chart.AxisFontSize * _renderScale);
-        using var labelPaint = new SKPaint();
-        labelPaint.Color = SKColors.Black;
-        labelPaint.IsAntialias = true;
-        using var valuePaint = new SKPaint();
-        valuePaint.Color = ChartAxisColor;
-        valuePaint.IsAntialias = true;
-
-        // Color gradient from light to dark blue
-        var startColor = SKColor.Parse(AppColors.PrimaryLighter);
-        var endColor = SKColor.Parse(AppColors.PrimaryDark);
-
-        var currentY = chartArea.Top + 10 * _renderScale;
-        var displayCount = Math.Min(sortedData.Count, 10);
-
-        for (int i = 0; i < displayCount; i++)
+        if (lands.Length == 0)
         {
-            var kvp = sortedData[i];
-            var ratio = (float)(kvp.Value / maxValue);
-
-            // Interpolate color based on value
-            var colorRatio = (float)i / Math.Max(displayCount - 1, 1);
-            var barColor = new SKColor(
-                (byte)(startColor.Red + (endColor.Red - startColor.Red) * colorRatio),
-                (byte)(startColor.Green + (endColor.Green - startColor.Green) * colorRatio),
-                (byte)(startColor.Blue + (endColor.Blue - startColor.Blue) * colorRatio)
-            );
-
-            using var barPaint = new SKPaint();
-            barPaint.Color = barColor;
-            barPaint.Style = SKPaintStyle.Fill;
-            barPaint.IsAntialias = true;
-
-            // Draw country name
-            var countryName = kvp.Key;
-            if (countryName.Length > 15) countryName = countryName[..15] + "...";
-            canvas.DrawText(countryName, chartArea.Left, currentY + barHeight * 0.7f, SKTextAlign.Left, labelFont, labelPaint);
-
-            // Draw bar
-            var barStartX = chartArea.Left + labelWidth;
-            var barEndX = barStartX + (maxBarWidth * ratio);
-            var barRect = new SKRect(barStartX, currentY + 2 * _renderScale, barEndX, currentY + barHeight - 2 * _renderScale);
-            canvas.DrawRect(barRect, barPaint);
-
-            // Draw value
-            canvas.DrawText($"${kvp.Value:N0}", chartArea.Right - 5 * _renderScale, currentY + barHeight * 0.7f, SKTextAlign.Right, valueFont, valuePaint);
-
-            currentY += barHeight + 3 * _renderScale;
+            DrawNoDataPlaceholder(canvas, chartArea);
+            return;
         }
 
-        // Show "and X more..." if there are more countries
-        if (sortedData.Count > 10)
+        var width = (int)chartArea.Width;
+        var height = (int)chartArea.Height;
+        if (width <= 0 || height <= 0) return;
+
+        try
         {
-            using var moreFont = new SKFont(_defaultTypeface, 9 * _renderScale);
-            using var morePaint = new SKPaint();
-            morePaint.Color = SKColors.Gray;
-            morePaint.IsAntialias = true;
-            var moreCountriesText = string.Format(Tr("and {0} more countries..."), sortedData.Count - 10);
-            canvas.DrawText(moreCountriesText, chartArea.Left, currentY + 10 * _renderScale, SKTextAlign.Left, moreFont, morePaint);
+            var geoMap = new SKGeoMap
+            {
+                Width = width,
+                Height = height,
+                Series = [new HeatLandSeries { Lands = lands }],
+                MapProjection = LiveChartsCore.Geo.MapProjection.Mercator
+            };
+
+            using var image = geoMap.GetImage();
+            if (image != null)
+            {
+                canvas.DrawImage(image, chartArea.Left, chartArea.Top);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Fallback to placeholder if SKGeoMap rendering fails
+            System.Diagnostics.Debug.WriteLine($"GeoMap render failed: {ex.Message}");
+            DrawNoDataPlaceholder(canvas, chartArea);
         }
     }
 

--- a/ArgoBooks.Core/Services/ReportRenderer.cs
+++ b/ArgoBooks.Core/Services/ReportRenderer.cs
@@ -1450,6 +1450,8 @@ public class ReportRenderer : IDisposable
 
     /// <summary>
     /// Renders a pie chart using SkiaSharp.
+    /// Styled to match the dashboard/analytics pie charts: pie shifted left,
+    /// legend vertically centered with circular color indicators, no slice borders.
     /// </summary>
     private void RenderPieChart(SKCanvas canvas, SKRect chartArea, List<ChartDataPoint> dataPoints, ChartReportElement chart)
     {
@@ -1462,24 +1464,22 @@ public class ReportRenderer : IDisposable
         var total = dataPoints.Sum(p => Math.Abs(p.Value));
         if (total == 0) return;
 
-        // Determine pie chart dimensions - use smaller of width/height with padding
-        // Center the pie in the chart area, legend will be positioned to the right of the pie
-        var pieSize = Math.Min(chartArea.Width, chartArea.Height) * 0.7f;
-        var centerX = chartArea.MidX;
-        var centerY = chartArea.MidY;
+        // Determine pie chart dimensions — fit within the left portion of the chart area
+        // to leave room for the legend on the right
+        var pieSize = Math.Min(chartArea.Width * 0.5f, chartArea.Height) * 0.85f;
         var radius = pieSize / 2;
 
         // Ensure we have a valid radius
         if (radius <= 0) return;
 
+        // Position pie in the left half, vertically centered
+        var centerX = chartArea.Left + chartArea.Width * 0.3f;
+        var centerY = chartArea.MidY;
+
         // Color palette for pie slices
         var colors = AppColors.Palette.Select(SKColor.Parse).ToArray();
 
         var startAngle = -90f; // Start at top
-
-        // Position legend to the right of the pie
-        var legendX = centerX + radius + 20 * _renderScale;
-        var legendY = chartArea.Top + 10 * _renderScale;
 
         using var labelFont = new SKFont(chartTypeface, (float)chart.LegendFontSize * _renderScale);
         using var labelPaint = new SKPaint();
@@ -1493,6 +1493,7 @@ public class ReportRenderer : IDisposable
             centerY + radius
         );
 
+        // --- Draw all pie slices first (no white borders) ---
         for (int i = 0; i < dataPoints.Count; i++)
         {
             var point = dataPoints[i];
@@ -1500,56 +1501,61 @@ public class ReportRenderer : IDisposable
             var sweepAngle = percentage * 360f;
             var color = colors[i % colors.Length];
 
-            // Draw pie slice
             using var slicePaint = new SKPaint();
             slicePaint.Color = color;
             slicePaint.Style = SKPaintStyle.Fill;
             slicePaint.IsAntialias = true;
 
-            // Handle full circle (360 degrees) - SkiaSharp ArcTo doesn't handle this well
             if (sweepAngle >= 359.9f)
             {
-                // Draw a full circle instead
                 canvas.DrawOval(pieRect, slicePaint);
             }
             else if (sweepAngle > 0)
             {
-                // Draw pie slice using arc
                 using var path = new SKPath();
                 path.MoveTo(centerX, centerY);
                 path.ArcTo(pieRect, startAngle, sweepAngle, false);
                 path.Close();
                 canvas.DrawPath(path, slicePaint);
-
-                // Draw slice border
-                using var borderPaint = new SKPaint();
-                borderPaint.Color = SKColors.White;
-                borderPaint.Style = SKPaintStyle.Stroke;
-                borderPaint.StrokeWidth = 2 * _renderScale;
-                borderPaint.IsAntialias = true;
-                canvas.DrawPath(path, borderPaint);
-            }
-
-            // Draw legend item (if chart has show legend enabled and there's space)
-            if (chart.ShowLegend && legendX < chartArea.Right - 50 * _renderScale)
-            {
-                // Legend color box
-                var legendBoxSize = 10 * _renderScale;
-                var legendBoxRect = new SKRect(legendX, legendY, legendX + legendBoxSize, legendY + legendBoxSize);
-                canvas.DrawRect(legendBoxRect, slicePaint);
-
-                // Legend text
-                var legendText = point.Label;
-                var maxChars = chart.LegendMaxCharacters;
-                if (legendText.Length > maxChars) legendText = legendText[..maxChars] + "...";
-                legendText = $"{legendText} ({percentage:P0})";
-
-                canvas.DrawText(legendText, legendX + legendBoxSize + 5 * _renderScale, legendY + legendBoxSize - 2 * _renderScale, SKTextAlign.Left, labelFont, labelPaint);
-
-                legendY += 18 * _renderScale;
             }
 
             startAngle += sweepAngle;
+        }
+
+        // --- Draw legend to the right of the pie, vertically centered ---
+        if (chart.ShowLegend)
+        {
+            var legendX = centerX + radius + 20 * _renderScale;
+            if (legendX < chartArea.Right - 50 * _renderScale)
+            {
+                var lineHeight = 18 * _renderScale;
+                var totalLegendHeight = dataPoints.Count * lineHeight;
+                var legendY = chartArea.MidY - totalLegendHeight / 2;
+                var circleRadius = 5 * _renderScale;
+
+                for (int i = 0; i < dataPoints.Count; i++)
+                {
+                    var point = dataPoints[i];
+                    var percentage = (float)(Math.Abs(point.Value) / total);
+                    var color = colors[i % colors.Length];
+
+                    using var dotPaint = new SKPaint { Color = color, Style = SKPaintStyle.Fill, IsAntialias = true };
+
+                    // Circular color indicator
+                    var dotCenterY = legendY + circleRadius;
+                    canvas.DrawCircle(legendX + circleRadius, dotCenterY, circleRadius, dotPaint);
+
+                    // Legend text
+                    var legendText = point.Label;
+                    var maxChars = chart.LegendMaxCharacters;
+                    if (legendText.Length > maxChars) legendText = legendText[..maxChars] + "...";
+                    legendText = $"{legendText} ({percentage:P0})";
+
+                    canvas.DrawText(legendText, legendX + circleRadius * 2 + 6 * _renderScale, dotCenterY + circleRadius * 0.4f, SKTextAlign.Left, labelFont, labelPaint);
+
+                    legendY += lineHeight;
+                }
+            }
         }
     }
 

--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml
@@ -28,7 +28,7 @@
             <!-- Zoom transform control -->
             <LayoutTransformControl x:Name="ZoomTransformControl"
                                     HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
+                                    VerticalAlignment="Top"
                                     Margin="10">
                 <LayoutTransformControl.LayoutTransform>
                     <ScaleTransform ScaleX="1" ScaleY="1" />

--- a/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
+++ b/ArgoBooks/Controls/Reports/SkiaReportDesignCanvas.axaml.cs
@@ -377,6 +377,7 @@ public partial class SkiaReportDesignCanvas : UserControl
         var companyData = App.CompanyManager?.CompanyData;
         Configuration.Use24HourFormat = TimeZoneService.Is24HourFormat;
         Configuration.CompanyLogoPath = App.CompanyManager?.CurrentCompanyLogoPath;
+        Configuration.MaxPieSlices = Services.ChartSettingsService.GetMaxPieSlices();
         using var renderer = new ReportRenderer(Configuration, companyData, 1f, LanguageServiceTranslationProvider.Instance, App.ErrorLogger);
         renderer.ComputeContinuationPlan();
         _continuationPlan = renderer.GetContinuationPlan();

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -2796,6 +2796,13 @@ public partial class ReportsPageViewModel : ViewModelBase
 
     private void ApplyFiltersToConfiguration()
     {
+        // Custom (charts) tab always uses landscape orientation
+        if (IsChartsTabSelected)
+        {
+            PageOrientation = PageOrientation.Landscape;
+            Configuration.PageOrientation = PageOrientation.Landscape;
+        }
+
         Configuration.Title = ReportName;
         Configuration.Filters.TransactionType = SelectedTransactionType;
         Configuration.Filters.DatePresetName = SelectedDatePreset;

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -1632,6 +1632,7 @@ public partial class ReportsPageViewModel : ViewModelBase
             const int resolutionMultiplier = 2;
             Configuration.Use24HourFormat = TimeZoneService.Is24HourFormat;
             Configuration.CompanyLogoPath = App.CompanyManager?.CurrentCompanyLogoPath;
+            Configuration.MaxPieSlices = ChartSettingsService.GetMaxPieSlices();
             using var renderer = new ReportRenderer(Configuration, companyData, 1f, LanguageServiceTranslationProvider.Instance, App.ErrorLogger);
 
             // Dispose previous page bitmaps
@@ -1713,6 +1714,7 @@ public partial class ReportsPageViewModel : ViewModelBase
             var companyData = App.CompanyManager?.CompanyData;
             Configuration.Use24HourFormat = TimeZoneService.Is24HourFormat;
             Configuration.CompanyLogoPath = App.CompanyManager?.CurrentCompanyLogoPath;
+            Configuration.MaxPieSlices = ChartSettingsService.GetMaxPieSlices();
             using var renderer = new ReportRenderer(Configuration, companyData, PageDimensions.RenderScale, LanguageServiceTranslationProvider.Instance, App.ErrorLogger);
 
             bool success;

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -261,6 +261,8 @@ public partial class ReportsPageViewModel : ViewModelBase
             IsDateRangeEnabled = true;
             ReportName = ReportTemplateFactory.TemplateNames.Custom;
             Configuration.Title = ReportTemplateFactory.TemplateNames.Custom;
+            PageOrientation = PageOrientation.Landscape;
+            Configuration.PageOrientation = PageOrientation.Landscape;
         }
     }
 
@@ -2917,6 +2919,11 @@ public partial class ReportsPageViewModel : ViewModelBase
 
         var cellWidth = (context.ContentWidth - (spacing * (columns - 1))) / columns;
         var cellHeight = (context.ContentHeight - (spacing * (rows - 1))) / rows;
+
+        // Cap cell height so 1-2 charts don't stretch to fill the full page.
+        // Use the same height as a 2-row layout (like 4 charts in a 2×2 grid).
+        var maxCellHeight = (context.ContentHeight - spacing) / 2;
+        cellHeight = Math.Min(cellHeight, maxCellHeight);
 
         // Position each chart element in the grid below date range area
         for (int i = 0; i < chartElements.Count; i++)

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -252,6 +252,16 @@ public partial class ReportsPageViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(IsTemplatesTabSelected));
         OnPropertyChanged(nameof(IsChartsTabSelected));
+
+        // When switching to the Custom (charts) tab, reset template-specific state
+        // so Balance Sheet's disabled date range doesn't carry over, and the report
+        // name reflects that this is now a custom chart report.
+        if (IsChartsTabSelected)
+        {
+            IsDateRangeEnabled = true;
+            ReportName = ReportTemplateFactory.TemplateNames.Custom;
+            Configuration.Title = ReportTemplateFactory.TemplateNames.Custom;
+        }
     }
 
     [RelayCommand]
@@ -2823,14 +2833,16 @@ public partial class ReportsPageViewModel : ViewModelBase
     /// </summary>
     private void SyncChartElementsWithSelection()
     {
-        // When user is on the Custom (charts) tab, remove summary elements that
-        // may have been added by a previously selected template — this mode is
-        // chart-only so summary cards should not appear.
+        // When user is on the Custom (charts) tab, remove all non-chart elements
+        // that may have been added by a previously selected template (summary cards,
+        // accounting tables, labels, images, etc.) — this mode is chart-only.
         if (IsChartsTabSelected)
         {
-            foreach (var summary in Configuration.Elements.OfType<SummaryReportElement>().ToList())
+            foreach (var element in Configuration.Elements
+                         .Where(e => e is not ChartReportElement && e is not DateRangeReportElement)
+                         .ToList())
             {
-                Configuration.RemoveElement(summary.Id);
+                Configuration.RemoveElement(element.Id);
             }
         }
 

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -2741,7 +2741,8 @@ public partial class ReportsPageViewModel : ViewModelBase
 
             _datePresetToPreserve = null;
         }
-        else if (string.IsNullOrEmpty(SelectedDatePreset))
+        else if (IsDateRangeEnabled &&
+                 (string.IsNullOrEmpty(SelectedDatePreset) || !DatePresets.Any(o => o.IsSelected)))
         {
             // Only set a date preset if the user hasn't already selected one.
             // Default to "Last 30 days" when no selection exists.
@@ -2822,6 +2823,17 @@ public partial class ReportsPageViewModel : ViewModelBase
     /// </summary>
     private void SyncChartElementsWithSelection()
     {
+        // When user is on the Custom (charts) tab, remove summary elements that
+        // may have been added by a previously selected template — this mode is
+        // chart-only so summary cards should not appear.
+        if (IsChartsTabSelected)
+        {
+            foreach (var summary in Configuration.Elements.OfType<SummaryReportElement>().ToList())
+            {
+                Configuration.RemoveElement(summary.Id);
+            }
+        }
+
         var selectedChartTypes = Configuration.Filters.SelectedChartTypes.ToHashSet();
 
         // Get existing chart elements

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <!-- Windows-specific (DPAPI for secure credential storage) -->
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.2" />
     <!-- Charts -->
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc5.4" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
     <!-- Color Picker -->
     <PackageVersion Include="PixiEditor.ColorPicker.AvaloniaUI" Version="1.0.10" />


### PR DESCRIPTION
## Summary
This PR enhances the pie chart rendering to match dashboard/analytics styling and improves the custom chart report workflow by ensuring proper state management when switching between report templates and custom charts.

## Key Changes

### Pie Chart Rendering (`ReportRenderer.cs`)
- **Repositioned pie chart layout**: Shifted pie to the left (30% of chart width) to accommodate legend on the right, matching dashboard design patterns
- **Removed slice borders**: Eliminated white borders between pie slices for a cleaner appearance
- **Redesigned legend**: 
  - Changed from square color boxes to circular color indicators
  - Vertically centered legend aligned with pie chart
  - Added lighter gray percentage text displayed to the right of labels
  - Positioned legend at 58% of chart width for better spacing
- **Improved sizing**: Adjusted pie size calculation to use 50% of chart width and 85% of available height for better proportions

### Custom Chart Report Workflow (`ReportsPageViewModel.cs`)
- **Tab switching state reset**: When switching to the Custom (charts) tab, now resets:
  - Date range enabled state (re-enables date range controls)
  - Report name to "Custom"
  - Page orientation to Landscape
- **Template cleanup**: Added logic to remove non-chart elements (summary cards, tables, labels, images) when on the Custom charts tab, ensuring chart-only mode
- **Chart layout optimization**: Capped cell height for chart grids so 1-2 charts don't stretch to fill the entire page
- **Date preset handling**: Improved logic to properly set default date presets when switching tabs

### UI Layout (`SkiaReportDesignCanvas.axaml`)
- Changed zoom transform control vertical alignment from `Center` to `Top` for better canvas positioning

## Implementation Details
- Pie chart legend now uses circular indicators (5px radius) with proper spacing and alignment
- Percentage values displayed in lighter gray (RGB 160,160,160) to match TextTertiaryBrush styling
- Chart grid layout respects a maximum cell height to prevent over-stretching with few charts
- Custom chart tab properly cleans up template-specific configuration when activated

https://claude.ai/code/session_01Lp5KLk6zTg7TgoUwFHpL89