### PR TITLE
Improve license key formatting and consolidate payment method options

### DIFF
--- a/ArgoBooks.Core/Enums/PaymentMethod.cs
+++ b/ArgoBooks.Core/Enums/PaymentMethod.cs
@@ -69,4 +69,12 @@ public static class PaymentMethodExtensions
             PaymentMethod.Other.GetDisplayName()
         ];
     }
+
+    /// <summary>
+    /// Gets all payment method options for filter dropdowns, prefixed with "All".
+    /// </summary>
+    public static string[] GetFilterOptions()
+    {
+        return ["All", .. Enum.GetValues<PaymentMethod>().Select(m => m.GetDisplayName())];
+    }
 }

--- a/ArgoBooks.Core/Enums/PaymentMethod.cs
+++ b/ArgoBooks.Core/Enums/PaymentMethod.cs
@@ -61,7 +61,8 @@ public static class PaymentMethodExtensions
         return
         [
             PaymentMethod.Cash.GetDisplayName(),
-            "Bank Card",
+            PaymentMethod.CreditCard.GetDisplayName(),
+            PaymentMethod.DebitCard.GetDisplayName(),
             PaymentMethod.BankTransfer.GetDisplayName(),
             PaymentMethod.Check.GetDisplayName(),
             PaymentMethod.PayPal.GetDisplayName(),

--- a/ArgoBooks/Modals/UpgradeModal.axaml.cs
+++ b/ArgoBooks/Modals/UpgradeModal.axaml.cs
@@ -325,6 +325,13 @@ public partial class UpgradeModal : UserControl
                 formatted.Append(digitsOnly[i]);
             }
 
+            // If user typed a dash at a group boundary, add trailing dash
+            // so the caret can advance past it (e.g. "3333" -> "3333-")
+            if (userTypedDash && digitsOnly.Length > 0 && digitsOnly.Length % 4 == 0 && digitsOnly.Length < 20)
+            {
+                formatted.Append('-');
+            }
+
             var formattedText = formatted.ToString();
 
             // Calculate new caret position based on digits before caret

--- a/ArgoBooks/Modals/UpgradeModal.axaml.cs
+++ b/ArgoBooks/Modals/UpgradeModal.axaml.cs
@@ -302,6 +302,10 @@ public partial class UpgradeModal : UserControl
             var text = textBox.Text ?? string.Empty;
             var caretIndex = textBox.CaretIndex;
 
+            // Detect if the user just typed a dash (text has a dash that isn't at a formatted position)
+            var userTypedDash = caretIndex > 0 && caretIndex <= text.Length
+                && text[caretIndex - 1] == '-';
+
             // Count digits before cursor in original text
             var digitsBeforeCaret = text.Take(caretIndex).Count(char.IsLetterOrDigit);
 
@@ -323,23 +327,29 @@ public partial class UpgradeModal : UserControl
 
             var formattedText = formatted.ToString();
 
-            // Only update if different to avoid infinite loop
+            // Calculate new caret position based on digits before caret
+            var newCaretIndex = 0;
+            var digitCount = 0;
+            for (int i = 0; i < formattedText.Length && digitCount < digitsBeforeCaret; i++)
+            {
+                newCaretIndex = i + 1;
+                if (char.IsLetterOrDigit(formattedText[i]))
+                    digitCount++;
+            }
+
+            // If user typed a dash, advance caret past the next dash in formatted text
+            if (userTypedDash && newCaretIndex < formattedText.Length && formattedText[newCaretIndex] == '-')
+            {
+                newCaretIndex++;
+            }
+
+            // Only update text if different to avoid infinite loop
             if (text != formattedText)
             {
                 textBox.Text = formattedText;
-
-                // Calculate new caret position based on digits before caret
-                var newCaretIndex = 0;
-                var digitCount = 0;
-                for (int i = 0; i < formattedText.Length && digitCount < digitsBeforeCaret; i++)
-                {
-                    newCaretIndex = i + 1;
-                    if (char.IsLetterOrDigit(formattedText[i]))
-                        digitCount++;
-                }
-
-                textBox.CaretIndex = Math.Min(newCaretIndex, formattedText.Length);
             }
+
+            textBox.CaretIndex = Math.Min(newCaretIndex, formattedText.Length);
         }
         finally
         {

--- a/ArgoBooks/ViewModels/PaymentModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/PaymentModalsViewModel.cs
@@ -165,14 +165,14 @@ public partial class PaymentModalsViewModel : ViewModelBase
     #region Dropdown Options
 
     /// <summary>
-    /// Payment method options for add/edit modal (Cash and Check only as per requirements).
+    /// Payment method options for add/edit modal.
     /// </summary>
-    public ObservableCollection<string> ModalPaymentMethodOptions { get; } = ["Cash", "Credit Card", "Debit Card", "Check"];
+    public ObservableCollection<string> ModalPaymentMethodOptions { get; } = new(PaymentMethodExtensions.GetCommonOptions());
 
     /// <summary>
     /// Payment method options for filter (includes All).
     /// </summary>
-    public ObservableCollection<string> FilterPaymentMethodOptions { get; } = ["All", "Cash", "Credit Card", "Debit Card", "Check", "Stripe", "PayPal", "Square"];
+    public ObservableCollection<string> FilterPaymentMethodOptions { get; } = new(PaymentMethodExtensions.GetFilterOptions());
 
     /// <summary>
     /// Status options for filter.

--- a/ArgoBooks/ViewModels/PaymentModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/PaymentModalsViewModel.cs
@@ -167,12 +167,12 @@ public partial class PaymentModalsViewModel : ViewModelBase
     /// <summary>
     /// Payment method options for add/edit modal (Cash and Check only as per requirements).
     /// </summary>
-    public ObservableCollection<string> ModalPaymentMethodOptions { get; } = ["Cash", "Check"];
+    public ObservableCollection<string> ModalPaymentMethodOptions { get; } = ["Cash", "Credit Card", "Debit Card", "Check"];
 
     /// <summary>
     /// Payment method options for filter (includes All).
     /// </summary>
-    public ObservableCollection<string> FilterPaymentMethodOptions { get; } = ["All", "Cash", "Check", "Stripe", "PayPal", "Square"];
+    public ObservableCollection<string> FilterPaymentMethodOptions { get; } = ["All", "Cash", "Credit Card", "Debit Card", "Check", "Stripe", "PayPal", "Square"];
 
     /// <summary>
     /// Status options for filter.

--- a/ArgoBooks/ViewModels/PaymentsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/PaymentsPageViewModel.cs
@@ -328,7 +328,7 @@ public partial class PaymentsPageViewModel : SortablePageViewModelBase
     /// <summary>
     /// Payment method options for filter.
     /// </summary>
-    public ObservableCollection<string> PaymentMethodOptions { get; } = ["All", "Cash", "Check"];
+    public ObservableCollection<string> PaymentMethodOptions { get; } = ["All", "Cash", "Credit Card", "Debit Card", "Check"];
 
     /// <summary>
     /// Status options for filter.

--- a/ArgoBooks/ViewModels/PaymentsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/PaymentsPageViewModel.cs
@@ -328,7 +328,7 @@ public partial class PaymentsPageViewModel : SortablePageViewModelBase
     /// <summary>
     /// Payment method options for filter.
     /// </summary>
-    public ObservableCollection<string> PaymentMethodOptions { get; } = ["All", "Cash", "Credit Card", "Debit Card", "Check"];
+    public ObservableCollection<string> PaymentMethodOptions { get; } = new(PaymentMethodExtensions.GetFilterOptions());
 
     /// <summary>
     /// Status options for filter.

--- a/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
@@ -583,8 +583,8 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
         LineItems.Clear();
         foreach (var item in result.LineItems)
         {
-            // Skip discount lines and negative-amount adjustments
-            if (IsDiscountLine(item))
+            // Skip discount lines, negative-amount adjustments, and $0 items
+            if (IsDiscountLine(item) || item.TotalPrice == 0)
                 continue;
 
             var lineItem = new ScannedLineItemViewModel

--- a/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
@@ -305,16 +305,7 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
 
     public ObservableCollection<SupplierOption> SupplierOptions { get; } = [];
     public ObservableCollection<ProductOption> ProductOptions { get; } = [];
-    public ObservableCollection<string> PaymentMethodOptions { get; } =
-    [
-        "Cash",
-        "Credit Card",
-        "Debit Card",
-        "Bank Transfer",
-        "Check",
-        "PayPal",
-        "Other"
-    ];
+    public ObservableCollection<string> PaymentMethodOptions { get; } = new(PaymentMethodExtensions.GetCommonOptions());
 
     [ObservableProperty]
     private bool _hasTotalError;


### PR DESCRIPTION
## Summary
This PR improves the license key input formatting experience and refactors payment method options to use a centralized enum extension method, reducing code duplication and ensuring consistency across the application.

## Key Changes

### License Key Formatting Enhancement
- **Improved dash handling**: Detect when users explicitly type a dash and automatically advance the caret past formatted dashes, providing a smoother input experience
- **Better caret positioning**: Refactored caret position calculation to work correctly with the new dash detection logic
- **Moved caret update outside conditional**: Caret position is now always updated, even when text hasn't changed, ensuring proper cursor placement after formatting

### Payment Method Options Consolidation
- **Centralized enum extensions**: Added `GetCommonOptions()` and `GetFilterOptions()` methods to `PaymentMethodExtensions` to provide consistent payment method lists across the application
- **Updated view models**: Refactored `ReceiptsModalsViewModel`, `PaymentModalsViewModel`, and `PaymentsPageViewModel` to use the new centralized methods instead of hardcoded string arrays
- **Improved maintainability**: Payment method options are now defined in a single location, making future updates easier and reducing the risk of inconsistencies

### Additional Improvements
- **Receipt scanning**: Added filter to skip $0 items when populating scanned line items
- **UI spacing**: Added vertical margins (24px) to upgrade modal cards for better visual spacing

## Implementation Details
- The license key formatting now properly detects user-typed dashes by checking if a dash exists at the caret position before formatting
- Payment method options are now sourced from the enum's display names, ensuring they stay in sync with the actual enum values
- The filter options method includes an "All" option prefixed to the complete enum list for filtering scenarios

https://claude.ai/code/session_01UgH8SViyXjWA6F5oweS1m8