### PR TITLE
Restore using var on CancellationTokenSource instances

### DIFF
--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -2875,7 +2875,7 @@ public class App : Application
     {
         if (_appShellViewModel == null) return;
 
-        var analysisCts = new CancellationTokenSource();
+        using var analysisCts = new CancellationTokenSource();
         _mainWindowViewModel?.ShowLoading("Analyzing spreadsheet structure...".Translate(), "Reading file...", 0, analysisCts, ConfirmCancelAsync);
         await Task.Yield(); // Allow UI to render the loading overlay before heavy work begins
 
@@ -3005,7 +3005,7 @@ public class App : Application
                 }
 
                 // Import Tier 1 data
-                var importCts = new CancellationTokenSource();
+                using var importCts = new CancellationTokenSource();
                 _mainWindowViewModel?.ShowLoading("Importing data...".Translate(), cts: importCts, cancelConfirmation: ConfirmCancelAsync);
 
                 var importProgress = new Progress<(string detail, double percent)>(p =>
@@ -3038,7 +3038,7 @@ public class App : Application
             var allSheetResults = new List<SheetImportResult>();
             if (tier2Sheets.Count > 0)
             {
-                var tier2Cts = new CancellationTokenSource();
+                using var tier2Cts = new CancellationTokenSource();
 
                 _mainWindowViewModel?.ShowLoading(
                     "AI processing...".Translate(),


### PR DESCRIPTION
Ensures analysisCts, importCts, and tier2Cts are properly disposed when PerformAiImportAsync completes or returns early, matching the existing pattern used by validationCts.