### PR TITLE
Remove hover styling from pie chart legend items

### DIFF
--- a/ArgoBooks/Controls/PieChartLegend.axaml
+++ b/ArgoBooks/Controls/PieChartLegend.axaml
@@ -15,11 +15,6 @@
             <ItemsControl.ItemTemplate>
                 <DataTemplate DataType="controls:PieLegendItem">
                     <Border Padding="4,3" CornerRadius="4">
-                        <Border.Styles>
-                            <Style Selector="Border:pointerover">
-                                <Setter Property="Background" Value="{DynamicResource SurfaceHoverBrush}" />
-                            </Style>
-                        </Border.Styles>
                         <Grid ColumnDefinitions="Auto,*,Auto">
                             <!-- Color indicator -->
                             <Border Grid.Column="0"


### PR DESCRIPTION
## Summary
Removed the pointer-over hover effect styling from the pie chart legend item borders in the PieChartLegend control.

## Changes
- Removed the `Border.Styles` section that applied `SurfaceHoverBrush` background color on pointer-over events from legend items
- The legend items will no longer display a hover background color when the user hovers over them

## Details
The hover style block was removed from the DataTemplate of the PieChartLegend ItemsControl. This simplifies the legend item appearance and removes the interactive hover feedback that was previously applied to the border element.

https://claude.ai/code/session_01JT7xBb6HWzQ1RrT7z1J2vi