### PR TITLE
Enlarge chart elements in fullscreen overlay view

### DIFF
--- a/ArgoBooks/Controls/ChartExpandOverlay.axaml
+++ b/ArgoBooks/Controls/ChartExpandOverlay.axaml
@@ -27,25 +27,17 @@
                 BoxShadow="0 8 32 0 #40000000"
                 PointerPressed="OnModalContentClick">
             <Grid RowDefinitions="Auto,*">
-                <!-- Header -->
+                <!-- Header (close button only) -->
                 <Border Grid.Row="0"
-                        Padding="20,14"
+                        Padding="8,6"
                         BorderBrush="{DynamicResource BorderBrush}"
-                        BorderThickness="0,0,0,1">
-                    <Grid ColumnDefinitions="*,Auto">
-                        <TextBlock x:Name="TitleText"
-                                   Text="Chart"
-                                   FontSize="18"
-                                   FontWeight="SemiBold"
-                                   Foreground="{DynamicResource TextPrimaryBrush}"
-                                   VerticalAlignment="Center" />
-                        <Button Grid.Column="1"
-                                Classes="icon-button"
-                                Click="OnCloseClick">
-                            <PathIcon Data="{x:Static icons:Icons.Close}"
-                                      Width="18" Height="18" />
-                        </Button>
-                    </Grid>
+                        BorderThickness="0,0,0,0">
+                    <Button HorizontalAlignment="Right"
+                            Classes="icon-button"
+                            Click="OnCloseClick">
+                        <PathIcon Data="{x:Static icons:Icons.Close}"
+                                  Width="18" Height="18" />
+                    </Button>
                 </Border>
 
                 <!-- Chart Content Area + Context Menu -->

--- a/ArgoBooks/Controls/ChartExpandOverlay.axaml.cs
+++ b/ArgoBooks/Controls/ChartExpandOverlay.axaml.cs
@@ -33,6 +33,8 @@ public partial class ChartExpandOverlay : UserControl
     private Button? _expandButton;
     private readonly List<Control> _movedChildren = new();
     private ContentControl? _pageContentControl;
+    private readonly List<(object element, double originalSize)> _originalTitleSizes = new();
+    private readonly List<(PieChartLegend legend, double origFontSize, double origIndicatorSize, double origMaxHeight)> _originalLegendSizes = new();
 
     public ChartExpandOverlay()
     {
@@ -220,55 +222,20 @@ public partial class ChartExpandOverlay : UserControl
         if (sender is not Button button) return;
         if (button.Parent is not Panel sourcePanel) return;
 
-        var title = FindChartTitle(sourcePanel);
-        ShowChart(sourcePanel, button, title);
+        ShowChart(sourcePanel, button);
         e.Handled = true;
-    }
-
-    /// <summary>
-    /// Finds the title of a chart within a panel by examining its children.
-    /// </summary>
-    private static string FindChartTitle(Panel panel)
-    {
-        foreach (var child in panel.Children)
-        {
-            if (child is CartesianChart cc &&
-                cc.Title is LabelVisual cartLabel &&
-                !string.IsNullOrWhiteSpace(cartLabel.Text))
-            {
-                return cartLabel.Text;
-            }
-
-            if (child is Grid grid)
-            {
-                foreach (var gridChild in grid.Children)
-                {
-                    if (gridChild is TextBlock tb && !string.IsNullOrWhiteSpace(tb.Text))
-                        return tb.Text;
-                }
-            }
-
-            if (child is GeoMap)
-                return "World Map Overview";
-        }
-
-        return "Chart";
     }
 
     /// <summary>
     /// Shows the chart in the expanded overlay by reparenting its content.
     /// </summary>
-    private void ShowChart(Panel sourcePanel, Button expandButton, string title)
+    private void ShowChart(Panel sourcePanel, Button expandButton)
     {
         if (IsVisible) return;
 
         _sourcePanel = sourcePanel;
         _expandButton = expandButton;
         _movedChildren.Clear();
-
-        var titleText = this.FindControl<TextBlock>("TitleText");
-        if (titleText != null)
-            titleText.Text = title;
 
         var contentPanel = this.FindControl<Panel>("ContentPanel");
         if (contentPanel == null) return;
@@ -299,6 +266,9 @@ public partial class ChartExpandOverlay : UserControl
         // Hide the expand button while overlay is open
         expandButton.IsVisible = false;
 
+        // Enlarge chart titles and legends for the fullscreen view
+        EnlargeChartElements(contentPanel);
+
         IsVisible = true;
         Focus();
     }
@@ -317,6 +287,9 @@ public partial class ChartExpandOverlay : UserControl
         var chartArea = this.FindControl<Panel>("ChartArea");
         if (chartArea?.DataContext is ChartContextMenuViewModelBase vm && vm.IsChartContextMenuOpen)
             vm.HideChartContextMenuCommand.Execute(null);
+
+        // Restore original sizes before reparenting back
+        RestoreChartElements();
 
         var insertIndex = 0;
         foreach (var child in _movedChildren)
@@ -491,6 +464,89 @@ public partial class ChartExpandOverlay : UserControl
                 catch { /* best effort */ }
             }
         }
+    }
+
+    /// <summary>
+    /// Enlarges chart titles and pie chart legends for the fullscreen modal view.
+    /// </summary>
+    private void EnlargeChartElements(Panel contentPanel)
+    {
+        _originalTitleSizes.Clear();
+        _originalLegendSizes.Clear();
+
+        EnlargeChartElementsRecursive(contentPanel);
+    }
+
+    private void EnlargeChartElementsRecursive(Control control)
+    {
+        // Enlarge CartesianChart titles
+        if (control is CartesianChart cc && cc.Title is LabelVisual cartLabel)
+        {
+            _originalTitleSizes.Add((cartLabel, cartLabel.TextSize));
+            cartLabel.TextSize = 26;
+        }
+
+        // Enlarge PieChart titles
+        if (control is PieChart pc && pc.Title is LabelVisual pieLabel)
+        {
+            _originalTitleSizes.Add((pieLabel, pieLabel.TextSize));
+            pieLabel.TextSize = 26;
+        }
+
+        // Enlarge TextBlock titles (used by pie charts and other charts without LabelVisual)
+        if (control is TextBlock tb && tb.FontWeight == FontWeight.SemiBold && tb.FontSize < 20)
+        {
+            _originalTitleSizes.Add((tb, tb.FontSize));
+            tb.FontSize = 24;
+        }
+
+        // Enlarge PieChartLegend
+        if (control is PieChartLegend legend)
+        {
+            _originalLegendSizes.Add((legend, legend.LegendFontSize, legend.IndicatorSize, legend.MaxHeightOverride));
+            legend.LegendFontSize = 20;
+            legend.IndicatorSize = 18;
+            legend.MaxHeightOverride = 600;
+        }
+
+        // Recurse into children
+        if (control is Panel panel)
+        {
+            foreach (var child in panel.Children)
+                EnlargeChartElementsRecursive(child);
+        }
+        else if (control is ContentControl contentControl && contentControl.Content is Control content)
+        {
+            EnlargeChartElementsRecursive(content);
+        }
+        else if (control is Decorator decorator && decorator.Child != null)
+        {
+            EnlargeChartElementsRecursive(decorator.Child);
+        }
+    }
+
+    /// <summary>
+    /// Restores chart titles and legends to their original sizes.
+    /// </summary>
+    private void RestoreChartElements()
+    {
+        foreach (var (element, originalSize) in _originalTitleSizes)
+        {
+            if (element is LabelVisual label)
+                label.TextSize = originalSize;
+            else if (element is TextBlock tb)
+                tb.FontSize = originalSize;
+        }
+
+        foreach (var (legend, origFontSize, origIndicatorSize, origMaxHeight) in _originalLegendSizes)
+        {
+            legend.LegendFontSize = origFontSize;
+            legend.IndicatorSize = origIndicatorSize;
+            legend.MaxHeightOverride = origMaxHeight;
+        }
+
+        _originalTitleSizes.Clear();
+        _originalLegendSizes.Clear();
     }
 
     private void OnCloseClick(object? sender, RoutedEventArgs e)

--- a/ArgoBooks/Controls/ChartExpandOverlay.axaml.cs
+++ b/ArgoBooks/Controls/ChartExpandOverlay.axaml.cs
@@ -34,7 +34,7 @@ public partial class ChartExpandOverlay : UserControl
     private readonly List<Control> _movedChildren = new();
     private ContentControl? _pageContentControl;
     private readonly List<(object element, double originalSize)> _originalTitleSizes = new();
-    private readonly List<(PieChartLegend legend, double origFontSize, double origIndicatorSize, double origMaxHeight, double origWidth, Thickness origMargin)> _originalLegendSizes = new();
+    private readonly List<(PieChartLegend legend, double origFontSize, double origIndicatorSize, CornerRadius origCornerRadius, double origMaxHeight, double origWidth, Thickness origMargin)> _originalLegendSizes = new();
     private readonly List<(PieChart chart, Thickness origMargin)> _originalPieChartMargins = new();
 
     public ChartExpandOverlay()
@@ -510,9 +510,10 @@ public partial class ChartExpandOverlay : UserControl
         // Enlarge PieChartLegend
         if (control is PieChartLegend legend)
         {
-            _originalLegendSizes.Add((legend, legend.LegendFontSize, legend.IndicatorSize, legend.MaxHeightOverride, legend.Width, legend.Margin));
+            _originalLegendSizes.Add((legend, legend.LegendFontSize, legend.IndicatorSize, legend.IndicatorCornerRadius, legend.MaxHeightOverride, legend.Width, legend.Margin));
             legend.LegendFontSize = 20;
             legend.IndicatorSize = 18;
+            legend.IndicatorCornerRadius = new CornerRadius(9);
             legend.MaxHeightOverride = 600;
             legend.Width = 340;
             legend.Margin = new Thickness(8, 0, 24, 0);
@@ -547,10 +548,11 @@ public partial class ChartExpandOverlay : UserControl
                 tb.FontSize = originalSize;
         }
 
-        foreach (var (legend, origFontSize, origIndicatorSize, origMaxHeight, origWidth, origMargin) in _originalLegendSizes)
+        foreach (var (legend, origFontSize, origIndicatorSize, origCornerRadius, origMaxHeight, origWidth, origMargin) in _originalLegendSizes)
         {
             legend.LegendFontSize = origFontSize;
             legend.IndicatorSize = origIndicatorSize;
+            legend.IndicatorCornerRadius = origCornerRadius;
             legend.MaxHeightOverride = origMaxHeight;
             legend.Width = origWidth;
             legend.Margin = origMargin;

--- a/ArgoBooks/Controls/ChartExpandOverlay.axaml.cs
+++ b/ArgoBooks/Controls/ChartExpandOverlay.axaml.cs
@@ -34,7 +34,8 @@ public partial class ChartExpandOverlay : UserControl
     private readonly List<Control> _movedChildren = new();
     private ContentControl? _pageContentControl;
     private readonly List<(object element, double originalSize)> _originalTitleSizes = new();
-    private readonly List<(PieChartLegend legend, double origFontSize, double origIndicatorSize, double origMaxHeight)> _originalLegendSizes = new();
+    private readonly List<(PieChartLegend legend, double origFontSize, double origIndicatorSize, double origMaxHeight, double origWidth, Thickness origMargin)> _originalLegendSizes = new();
+    private readonly List<(PieChart chart, Thickness origMargin)> _originalPieChartMargins = new();
 
     public ChartExpandOverlay()
     {
@@ -486,11 +487,17 @@ public partial class ChartExpandOverlay : UserControl
             cartLabel.TextSize = 26;
         }
 
-        // Enlarge PieChart titles
-        if (control is PieChart pc && pc.Title is LabelVisual pieLabel)
+        // Enlarge PieChart titles and add margin to shrink pie slightly
+        if (control is PieChart pc)
         {
-            _originalTitleSizes.Add((pieLabel, pieLabel.TextSize));
-            pieLabel.TextSize = 26;
+            if (pc.Title is LabelVisual pieLabel)
+            {
+                _originalTitleSizes.Add((pieLabel, pieLabel.TextSize));
+                pieLabel.TextSize = 26;
+            }
+
+            _originalPieChartMargins.Add((pc, pc.Margin));
+            pc.Margin = new Thickness(40, 20, 0, 20);
         }
 
         // Enlarge TextBlock titles (used by pie charts and other charts without LabelVisual)
@@ -503,10 +510,12 @@ public partial class ChartExpandOverlay : UserControl
         // Enlarge PieChartLegend
         if (control is PieChartLegend legend)
         {
-            _originalLegendSizes.Add((legend, legend.LegendFontSize, legend.IndicatorSize, legend.MaxHeightOverride));
+            _originalLegendSizes.Add((legend, legend.LegendFontSize, legend.IndicatorSize, legend.MaxHeightOverride, legend.Width, legend.Margin));
             legend.LegendFontSize = 20;
             legend.IndicatorSize = 18;
             legend.MaxHeightOverride = 600;
+            legend.Width = 340;
+            legend.Margin = new Thickness(8, 0, 24, 0);
         }
 
         // Recurse into children
@@ -538,15 +547,23 @@ public partial class ChartExpandOverlay : UserControl
                 tb.FontSize = originalSize;
         }
 
-        foreach (var (legend, origFontSize, origIndicatorSize, origMaxHeight) in _originalLegendSizes)
+        foreach (var (legend, origFontSize, origIndicatorSize, origMaxHeight, origWidth, origMargin) in _originalLegendSizes)
         {
             legend.LegendFontSize = origFontSize;
             legend.IndicatorSize = origIndicatorSize;
             legend.MaxHeightOverride = origMaxHeight;
+            legend.Width = origWidth;
+            legend.Margin = origMargin;
+        }
+
+        foreach (var (chart, origMargin) in _originalPieChartMargins)
+        {
+            chart.Margin = origMargin;
         }
 
         _originalTitleSizes.Clear();
         _originalLegendSizes.Clear();
+        _originalPieChartMargins.Clear();
     }
 
     private void OnCloseClick(object? sender, RoutedEventArgs e)

--- a/ArgoBooks/Controls/PieChartLegend.axaml
+++ b/ArgoBooks/Controls/PieChartLegend.axaml
@@ -20,7 +20,7 @@
                             <Border Grid.Column="0"
                                     Width="{Binding IndicatorSize, RelativeSource={RelativeSource AncestorType=controls:PieChartLegend}}"
                                     Height="{Binding IndicatorSize, RelativeSource={RelativeSource AncestorType=controls:PieChartLegend}}"
-                                    CornerRadius="6"
+                                    CornerRadius="{Binding IndicatorCornerRadius, RelativeSource={RelativeSource AncestorType=controls:PieChartLegend}}"
                                     VerticalAlignment="Center"
                                     Margin="0,0,8,0"
                                     Background="{Binding ColorHex}" />

--- a/ArgoBooks/Controls/PieChartLegend.axaml
+++ b/ArgoBooks/Controls/PieChartLegend.axaml
@@ -18,8 +18,8 @@
                         <Grid ColumnDefinitions="Auto,*,Auto">
                             <!-- Color indicator -->
                             <Border Grid.Column="0"
-                                    Width="12"
-                                    Height="12"
+                                    Width="{Binding IndicatorSize, RelativeSource={RelativeSource AncestorType=controls:PieChartLegend}}"
+                                    Height="{Binding IndicatorSize, RelativeSource={RelativeSource AncestorType=controls:PieChartLegend}}"
                                     CornerRadius="6"
                                     VerticalAlignment="Center"
                                     Margin="0,0,8,0"
@@ -28,7 +28,7 @@
                             <!-- Label -->
                             <TextBlock Grid.Column="1"
                                        Text="{Binding Label}"
-                                       FontSize="13"
+                                       FontSize="{Binding LegendFontSize, RelativeSource={RelativeSource AncestorType=controls:PieChartLegend}}"
                                        VerticalAlignment="Center"
                                        TextTrimming="CharacterEllipsis"
                                        Foreground="{DynamicResource TextSecondaryBrush}"
@@ -37,7 +37,7 @@
                             <!-- Percentage/Value -->
                             <TextBlock Grid.Column="2"
                                        Text="{Binding FormattedPercentage}"
-                                       FontSize="13"
+                                       FontSize="{Binding LegendFontSize, RelativeSource={RelativeSource AncestorType=controls:PieChartLegend}}"
                                        VerticalAlignment="Center"
                                        Margin="8,0,0,0"
                                        Foreground="{DynamicResource TextTertiaryBrush}" />

--- a/ArgoBooks/Controls/PieChartLegend.axaml.cs
+++ b/ArgoBooks/Controls/PieChartLegend.axaml.cs
@@ -72,6 +72,9 @@ public partial class PieChartLegend : UserControl
     public static readonly StyledProperty<double> IndicatorSizeProperty =
         AvaloniaProperty.Register<PieChartLegend, double>(nameof(IndicatorSize), 12);
 
+    public static readonly StyledProperty<CornerRadius> IndicatorCornerRadiusProperty =
+        AvaloniaProperty.Register<PieChartLegend, CornerRadius>(nameof(IndicatorCornerRadius), new CornerRadius(6));
+
     #endregion
 
     #region Properties
@@ -128,6 +131,15 @@ public partial class PieChartLegend : UserControl
     {
         get => GetValue(IndicatorSizeProperty);
         set => SetValue(IndicatorSizeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the corner radius of the color indicator.
+    /// </summary>
+    public CornerRadius IndicatorCornerRadius
+    {
+        get => GetValue(IndicatorCornerRadiusProperty);
+        set => SetValue(IndicatorCornerRadiusProperty, value);
     }
 
     #endregion

--- a/ArgoBooks/Controls/PieChartLegend.axaml.cs
+++ b/ArgoBooks/Controls/PieChartLegend.axaml.cs
@@ -66,6 +66,12 @@ public partial class PieChartLegend : UserControl
     public static readonly StyledProperty<bool> ShowValueProperty =
         AvaloniaProperty.Register<PieChartLegend, bool>(nameof(ShowValue));
 
+    public static readonly StyledProperty<double> LegendFontSizeProperty =
+        AvaloniaProperty.Register<PieChartLegend, double>(nameof(LegendFontSize), 13);
+
+    public static readonly StyledProperty<double> IndicatorSizeProperty =
+        AvaloniaProperty.Register<PieChartLegend, double>(nameof(IndicatorSize), 12);
+
     #endregion
 
     #region Properties
@@ -104,6 +110,24 @@ public partial class PieChartLegend : UserControl
     {
         get => GetValue(ShowValueProperty);
         set => SetValue(ShowValueProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the font size for legend labels and percentages.
+    /// </summary>
+    public double LegendFontSize
+    {
+        get => GetValue(LegendFontSizeProperty);
+        set => SetValue(LegendFontSizeProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the size of the color indicator circle.
+    /// </summary>
+    public double IndicatorSize
+    {
+        get => GetValue(IndicatorSizeProperty);
+        set => SetValue(IndicatorSizeProperty, value);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
Enhanced the chart expand overlay to automatically enlarge chart titles, legends, and related elements when displaying charts in fullscreen mode, providing better readability for expanded views.

## Key Changes

- **ChartExpandOverlay.axaml.cs**
  - Removed `FindChartTitle()` method and title parameter from `ShowChart()` - titles are now handled dynamically
  - Added three new lists to track original sizes: `_originalTitleSizes`, `_originalLegendSizes`, and `_originalPieChartMargins`
  - Implemented `EnlargeChartElements()` and `EnlargeChartElementsRecursive()` methods to enlarge chart elements when overlay opens:
    - CartesianChart titles: increased to 26pt
    - PieChart titles: increased to 26pt with added margin (40, 20, 0, 20)
    - TextBlock titles: increased to 24pt
    - PieChartLegend: font size to 20pt, indicator size to 18pt, corner radius to 9pt, max height to 600, width to 340
  - Implemented `RestoreChartElements()` method to restore all elements to original sizes when overlay closes
  - Removed hardcoded title text display from overlay header

- **PieChartLegend.axaml.cs**
  - Added three new styled properties:
    - `LegendFontSizeProperty` (default: 13)
    - `IndicatorSizeProperty` (default: 12)
    - `IndicatorCornerRadiusProperty` (default: CornerRadius(6))
  - Added corresponding public properties with getters/setters

- **ChartExpandOverlay.axaml**
  - Simplified header: removed title TextBlock and reduced padding from 20,14 to 8,6
  - Removed border thickness from header
  - Repositioned close button to right-aligned only

- **PieChartLegend.axaml**
  - Updated color indicator Border to bind Width/Height to `IndicatorSize` property
  - Updated color indicator Border to bind CornerRadius to `IndicatorCornerRadius` property
  - Updated legend label and percentage TextBlocks to bind FontSize to `LegendFontSize` property

## Implementation Details
The enlargement is handled recursively through the control tree, supporting CartesianChart, PieChart, TextBlock titles, and PieChartLegend elements. Original sizes are stored before enlargement and restored when the overlay closes, ensuring the original layout is preserved when returning to normal view.

https://claude.ai/code/session_01P6pzsqY8tReGBzXTJXAFMS