### PR TITLE
Improve skip records handling and warning messages

### DIFF
--- a/ArgoBooks.Core/Services/SpreadsheetImportService.cs
+++ b/ArgoBooks.Core/Services/SpreadsheetImportService.cs
@@ -315,7 +315,7 @@ public class SpreadsheetImportService
                     result.TotalUpdated += sheetResult.Updated;
                     result.TotalSkipped += sheetResult.Skipped;
                     result.SheetResults.Add(sheetResult);
-                    if (sheetResult.Inserted == 0 && sheetResult.Updated == 0)
+                    if (sheetResult.Inserted == 0 && sheetResult.Updated == 0 && sheetResult.Skipped == 0)
                         result.Warnings.Add($"Sheet detected as '{sheetType}' but 0 records were imported from {rows.Count} rows.");
                 }
                 else
@@ -511,7 +511,7 @@ public class SpreadsheetImportService
         result.TotalUpdated += sheetResult.Updated;
         result.TotalSkipped += sheetResult.Skipped;
         result.SheetResults.Add(sheetResult);
-        if (sheetResult.Inserted == 0 && sheetResult.Updated == 0 && rows.Count > 0)
+        if (sheetResult.Inserted == 0 && sheetResult.Updated == 0 && sheetResult.Skipped == 0 && rows.Count > 0)
             result.Warnings.Add($"Sheet '{sheetName}': detected as '{sheetType}' but 0 records were imported from {rows.Count} rows.");
     }
 
@@ -629,7 +629,7 @@ public class SpreadsheetImportService
         {
             result.Skipped = options.SkippedCount;
             if (result.Skipped > 0)
-                result.SkipReasons.Add($"{result.Skipped} existing {sheetType} records skipped");
+                result.SkipReasons.Add($"{result.Skipped} {sheetType} records skipped (already exist)");
         }
         else
         {

--- a/ArgoBooks/ViewModels/ImportMappingDialogViewModel.cs
+++ b/ArgoBooks/ViewModels/ImportMappingDialogViewModel.cs
@@ -166,6 +166,34 @@ public partial class ImportMappingDialogViewModel : ViewModelBase
     [ObservableProperty]
     private bool _skipExistingRecords;
 
+    private bool _suppressSkipConfirmation;
+
+    async partial void OnSkipExistingRecordsChanged(bool value)
+    {
+        if (value || _suppressSkipConfirmation)
+            return;
+
+        var dialog = App.ConfirmationDialog;
+        if (dialog != null)
+        {
+            var result = await dialog.ShowAsync(new ConfirmationDialogOptions
+            {
+                Title = "Overwrite Existing Records?".Translate(),
+                Message = "This may overwrite existing data in your company file with values from the spreadsheet. Are you sure?".Translate(),
+                PrimaryButtonText = "Allow Overwrite".Translate(),
+                CancelButtonText = "Keep Safe".Translate(),
+                IsPrimaryDestructive = true
+            });
+
+            if (result != ConfirmationResult.Primary)
+            {
+                _suppressSkipConfirmation = true;
+                SkipExistingRecords = true;
+                _suppressSkipConfirmation = false;
+            }
+        }
+    }
+
     public ObservableCollection<SheetAnalysisViewModel> Sheets { get; } = [];
 
     public ObservableCollection<string> Warnings { get; } = [];


### PR DESCRIPTION
## Summary
This PR improves the user experience when handling skipped records during spreadsheet imports by adding a confirmation dialog and refining warning/skip reason messages.

## Key Changes
- **Added confirmation dialog for disabling skip**: When users uncheck "Skip Existing Records", a confirmation dialog now warns them about potential data overwrites and allows them to reconsider
- **Refined warning logic**: Updated conditions to exclude sheets from warnings when records are skipped, since skipped records are a valid outcome (not an error state)
- **Improved skip reason messaging**: Changed skip reason text from "existing X records skipped" to "X records skipped (already exist)" for clarity

## Implementation Details
- Added `_suppressSkipConfirmation` flag to prevent recursive dialog triggers when programmatically resetting the checkbox
- The confirmation dialog uses destructive styling on the "Allow Overwrite" button to emphasize the risky action
- Warning messages now only trigger when a sheet has zero inserted, zero updated, AND zero skipped records (indicating a potential detection issue)
- Skip reason messages are now more explicit about why records were skipped

https://claude.ai/code/session_01SLpyDqNaTfuWttir9EkedF