### PR TITLE
Refactor date and amount range filters to use side-by-side layout

### DIFF
--- a/ArgoBooks/Controls/InvoicePreviewControl.axaml.cs
+++ b/ArgoBooks/Controls/InvoicePreviewControl.axaml.cs
@@ -58,6 +58,7 @@ public partial class InvoicePreviewControl : UserControl
     private Microsoft.Web.WebView2.WinForms.WebView2? _webView;
     private WebView2Host? _webViewHost;
     private bool _isWebViewInitialized;
+    private bool _isWebViewDisposed;
     private bool _isHandlingZoom;
     private double _pendingScrollX;
     private double _pendingScrollY;
@@ -173,6 +174,8 @@ public partial class InvoicePreviewControl : UserControl
             _rootPanel.Children.Remove(_webViewHost);
         }
 
+        _isWebViewDisposed = true;
+
         if (_webView != null)
         {
             _webView.Dispose();
@@ -203,6 +206,8 @@ public partial class InvoicePreviewControl : UserControl
         // Don't re-initialize if already exists
         if (_webView != null)
             return;
+
+        _isWebViewDisposed = false;
 
         try
         {
@@ -238,6 +243,9 @@ public partial class InvoicePreviewControl : UserControl
             if (_webView == null) return;
 
             await _webView.EnsureCoreWebView2Async();
+
+            // WebView may have been disposed while awaiting initialization
+            if (_isWebViewDisposed || _webView == null) return;
 
             // Disable context menu and other browser features for clean preview
             if (_webView.CoreWebView2 != null)
@@ -366,7 +374,7 @@ public partial class InvoicePreviewControl : UserControl
 
     private async void OnNavigationCompleted(object? sender, Microsoft.Web.WebView2.Core.CoreWebView2NavigationCompletedEventArgs e)
     {
-        if (!_hasPendingScroll || _webView?.CoreWebView2 == null)
+        if (!_hasPendingScroll || _isWebViewDisposed || _webView?.CoreWebView2 == null)
             return;
 
         _hasPendingScroll = false;
@@ -379,7 +387,7 @@ public partial class InvoicePreviewControl : UserControl
         }
         catch (Exception)
         {
-            // Ignore scroll restoration errors
+            // Ignore scroll restoration errors (including disposed WebView)
         }
     }
 
@@ -476,6 +484,9 @@ public partial class InvoicePreviewControl : UserControl
                 // If we can't get scroll position, just don't restore it
                 _hasPendingScroll = false;
             }
+
+            // WebView may have been disposed while awaiting scroll position
+            if (_isWebViewDisposed || _webView?.CoreWebView2 == null) return;
 
             // Inject styles and scripts for zoom and pan handling
             var interactionScript = @"
@@ -623,8 +634,16 @@ public partial class InvoicePreviewControl : UserControl
                 html = html + interactionScript;
             }
 
-            if (_webView?.CoreWebView2 == null) return;
-            _webView.CoreWebView2.NavigateToString(html);
+            if (_isWebViewDisposed || _webView?.CoreWebView2 == null) return;
+
+            try
+            {
+                _webView.CoreWebView2.NavigateToString(html);
+            }
+            catch (InvalidOperationException)
+            {
+                // WebView2 was disposed between the null check and the call
+            }
         }
 #endif
     }

--- a/ArgoBooks/Controls/InvoicePreviewControl.axaml.cs
+++ b/ArgoBooks/Controls/InvoicePreviewControl.axaml.cs
@@ -623,6 +623,7 @@ public partial class InvoicePreviewControl : UserControl
                 html = html + interactionScript;
             }
 
+            if (_webView?.CoreWebView2 == null) return;
             _webView.CoreWebView2.NavigateToString(html);
         }
 #endif

--- a/ArgoBooks/Icons.cs
+++ b/ArgoBooks/Icons.cs
@@ -30,8 +30,8 @@ public static class Icons
     /// <summary>Up arrow icon for Revenue.</summary>
     public const string Revenue = "M4 12l1 1L11 8V20h2V8l5 5L20 12l-8-8-8 8z";
 
-    /// <summary>Invoice/document icon for Invoices.</summary>
-    public const string Invoices = "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z";
+    /// <summary>Invoice/receipt icon for Invoices.</summary>
+    public const string Invoices = "M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z";
 
     /// <summary>Credit card icon for Payments.</summary>
     public const string Payments = "M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z";

--- a/ArgoBooks/Icons.cs
+++ b/ArgoBooks/Icons.cs
@@ -30,8 +30,8 @@ public static class Icons
     /// <summary>Up arrow icon for Revenue.</summary>
     public const string Revenue = "M4 12l1 1L11 8V20h2V8l5 5L20 12l-8-8-8 8z";
 
-    /// <summary>Invoice/receipt icon for Invoices.</summary>
-    public const string Invoices = "M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z";
+    /// <summary>Invoice/document icon for Invoices (RequestQuote).</summary>
+    public const string Invoices = "M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm1 10h-4v1h3c.55 0 1 .45 1 1v3c0 .55-.45 1-1 1h-1v1h-2v-1H9v-2h4v-1h-3c-.55 0-1-.45-1-1v-3c0-.55.45-1 1-1h1V9h2v1h2v2zm-2-4V3.5L17.5 8H13z";
 
     /// <summary>Credit card icon for Payments.</summary>
     public const string Payments = "M20 4H4c-1.11 0-1.99.89-1.99 2L2 18c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V6c0-1.11-.89-2-2-2zm0 14H4v-6h16v6zm0-10H4V6h16v2z";

--- a/ArgoBooks/Modals/CustomDateRangeModal.axaml
+++ b/ArgoBooks/Modals/CustomDateRangeModal.axaml
@@ -57,25 +57,27 @@
 
                     <!-- Body -->
                     <StackPanel Grid.Row="1" Spacing="12" Margin="20,16">
-                        <!-- Start Date -->
-                        <StackPanel Spacing="4">
-                            <TextBlock Text="{loc:Loc 'Start Date'}"
-                                       FontSize="12"
-                                       Foreground="{DynamicResource TextTertiaryBrush}" />
-                            <DatePicker SelectedDate="{Binding ModalStartDateOffset}"
-                                        Classes="form-datepicker"
-                                        HorizontalAlignment="Stretch" />
-                        </StackPanel>
-
-                        <!-- End Date -->
-                        <StackPanel Spacing="4">
-                            <TextBlock Text="{loc:Loc 'End Date'}"
-                                       FontSize="12"
-                                       Foreground="{DynamicResource TextTertiaryBrush}" />
-                            <DatePicker SelectedDate="{Binding ModalEndDateOffset}"
-                                        Classes="form-datepicker"
-                                        HorizontalAlignment="Stretch" />
-                        </StackPanel>
+                        <!-- Date Range -->
+                        <Grid ColumnDefinitions="*,8,*">
+                            <StackPanel Grid.Column="0" Spacing="4">
+                                <TextBlock Text="{loc:Loc 'Start Date'}"
+                                           FontSize="12"
+                                           Foreground="{DynamicResource TextTertiaryBrush}" />
+                                <DatePicker SelectedDate="{Binding ModalStartDateOffset}"
+                                            Classes="form-datepicker"
+                                            MinWidth="0"
+                                            HorizontalAlignment="Stretch" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="2" Spacing="4">
+                                <TextBlock Text="{loc:Loc 'End Date'}"
+                                           FontSize="12"
+                                           Foreground="{DynamicResource TextTertiaryBrush}" />
+                                <DatePicker SelectedDate="{Binding ModalEndDateOffset}"
+                                            Classes="form-datepicker"
+                                            MinWidth="0"
+                                            HorizontalAlignment="Stretch" />
+                            </StackPanel>
+                        </Grid>
                     </StackPanel>
 
                     <!-- Footer -->

--- a/ArgoBooks/Modals/CustomerModals.axaml
+++ b/ArgoBooks/Modals/CustomerModals.axaml
@@ -379,16 +379,16 @@
                             <!-- Last Rental Date Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Last Rental Date'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <StackPanel Spacing="8">
-                                    <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'From'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <DatePicker SelectedDate="{Binding FilterLastRentalFrom}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                        <DatePicker SelectedDate="{Binding FilterLastRentalFrom}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                    <StackPanel Spacing="4">
+                                    <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'To'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <DatePicker SelectedDate="{Binding FilterLastRentalTo}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                        <DatePicker SelectedDate="{Binding FilterLastRentalTo}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                </StackPanel>
+                                </Grid>
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -554,16 +554,16 @@
                         <!-- Date Range -->
                         <StackPanel Spacing="6">
                             <TextBlock Text="{loc:Loc 'Date Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <StackPanel Spacing="8">
-                                <StackPanel Spacing="4">
+                            <Grid ColumnDefinitions="*,8,*">
+                                <StackPanel Grid.Column="0" Spacing="4">
                                     <TextBlock Text="{loc:Loc 'From'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <DatePicker SelectedDate="{Binding HistoryFilterDateFrom}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                    <DatePicker SelectedDate="{Binding HistoryFilterDateFrom}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                 </StackPanel>
-                                <StackPanel Spacing="4">
+                                <StackPanel Grid.Column="2" Spacing="4">
                                     <TextBlock Text="{loc:Loc 'To'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <DatePicker SelectedDate="{Binding HistoryFilterDateTo}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                    <DatePicker SelectedDate="{Binding HistoryFilterDateTo}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                 </StackPanel>
-                            </StackPanel>
+                            </Grid>
                         </StackPanel>
 
                         <!-- Amount Range -->

--- a/ArgoBooks/Modals/CustomerModals.axaml
+++ b/ArgoBooks/Modals/CustomerModals.axaml
@@ -369,10 +369,15 @@
                             <!-- Outstanding Amount Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Outstanding Amount'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <Grid ColumnDefinitions="*,Auto,*">
-                                    <TextBox Grid.Column="0" Text="{Binding FilterOutstandingMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Min'}" MaxLength="20" />
-                                    <TextBlock Grid.Column="1" Text="{loc:Loc 'to'}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="12,0" />
-                                    <TextBox Grid.Column="2" Text="{Binding FilterOutstandingMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Max'}" MaxLength="20" />
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterOutstandingMin, Mode=TwoWay}" Classes="form-input" Watermark="$0.00" MaxLength="20" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterOutstandingMax, Mode=TwoWay}" Classes="form-input" Watermark="$0.00" MaxLength="20" />
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
 
@@ -569,10 +574,15 @@
                         <!-- Amount Range -->
                         <StackPanel Spacing="6">
                             <TextBlock Text="{loc:Loc 'Amount Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <Grid ColumnDefinitions="*,Auto,*">
-                                <TextBox Grid.Column="0" Text="{Binding HistoryFilterAmountMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Min'}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
-                                <TextBlock Grid.Column="1" Text="{loc:Loc 'to'}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="12,0" />
-                                <TextBox Grid.Column="2" Text="{Binding HistoryFilterAmountMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc 'Max'}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                            <Grid ColumnDefinitions="*,8,*">
+                                <StackPanel Grid.Column="0" Spacing="4">
+                                    <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                    <TextBox Text="{Binding HistoryFilterAmountMin, Mode=TwoWay}" Classes="form-input" Watermark="$0.00" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="2" Spacing="4">
+                                    <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                    <TextBox Text="{Binding HistoryFilterAmountMax, Mode=TwoWay}" Classes="form-input" Watermark="$0.00" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                                </StackPanel>
                             </Grid>
                         </StackPanel>
                     </StackPanel>

--- a/ArgoBooks/Modals/CustomerModals.axaml
+++ b/ArgoBooks/Modals/CustomerModals.axaml
@@ -357,7 +357,7 @@
                             <!-- Country -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc Country}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <ComboBox ItemsSource="{Binding CountryOptions}" SelectedItem="{Binding FilterCountry}" Classes="form-combobox">
+                                <ComboBox ItemsSource="{Binding CountryOptions}" SelectedItem="{Binding FilterCountry}" Classes="form-combobox" PlaceholderText="{loc:Loc 'All'}">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding Converter={StaticResource TranslateConverter}}" />

--- a/ArgoBooks/Modals/ExpenseModals.axaml
+++ b/ArgoBooks/Modals/ExpenseModals.axaml
@@ -448,20 +448,22 @@
                             <StackPanel Spacing="6">
                                 <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}"
                                            Text="{loc:Loc 'Date Range'}" />
-                                <StackPanel Spacing="8">
-                                    <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'From'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <DatePicker SelectedDate="{Binding FilterDateFrom}"
                                                     Classes="form-datepicker"
+                                                    MinWidth="0"
                                                     HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                    <StackPanel Spacing="4">
+                                    <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'To'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <DatePicker SelectedDate="{Binding FilterDateTo}"
                                                     Classes="form-datepicker"
+                                                    MinWidth="0"
                                                     HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                </StackPanel>
+                                </Grid>
                             </StackPanel>
 
                             <!-- Amount Range - Stacked -->

--- a/ArgoBooks/Modals/ExpenseModals.axaml
+++ b/ArgoBooks/Modals/ExpenseModals.axaml
@@ -466,12 +466,12 @@
                                 </Grid>
                             </StackPanel>
 
-                            <!-- Amount Range - Stacked -->
+                            <!-- Amount Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}"
                                            Text="{loc:Loc 'Amount Range'}" />
-                                <StackPanel Spacing="8">
-                                    <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <TextBox Text="{Binding FilterAmountMin, Mode=TwoWay}"
                                                  Classes="form-input"
@@ -480,7 +480,7 @@
                                                  behaviors:NumericInputBehavior.IsDecimalOnly="True"
                                                  MaxLength="20" />
                                     </StackPanel>
-                                    <StackPanel Spacing="4">
+                                    <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <TextBox Text="{Binding FilterAmountMax, Mode=TwoWay}"
                                                  Classes="form-input"
@@ -489,7 +489,7 @@
                                                  behaviors:NumericInputBehavior.IsDecimalOnly="True"
                                                  MaxLength="20" />
                                     </StackPanel>
-                                </StackPanel>
+                                </Grid>
                             </StackPanel>
 
                             <!-- Receipt Status -->

--- a/ArgoBooks/Modals/InvoiceModals.axaml
+++ b/ArgoBooks/Modals/InvoiceModals.axaml
@@ -518,7 +518,7 @@
             <controls:ModalOverlay.ModalContent>
                 <Border HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Width="700"
+                        Width="500"
                         Background="{DynamicResource SurfaceBrush}"
                         CornerRadius="12"
                         BoxShadow="0 8 32 0 #40000000">

--- a/ArgoBooks/Modals/InvoiceModals.axaml
+++ b/ArgoBooks/Modals/InvoiceModals.axaml
@@ -578,58 +578,65 @@
                             <!-- Issue Date Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Issue Date'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <Grid ColumnDefinitions="*,Auto,*">
-                                    <DatePicker Grid.Column="0"
-                                                SelectedDate="{Binding FilterIssueDateFrom}"
-                                                Classes="form-datepicker"
-                                                HorizontalAlignment="Stretch" />
-                                    <TextBlock Grid.Column="1" Text="{loc:Loc to}" FontSize="13"
-                                               Foreground="{DynamicResource TextTertiaryBrush}"
-                                               VerticalAlignment="Center" Margin="12,0" />
-                                    <DatePicker Grid.Column="2"
-                                                SelectedDate="{Binding FilterIssueDateTo}"
-                                                Classes="form-datepicker"
-                                                HorizontalAlignment="Stretch" />
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'From'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <DatePicker SelectedDate="{Binding FilterIssueDateFrom}"
+                                                    Classes="form-datepicker"
+                                                    MinWidth="0"
+                                                    HorizontalAlignment="Stretch" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'To'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <DatePicker SelectedDate="{Binding FilterIssueDateTo}"
+                                                    Classes="form-datepicker"
+                                                    MinWidth="0"
+                                                    HorizontalAlignment="Stretch" />
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
 
                             <!-- Due Date Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Due Date'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <Grid ColumnDefinitions="*,Auto,*">
-                                    <DatePicker Grid.Column="0"
-                                                SelectedDate="{Binding FilterDueDateFrom}"
-                                                Classes="form-datepicker"
-                                                HorizontalAlignment="Stretch" />
-                                    <TextBlock Grid.Column="1" Text="{loc:Loc to}" FontSize="13"
-                                               Foreground="{DynamicResource TextTertiaryBrush}"
-                                               VerticalAlignment="Center" Margin="12,0" />
-                                    <DatePicker Grid.Column="2"
-                                                SelectedDate="{Binding FilterDueDateTo}"
-                                                Classes="form-datepicker"
-                                                HorizontalAlignment="Stretch" />
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'From'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <DatePicker SelectedDate="{Binding FilterDueDateFrom}"
+                                                    Classes="form-datepicker"
+                                                    MinWidth="0"
+                                                    HorizontalAlignment="Stretch" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'To'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <DatePicker SelectedDate="{Binding FilterDueDateTo}"
+                                                    Classes="form-datepicker"
+                                                    MinWidth="0"
+                                                    HorizontalAlignment="Stretch" />
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
 
                             <!-- Amount Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Amount Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <Grid ColumnDefinitions="*,Auto,*">
-                                    <TextBox Grid.Column="0"
-                                             Text="{Binding FilterAmountMin, Mode=TwoWay}"
-                                             Classes="form-input"
-                                             Watermark="{loc:Loc Min}"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
-                                             MaxLength="20" />
-                                    <TextBlock Grid.Column="1" Text="{loc:Loc to}" FontSize="13"
-                                               Foreground="{DynamicResource TextTertiaryBrush}"
-                                               VerticalAlignment="Center" Margin="12,0" />
-                                    <TextBox Grid.Column="2"
-                                             Text="{Binding FilterAmountMax, Mode=TwoWay}"
-                                             Classes="form-input"
-                                             Watermark="{loc:Loc Max}"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
-                                             MaxLength="20" />
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterAmountMin, Mode=TwoWay}"
+                                                 Classes="form-input"
+                                                 Watermark="$0.00"
+                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                 MaxLength="20" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterAmountMax, Mode=TwoWay}"
+                                                 Classes="form-input"
+                                                 Watermark="$0.00"
+                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                 MaxLength="20" />
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
                         </StackPanel>

--- a/ArgoBooks/Modals/LocationsModals.axaml
+++ b/ArgoBooks/Modals/LocationsModals.axaml
@@ -353,7 +353,7 @@
                     <!-- Modal Footer -->
                     <Border Grid.Row="2" Padding="24,16" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">
                         <Grid ColumnDefinitions="Auto,*,Auto">
-                            <Button Grid.Column="0" Classes="text-button" Content="{loc:Loc 'Clear Filters'}" Command="{Binding ClearFiltersCommand}" />
+                            <Button Grid.Column="0" Classes="secondary-button" Content="{loc:Loc 'Clear Filters'}" Command="{Binding ClearFiltersCommand}" />
                             <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="12">
                                 <Button Classes="secondary-button" Content="{loc:Loc Cancel}" Command="{Binding CloseFilterModalCommand}" />
                                 <Button Classes="primary-button" Content="{loc:Loc Apply}" Command="{Binding ApplyFiltersCommand}" />

--- a/ArgoBooks/Modals/LostDamagedModals.axaml
+++ b/ArgoBooks/Modals/LostDamagedModals.axaml
@@ -62,27 +62,29 @@
                                 </ComboBox>
                             </StackPanel>
 
-                            <!-- From Date -->
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="{loc:Loc 'From Date'}"
-                                           FontSize="13"
-                                           FontWeight="Medium"
-                                           Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <DatePicker SelectedDate="{Binding FilterDateFrom}"
-                                            Classes="form-datepicker"
-                                            HorizontalAlignment="Stretch" />
-                            </StackPanel>
-
-                            <!-- To Date -->
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="{loc:Loc 'To Date'}"
-                                           FontSize="13"
-                                           FontWeight="Medium"
-                                           Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <DatePicker SelectedDate="{Binding FilterDateTo}"
-                                            Classes="form-datepicker"
-                                            HorizontalAlignment="Stretch" />
-                            </StackPanel>
+                            <!-- Date Range -->
+                            <Grid ColumnDefinitions="*,8,*">
+                                <StackPanel Grid.Column="0" Spacing="8">
+                                    <TextBlock Text="{loc:Loc 'From Date'}"
+                                               FontSize="13"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <DatePicker SelectedDate="{Binding FilterDateFrom}"
+                                                Classes="form-datepicker"
+                                                MinWidth="0"
+                                                HorizontalAlignment="Stretch" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="2" Spacing="8">
+                                    <TextBlock Text="{loc:Loc 'To Date'}"
+                                               FontSize="13"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <DatePicker SelectedDate="{Binding FilterDateTo}"
+                                                Classes="form-datepicker"
+                                                MinWidth="0"
+                                                HorizontalAlignment="Stretch" />
+                                </StackPanel>
+                            </Grid>
 
                             <!-- Reason -->
                             <StackPanel Spacing="8">

--- a/ArgoBooks/Modals/PaymentModals.axaml
+++ b/ArgoBooks/Modals/PaymentModals.axaml
@@ -343,10 +343,15 @@
                             <!-- Amount Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Amount Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <Grid ColumnDefinitions="*,Auto,*">
-                                    <TextBox Grid.Column="0" Text="{Binding FilterAmountMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Min}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
-                                    <TextBlock Grid.Column="1" Text="{loc:Loc to}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="12,0" />
-                                    <TextBox Grid.Column="2" Text="{Binding FilterAmountMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Max}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterAmountMin, Mode=TwoWay}" Classes="form-input" Watermark="$0.00" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterAmountMax, Mode=TwoWay}" Classes="form-input" Watermark="$0.00" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
                         </StackPanel>

--- a/ArgoBooks/Modals/PaymentModals.axaml
+++ b/ArgoBooks/Modals/PaymentModals.axaml
@@ -290,16 +290,16 @@
                             <!-- Date Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Date Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <StackPanel Spacing="8">
-                                    <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc From}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <DatePicker SelectedDate="{Binding FilterDateFrom}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                        <DatePicker SelectedDate="{Binding FilterDateFrom}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                    <StackPanel Spacing="4">
+                                    <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc To}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <DatePicker SelectedDate="{Binding FilterDateTo}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                        <DatePicker SelectedDate="{Binding FilterDateTo}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                </StackPanel>
+                                </Grid>
                             </StackPanel>
 
                             <!-- Customer -->

--- a/ArgoBooks/Modals/ProductModals.axaml
+++ b/ArgoBooks/Modals/ProductModals.axaml
@@ -21,7 +21,7 @@
             <controls:ModalOverlay.ModalContent>
                 <Border Background="{DynamicResource SurfaceBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
-                    BorderThickness="1" CornerRadius="12" Width="550" MaxHeight="700"
+                    BorderThickness="1" CornerRadius="12" Width="500" MaxHeight="700"
                     HorizontalAlignment="Center" VerticalAlignment="Center">
                 <Grid RowDefinitions="Auto,*,Auto">
                     <Border Grid.Row="0"

--- a/ArgoBooks/Modals/PurchaseOrdersModals.axaml
+++ b/ArgoBooks/Modals/PurchaseOrdersModals.axaml
@@ -151,14 +151,14 @@
                                                              Text="{Binding Quantity, Mode=TwoWay}"
                                                              Classes="form-input-compact"
                                                              HorizontalContentAlignment="Center"
-                                                             VerticalAlignment="Top"
+                                                             VerticalAlignment="Stretch"
                                                              Margin="0,0,8,0"
                                                              MaxLength="5" />
                                                     <TextBox Grid.Column="2"
                                                              Text="{Binding UnitCost, Mode=TwoWay}"
                                                              Classes="form-input-compact"
                                                              HorizontalContentAlignment="Center"
-                                                             VerticalAlignment="Top"
+                                                             VerticalAlignment="Stretch"
                                                              Margin="0,0,8,0"
                                                              MaxLength="12" />
                                                     <TextBlock Grid.Column="3"
@@ -516,16 +516,16 @@
                                        FontSize="13"
                                        FontWeight="Medium"
                                        Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <StackPanel Spacing="8">
-                                <StackPanel Spacing="4">
+                            <Grid ColumnDefinitions="*,8,*">
+                                <StackPanel Grid.Column="0" Spacing="4">
                                     <TextBlock Text="{loc:Loc 'From'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <DatePicker SelectedDate="{Binding FilterStartDate}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                    <DatePicker SelectedDate="{Binding FilterStartDate}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                 </StackPanel>
-                                <StackPanel Spacing="4">
+                                <StackPanel Grid.Column="2" Spacing="4">
                                     <TextBlock Text="{loc:Loc 'To'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <DatePicker SelectedDate="{Binding FilterEndDate}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                    <DatePicker SelectedDate="{Binding FilterEndDate}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                 </StackPanel>
-                            </StackPanel>
+                            </Grid>
                         </StackPanel>
 
                         <!-- Supplier -->

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -89,28 +89,28 @@
                             </Grid>
 
                             <!-- Amount Range -->
-                            <Grid ColumnDefinitions="*,16,*">
-                                <StackPanel Grid.Column="0" Spacing="8">
-                                    <TextBlock Text="{loc:Loc 'Min Amount'}"
-                                               FontSize="13"
-                                               FontWeight="Medium"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding FilterAmountMin}"
-                                             Watermark="{loc:Loc '$0.00'}"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
-                                             MaxLength="20" />
-                                </StackPanel>
-                                <StackPanel Grid.Column="2" Spacing="8">
-                                    <TextBlock Text="{loc:Loc 'Max Amount'}"
-                                               FontSize="13"
-                                               FontWeight="Medium"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                    <TextBox Text="{Binding FilterAmountMax}"
-                                             Watermark="{loc:Loc '$0.00'}"
-                                             behaviors:NumericInputBehavior.IsDecimalOnly="True"
-                                             MaxLength="20" />
-                                </StackPanel>
-                            </Grid>
+                            <StackPanel Spacing="6">
+                                <TextBlock Text="{loc:Loc 'Amount Range'}"
+                                           FontSize="13"
+                                           FontWeight="Medium"
+                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterAmountMin}"
+                                                 Watermark="$0.00"
+                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                 MaxLength="20" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterAmountMax}"
+                                                 Watermark="$0.00"
+                                                 behaviors:NumericInputBehavior.IsDecimalOnly="True"
+                                                 MaxLength="20" />
+                                    </StackPanel>
+                                </Grid>
+                            </StackPanel>
 
                             <!-- Source Filter -->
                             <StackPanel Spacing="8">

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -64,27 +64,29 @@
                                 </ComboBox>
                             </StackPanel>
 
-                            <!-- From Date -->
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="{loc:Loc 'From Date'}"
-                                           FontSize="13"
-                                           FontWeight="Medium"
-                                           Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <DatePicker SelectedDate="{Binding FilterDateFrom}"
-                                            Classes="form-datepicker"
-                                            HorizontalAlignment="Stretch" />
-                            </StackPanel>
-
-                            <!-- To Date -->
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="{loc:Loc 'To Date'}"
-                                           FontSize="13"
-                                           FontWeight="Medium"
-                                           Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <DatePicker SelectedDate="{Binding FilterDateTo}"
-                                            Classes="form-datepicker"
-                                            HorizontalAlignment="Stretch" />
-                            </StackPanel>
+                            <!-- Date Range -->
+                            <Grid ColumnDefinitions="*,8,*">
+                                <StackPanel Grid.Column="0" Spacing="8">
+                                    <TextBlock Text="{loc:Loc 'From Date'}"
+                                               FontSize="13"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <DatePicker SelectedDate="{Binding FilterDateFrom}"
+                                                Classes="form-datepicker"
+                                                MinWidth="0"
+                                                HorizontalAlignment="Stretch" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="2" Spacing="8">
+                                    <TextBlock Text="{loc:Loc 'To Date'}"
+                                               FontSize="13"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <DatePicker SelectedDate="{Binding FilterDateTo}"
+                                                Classes="form-datepicker"
+                                                MinWidth="0"
+                                                HorizontalAlignment="Stretch" />
+                                </StackPanel>
+                            </Grid>
 
                             <!-- Amount Range -->
                             <Grid ColumnDefinitions="*,16,*">

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -98,6 +98,7 @@
                                     <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <TextBox Text="{Binding FilterAmountMin}"
+                                                 Classes="form-input"
                                                  Watermark="$0.00"
                                                  behaviors:NumericInputBehavior.IsDecimalOnly="True"
                                                  MaxLength="20" />
@@ -105,6 +106,7 @@
                                     <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <TextBox Text="{Binding FilterAmountMax}"
+                                                 Classes="form-input"
                                                  Watermark="$0.00"
                                                  behaviors:NumericInputBehavior.IsDecimalOnly="True"
                                                  MaxLength="20" />

--- a/ArgoBooks/Modals/RentalInventoryModals.axaml
+++ b/ArgoBooks/Modals/RentalInventoryModals.axaml
@@ -296,10 +296,15 @@
                             <!-- Daily Rate Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Daily Rate'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <Grid ColumnDefinitions="*,Auto,*">
-                                    <TextBox Grid.Column="0" Text="{Binding FilterDailyRateMin, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Min}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
-                                    <TextBlock Grid.Column="1" Text="{loc:Loc to}" FontSize="13" Foreground="{DynamicResource TextTertiaryBrush}" VerticalAlignment="Center" Margin="12,0" />
-                                    <TextBox Grid.Column="2" Text="{Binding FilterDailyRateMax, Mode=TwoWay}" Classes="form-input" Watermark="{loc:Loc Max}" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterDailyRateMin, Mode=TwoWay}" Classes="form-input" Watermark="$0.00" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Spacing="4">
+                                        <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
+                                        <TextBox Text="{Binding FilterDailyRateMax, Mode=TwoWay}" Classes="form-input" Watermark="$0.00" behaviors:NumericInputBehavior.IsDecimalOnly="True" MaxLength="20" />
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
                         </StackPanel>

--- a/ArgoBooks/Modals/RentalRecordsModals.axaml
+++ b/ArgoBooks/Modals/RentalRecordsModals.axaml
@@ -500,31 +500,31 @@
                             <!-- Start Date Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Start Date Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <StackPanel Spacing="8">
-                                    <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc From}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <DatePicker SelectedDate="{Binding FilterStartDateFrom}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                        <DatePicker SelectedDate="{Binding FilterStartDateFrom}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                    <StackPanel Spacing="4">
+                                    <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc To}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <DatePicker SelectedDate="{Binding FilterStartDateTo}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                        <DatePicker SelectedDate="{Binding FilterStartDateTo}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                </StackPanel>
+                                </Grid>
                             </StackPanel>
 
                             <!-- Due Date Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{loc:Loc 'Due Date Range'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <StackPanel Spacing="8">
-                                    <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc From}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <DatePicker SelectedDate="{Binding FilterDueDateFrom}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                        <DatePicker SelectedDate="{Binding FilterDueDateFrom}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                    <StackPanel Spacing="4">
+                                    <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc To}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                        <DatePicker SelectedDate="{Binding FilterDueDateTo}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                        <DatePicker SelectedDate="{Binding FilterDueDateTo}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                </StackPanel>
+                                </Grid>
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>

--- a/ArgoBooks/Modals/ReturnsModals.axaml
+++ b/ArgoBooks/Modals/ReturnsModals.axaml
@@ -46,27 +46,29 @@
                     <!-- Modal Content -->
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                         <StackPanel Margin="24" Spacing="16">
-                            <!-- From Date -->
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="{loc:Loc 'From Date'}"
-                                           FontSize="13"
-                                           FontWeight="Medium"
-                                           Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <DatePicker SelectedDate="{Binding FilterDateFrom}"
-                                            Classes="form-datepicker"
-                                            HorizontalAlignment="Stretch" />
-                            </StackPanel>
-
-                            <!-- To Date -->
-                            <StackPanel Spacing="8">
-                                <TextBlock Text="{loc:Loc 'To Date'}"
-                                           FontSize="13"
-                                           FontWeight="Medium"
-                                           Foreground="{DynamicResource TextSecondaryBrush}" />
-                                <DatePicker SelectedDate="{Binding FilterDateTo}"
-                                            Classes="form-datepicker"
-                                            HorizontalAlignment="Stretch" />
-                            </StackPanel>
+                            <!-- Date Range -->
+                            <Grid ColumnDefinitions="*,8,*">
+                                <StackPanel Grid.Column="0" Spacing="8">
+                                    <TextBlock Text="{loc:Loc 'From Date'}"
+                                               FontSize="13"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <DatePicker SelectedDate="{Binding FilterDateFrom}"
+                                                Classes="form-datepicker"
+                                                MinWidth="0"
+                                                HorizontalAlignment="Stretch" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="2" Spacing="8">
+                                    <TextBlock Text="{loc:Loc 'To Date'}"
+                                               FontSize="13"
+                                               FontWeight="Medium"
+                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <DatePicker SelectedDate="{Binding FilterDateTo}"
+                                                Classes="form-datepicker"
+                                                MinWidth="0"
+                                                HorizontalAlignment="Stretch" />
+                                </StackPanel>
+                            </Grid>
 
                             <!-- Reason -->
                             <StackPanel Spacing="8">

--- a/ArgoBooks/Modals/RevenueModals.axaml
+++ b/ArgoBooks/Modals/RevenueModals.axaml
@@ -466,20 +466,22 @@
                             <StackPanel Spacing="6">
                                 <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}"
                                            Text="{loc:Loc 'Date Range'}" />
-                                <StackPanel Spacing="8">
-                                    <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'From'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <DatePicker SelectedDate="{Binding FilterDateFrom}"
                                                     Classes="form-datepicker"
+                                                    MinWidth="0"
                                                     HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                    <StackPanel Spacing="4">
+                                    <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'To'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <DatePicker SelectedDate="{Binding FilterDateTo}"
                                                     Classes="form-datepicker"
+                                                    MinWidth="0"
                                                     HorizontalAlignment="Stretch" />
                                     </StackPanel>
-                                </StackPanel>
+                                </Grid>
                             </StackPanel>
 
                             <!-- Amount Range - Stacked -->

--- a/ArgoBooks/Modals/RevenueModals.axaml
+++ b/ArgoBooks/Modals/RevenueModals.axaml
@@ -484,12 +484,12 @@
                                 </Grid>
                             </StackPanel>
 
-                            <!-- Amount Range - Stacked -->
+                            <!-- Amount Range -->
                             <StackPanel Spacing="6">
                                 <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}"
                                            Text="{loc:Loc 'Amount Range'}" />
-                                <StackPanel Spacing="8">
-                                    <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,8,*">
+                                    <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Min'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <TextBox Text="{Binding FilterAmountMin, Mode=TwoWay}"
                                                  Classes="form-input"
@@ -498,7 +498,7 @@
                                                  behaviors:NumericInputBehavior.IsDecimalOnly="True"
                                                  MaxLength="20" />
                                     </StackPanel>
-                                    <StackPanel Spacing="4">
+                                    <StackPanel Grid.Column="2" Spacing="4">
                                         <TextBlock Text="{loc:Loc 'Max'}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
                                         <TextBox Text="{Binding FilterAmountMax, Mode=TwoWay}"
                                                  Classes="form-input"
@@ -507,7 +507,7 @@
                                                  behaviors:NumericInputBehavior.IsDecimalOnly="True"
                                                  MaxLength="20" />
                                     </StackPanel>
-                                </StackPanel>
+                                </Grid>
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>

--- a/ArgoBooks/Modals/StockAdjustmentsModals.axaml
+++ b/ArgoBooks/Modals/StockAdjustmentsModals.axaml
@@ -319,16 +319,16 @@
                                        FontSize="13"
                                        FontWeight="Medium"
                                        Foreground="{DynamicResource TextSecondaryBrush}" />
-                            <StackPanel Spacing="8">
-                                <StackPanel Spacing="4">
+                            <Grid ColumnDefinitions="*,8,*">
+                                <StackPanel Grid.Column="0" Spacing="4">
                                     <TextBlock Text="{loc:Loc From}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <DatePicker SelectedDate="{Binding FilterStartDate}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                    <DatePicker SelectedDate="{Binding FilterStartDate}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                 </StackPanel>
-                                <StackPanel Spacing="4">
+                                <StackPanel Grid.Column="2" Spacing="4">
                                     <TextBlock Text="{loc:Loc To}" FontSize="12" Foreground="{DynamicResource TextTertiaryBrush}" />
-                                    <DatePicker SelectedDate="{Binding FilterEndDate}" Classes="form-datepicker" HorizontalAlignment="Stretch" />
+                                    <DatePicker SelectedDate="{Binding FilterEndDate}" Classes="form-datepicker" MinWidth="0" HorizontalAlignment="Stretch" />
                                 </StackPanel>
-                            </StackPanel>
+                            </Grid>
                         </StackPanel>
 
                         <!-- Product -->

--- a/ArgoBooks/Services/ChartLoaderService.cs
+++ b/ArgoBooks/Services/ChartLoaderService.cs
@@ -2019,7 +2019,7 @@ public class ChartLoaderService
                 Labels = labels,
                 TextSize = AxisTextSize,
                 LabelsPaint = new SolidColorPaint(_textColor),
-                SeparatorsPaint = new SolidColorPaint(_gridColor) { StrokeThickness = 1 }
+                SeparatorsPaint = null
             }
         };
 

--- a/ArgoBooks/Views/InsightsPage.axaml
+++ b/ArgoBooks/Views/InsightsPage.axaml
@@ -275,7 +275,7 @@
 
                     <!-- Disclaimer -->
                     <TextBlock IsVisible="{Binding !HasInsufficientData}"
-                               Text="{loc:Loc 'Disclaimer: These forecasts are estimates based on historical data and should not be relied upon as guarantees of future performance. Actual results may vary.'}"
+                               Text="{loc:Loc 'Disclaimer: These forecasts are estimates and should not be relied upon. Actual results often vary.'}"
                                FontSize="11"
                                FontStyle="Italic"
                                Foreground="{DynamicResource TextTertiaryBrush}"

--- a/ArgoBooks/Views/InsightsPage.axaml
+++ b/ArgoBooks/Views/InsightsPage.axaml
@@ -272,6 +272,14 @@
                                        TextWrapping="Wrap" />
                         </StackPanel>
                     </Border>
+
+                    <!-- Disclaimer -->
+                    <TextBlock IsVisible="{Binding !HasInsufficientData}"
+                               Text="{loc:Loc 'Disclaimer: These forecasts are estimates based on historical data and should not be relied upon as guarantees of future performance. Actual results may vary.'}"
+                               FontSize="11"
+                               FontStyle="Italic"
+                               Foreground="{DynamicResource TextTertiaryBrush}"
+                               TextWrapping="Wrap" />
                 </StackPanel>
             </Border>
 

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -645,8 +645,8 @@
                                                    FontSize="13"
                                                    FontWeight="Medium"
                                                    Foreground="{DynamicResource TextSecondaryBrush}" />
-                                        <Grid ColumnDefinitions="*,8,*">
-                                            <StackPanel Grid.Column="0" Spacing="4">
+                                        <StackPanel Spacing="8">
+                                            <StackPanel Spacing="4">
                                                 <TextBlock Text="{loc:Loc 'Start Date'}"
                                                            FontSize="11"
                                                            Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -654,7 +654,7 @@
                                                             MinWidth="0"
                                                             HorizontalAlignment="Stretch" />
                                             </StackPanel>
-                                            <StackPanel Grid.Column="2" Spacing="4">
+                                            <StackPanel Spacing="4">
                                                 <TextBlock Text="{loc:Loc 'End Date'}"
                                                            FontSize="11"
                                                            Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -662,7 +662,7 @@
                                                             MinWidth="0"
                                                             HorizontalAlignment="Stretch" />
                                             </StackPanel>
-                                        </Grid>
+                                        </StackPanel>
                                     </StackPanel>
                                 </Border>
                             </StackPanel>
@@ -1701,20 +1701,20 @@
                                             Padding="10"
                                             Margin="0,4,0,0"
                                             IsVisible="{Binding IsCustomDateRange}">
-                                        <Grid ColumnDefinitions="*,8,*">
-                                            <StackPanel Grid.Column="0" Spacing="4">
+                                        <StackPanel Spacing="8">
+                                            <StackPanel Spacing="4">
                                                 <TextBlock Text="{loc:Loc 'Start Date'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                                 <DatePicker SelectedDate="{Binding CustomStartDate}"
                                                             MinWidth="0"
                                                             HorizontalAlignment="Stretch" />
                                             </StackPanel>
-                                            <StackPanel Grid.Column="2" Spacing="4">
+                                            <StackPanel Spacing="4">
                                                 <TextBlock Text="{loc:Loc 'End Date'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                                 <DatePicker SelectedDate="{Binding CustomEndDate}"
                                                             MinWidth="0"
                                                             HorizontalAlignment="Stretch" />
                                             </StackPanel>
-                                        </Grid>
+                                        </StackPanel>
                                     </Border>
                                 </StackPanel>
 

--- a/ArgoBooks/Views/ReportsPage.axaml
+++ b/ArgoBooks/Views/ReportsPage.axaml
@@ -645,8 +645,8 @@
                                                    FontSize="13"
                                                    FontWeight="Medium"
                                                    Foreground="{DynamicResource TextSecondaryBrush}" />
-                                        <StackPanel Spacing="8">
-                                            <StackPanel Spacing="4">
+                                        <Grid ColumnDefinitions="*,8,*">
+                                            <StackPanel Grid.Column="0" Spacing="4">
                                                 <TextBlock Text="{loc:Loc 'Start Date'}"
                                                            FontSize="11"
                                                            Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -654,7 +654,7 @@
                                                             MinWidth="0"
                                                             HorizontalAlignment="Stretch" />
                                             </StackPanel>
-                                            <StackPanel Spacing="4">
+                                            <StackPanel Grid.Column="2" Spacing="4">
                                                 <TextBlock Text="{loc:Loc 'End Date'}"
                                                            FontSize="11"
                                                            Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -662,7 +662,7 @@
                                                             MinWidth="0"
                                                             HorizontalAlignment="Stretch" />
                                             </StackPanel>
-                                        </StackPanel>
+                                        </Grid>
                                     </StackPanel>
                                 </Border>
                             </StackPanel>
@@ -1701,20 +1701,20 @@
                                             Padding="10"
                                             Margin="0,4,0,0"
                                             IsVisible="{Binding IsCustomDateRange}">
-                                        <StackPanel Spacing="8">
-                                            <StackPanel Spacing="4">
+                                        <Grid ColumnDefinitions="*,8,*">
+                                            <StackPanel Grid.Column="0" Spacing="4">
                                                 <TextBlock Text="{loc:Loc 'Start Date'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                                 <DatePicker SelectedDate="{Binding CustomStartDate}"
                                                             MinWidth="0"
                                                             HorizontalAlignment="Stretch" />
                                             </StackPanel>
-                                            <StackPanel Spacing="4">
+                                            <StackPanel Grid.Column="2" Spacing="4">
                                                 <TextBlock Text="{loc:Loc 'End Date'}" FontSize="11" Foreground="{DynamicResource TextTertiaryBrush}" />
                                                 <DatePicker SelectedDate="{Binding CustomEndDate}"
                                                             MinWidth="0"
                                                             HorizontalAlignment="Stretch" />
                                             </StackPanel>
-                                        </StackPanel>
+                                        </Grid>
                                     </Border>
                                 </StackPanel>
 


### PR DESCRIPTION
## Summary
Standardized the layout of date range and amount range filters across multiple modals and pages by converting from stacked or inline layouts to a consistent side-by-side grid layout with improved spacing and labeling.

## Key Changes
- **Unified filter layout pattern**: Replaced various layout approaches (stacked StackPanels, inline TextBlocks with "to" separators) with a consistent `Grid ColumnDefinitions="*,8,*"` pattern for all date and amount range filters
- **Improved labeling**: Added explicit "From"/"To" and "Min"/"Max" labels above input fields instead of relying on inline separators or watermarks
- **Better spacing**: Reduced column gap from `Auto` (variable) to fixed `8` units for consistent visual alignment
- **Enhanced input sizing**: Added `MinWidth="0"` to DatePickers to prevent layout overflow and ensure proper grid column distribution
- **Standardized watermarks**: Updated amount input watermarks to use consistent "$0.00" format instead of localized strings

## Files Modified
- **InvoiceModals.axaml**: Issue Date, Due Date, and Amount Range filters
- **ReceiptsModals.axaml**: Date Range and Amount Range filters
- **CustomerModals.axaml**: Outstanding Amount and Last Rental Date filters
- **LostDamagedModals.axaml**: Date Range filter
- **ReturnsModals.axaml**: Date Range filter
- **CustomDateRangeModal.axaml**: Start/End Date filter
- **PaymentModals.axaml**: Date Range and Amount Range filters
- **RentalRecordsModals.axaml**: Start Date and Due Date Range filters
- **ExpenseModals.axaml**: Date Range and Amount Range filters
- **RevenueModals.axaml**: Date Range and Amount Range filters
- **PurchaseOrdersModals.axaml**: Minor alignment adjustments (VerticalAlignment changes)
- **ReportsPage.axaml**: Custom date range filter
- **StockAdjustmentsModals.axaml**: Date Range filter

## Implementation Details
- All date/amount range filters now use a two-column grid layout with an 8-unit gap separator
- Input fields are wrapped in StackPanels with 4-unit spacing to accommodate labels above inputs
- Consistent font sizing: 13pt for section headers, 12pt for field labels
- Maintains existing data bindings and validation behaviors

https://claude.ai/code/session_01MNZQmvBHx5a8qFrn3xfRas