### PR TITLE
Add offline transaction support with pending USD conversion queue

### DIFF
--- a/ArgoBooks.Core/Data/CompanyData.cs
+++ b/ArgoBooks.Core/Data/CompanyData.cs
@@ -1,4 +1,5 @@
 using ArgoBooks.Core.Models;
+using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Core.Models.Insights;
 using ArgoBooks.Core.Models.Inventory;
@@ -204,6 +205,17 @@ public class CompanyData
     /// </summary>
     [JsonPropertyName("invoiceTemplates")]
     public List<InvoiceTemplate> InvoiceTemplates { get; init; } = [];
+
+    #endregion
+
+    #region Pending Conversions
+
+    /// <summary>
+    /// Transactions saved offline that are awaiting USD conversion.
+    /// Persisted in the .argo file as a secondary backup (primary backup is in app data directory).
+    /// </summary>
+    [JsonPropertyName("pendingConversions")]
+    public List<PendingConversion> PendingConversions { get; init; } = [];
 
     #endregion
 

--- a/ArgoBooks.Core/Models/Common/PendingConversion.cs
+++ b/ArgoBooks.Core/Models/Common/PendingConversion.cs
@@ -1,0 +1,58 @@
+namespace ArgoBooks.Core.Models.Common;
+
+/// <summary>
+/// Represents a transaction that was saved offline without USD conversion.
+/// Stored in a persistent queue that survives between sessions.
+/// </summary>
+public class PendingConversion
+{
+    /// <summary>
+    /// The ID of the transaction awaiting conversion (e.g., "PUR-2026-00001" or "REV-2026-00001").
+    /// </summary>
+    [JsonPropertyName("transactionId")]
+    public string TransactionId { get; set; } = "";
+
+    /// <summary>
+    /// The type of transaction: "Revenue" or "Expense".
+    /// </summary>
+    [JsonPropertyName("transactionType")]
+    public string TransactionType { get; set; } = "";
+
+    /// <summary>
+    /// The ISO currency code of the original transaction (e.g., "EUR", "CAD").
+    /// </summary>
+    [JsonPropertyName("originalCurrency")]
+    public string OriginalCurrency { get; set; } = "";
+
+    /// <summary>
+    /// The date of the transaction, used for exchange rate lookup.
+    /// </summary>
+    [JsonPropertyName("transactionDate")]
+    public DateTime TransactionDate { get; set; }
+
+    /// <summary>
+    /// When this pending conversion entry was created.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    // Original amounts stored as backup for conversion
+
+    [JsonPropertyName("total")]
+    public decimal Total { get; set; }
+
+    [JsonPropertyName("taxAmount")]
+    public decimal TaxAmount { get; set; }
+
+    [JsonPropertyName("shippingCost")]
+    public decimal ShippingCost { get; set; }
+
+    [JsonPropertyName("discount")]
+    public decimal Discount { get; set; }
+
+    [JsonPropertyName("fee")]
+    public decimal Fee { get; set; }
+
+    [JsonPropertyName("unitPrice")]
+    public decimal UnitPrice { get; set; }
+}

--- a/ArgoBooks.Core/Models/Transactions/Transaction.cs
+++ b/ArgoBooks.Core/Models/Transactions/Transaction.cs
@@ -178,29 +178,40 @@ public abstract class Transaction
     public decimal FeeUSD { get; set; }
 
     /// <summary>
+    /// Whether this transaction was saved offline and is awaiting USD conversion.
+    /// When true, all Effective*USD properties return 0 to prevent wrong cross-currency aggregation.
+    /// </summary>
+    [JsonPropertyName("isPendingConversion")]
+    public bool IsPendingConversion { get; set; }
+
+    /// <summary>
     /// Gets the effective total in USD, falling back to Total for legacy data.
+    /// Returns 0 for pending-conversion transactions to avoid cross-currency contamination.
     /// </summary>
     [JsonIgnore]
-    public decimal EffectiveTotalUSD => TotalUSD > 0 ? TotalUSD : Total;
+    public decimal EffectiveTotalUSD => IsPendingConversion ? 0 : (TotalUSD > 0 ? TotalUSD : Total);
 
     /// <summary>
     /// Gets the effective pre-tax subtotal in USD (excludes tax).
     /// Tax is a liability, not revenue/expense, so this matches Income Statement treatment.
+    /// Returns 0 for pending-conversion transactions.
     /// </summary>
     [JsonIgnore]
-    public decimal EffectiveSubtotalUSD => EffectiveTotalUSD - (TaxAmountUSD > 0 ? TaxAmountUSD : TaxAmount);
+    public decimal EffectiveSubtotalUSD => IsPendingConversion ? 0 : (EffectiveTotalUSD - (TaxAmountUSD > 0 ? TaxAmountUSD : TaxAmount));
 
     /// <summary>
     /// Gets the effective unit price in USD, falling back to UnitPrice for legacy data.
+    /// Returns 0 for pending-conversion transactions.
     /// </summary>
     [JsonIgnore]
-    public decimal EffectiveUnitPriceUSD => UnitPriceUSD > 0 ? UnitPriceUSD : UnitPrice;
+    public decimal EffectiveUnitPriceUSD => IsPendingConversion ? 0 : (UnitPriceUSD > 0 ? UnitPriceUSD : UnitPrice);
 
     /// <summary>
     /// Gets the effective shipping cost in USD, falling back to ShippingCost for legacy data.
+    /// Returns 0 for pending-conversion transactions.
     /// </summary>
     [JsonIgnore]
-    public decimal EffectiveShippingCostUSD => ShippingCostUSD > 0 ? ShippingCostUSD : ShippingCost;
+    public decimal EffectiveShippingCostUSD => IsPendingConversion ? 0 : (ShippingCostUSD > 0 ? ShippingCostUSD : ShippingCost);
 
     #endregion
 }

--- a/ArgoBooks.Core/Services/FileService.cs
+++ b/ArgoBooks.Core/Services/FileService.cs
@@ -1,5 +1,6 @@
 using ArgoBooks.Core.Data;
 using ArgoBooks.Core.Models;
+using ArgoBooks.Core.Models.Common;
 using SkiaSharp;
 
 namespace ArgoBooks.Core.Services;
@@ -69,6 +70,7 @@ public class FileService(
             await WriteJsonAsync(companyDir, "reportTemplates.json", companyData.ReportTemplates, cancellationToken);
             await WriteJsonAsync(companyDir, "idCounters.json", companyData.IdCounters, cancellationToken);
             await WriteJsonAsync(companyDir, "eventLog.json", companyData.EventLog, cancellationToken);
+            await WriteJsonAsync(companyDir, "pendingConversions.json", companyData.PendingConversions, cancellationToken);
 
             // Create receipts subdirectory
             Directory.CreateDirectory(Path.Combine(companyDir, "receipts"));
@@ -279,7 +281,8 @@ public class FileService(
             LostDamaged = await ReadJsonAsync<List<Models.Tracking.LostDamaged>>(tempDirectory, "lostDamaged.json", cancellationToken) ?? [],
             Receipts = await ReadJsonAsync<List<Models.Tracking.Receipt>>(tempDirectory, "receipts.json", cancellationToken) ?? [],
             ReportTemplates = await ReadJsonAsync<List<Models.Reports.ReportTemplate>>(tempDirectory, "reportTemplates.json", cancellationToken) ?? [],
-            EventLog = await ReadJsonAsync<List<AuditEvent>>(tempDirectory, "eventLog.json", cancellationToken) ?? []
+            EventLog = await ReadJsonAsync<List<AuditEvent>>(tempDirectory, "eventLog.json", cancellationToken) ?? [],
+            PendingConversions = await ReadJsonAsync<List<PendingConversion>>(tempDirectory, "pendingConversions.json", cancellationToken) ?? []
         };
 
         return data;
@@ -323,6 +326,7 @@ public class FileService(
         await WriteJsonAsync(companyDirectory, "receipts.json", data.Receipts, cancellationToken);
         await WriteJsonAsync(companyDirectory, "reportTemplates.json", data.ReportTemplates, cancellationToken);
         await WriteJsonAsync(companyDirectory, "eventLog.json", data.EventLog, cancellationToken);
+        await WriteJsonAsync(companyDirectory, "pendingConversions.json", data.PendingConversions, cancellationToken);
 
         data.MarkAsSaved();
     }

--- a/ArgoBooks.Core/Services/PendingConversionService.cs
+++ b/ArgoBooks.Core/Services/PendingConversionService.cs
@@ -33,7 +33,7 @@ public class PendingConversionService
     /// Fired after pending conversions are successfully processed.
     /// UI should refresh transaction lists and charts.
     /// </summary>
-    public event EventHandler? PendingConversionsProcessed;
+    public event EventHandler<PendingConversionsProcessedEventArgs>? PendingConversionsProcessed;
 
     public PendingConversionService(IErrorLogger? errorLogger = null)
         : this(PlatformServiceFactory.GetPlatformService(), errorLogger)
@@ -231,7 +231,7 @@ public class PendingConversionService
             // Mark company data as changed so the next save includes the updated USD values
             companyData.MarkAsModified();
 
-            PendingConversionsProcessed?.Invoke(this, EventArgs.Empty);
+            PendingConversionsProcessed?.Invoke(this, new PendingConversionsProcessedEventArgs(processed.Count));
         }
     }
 
@@ -278,4 +278,15 @@ public class PendingConversionService
     {
         return _platformService.CombinePaths(_platformService.GetAppDataPath(), QueueFileName);
     }
+}
+
+/// <summary>
+/// Event args for when pending conversions are processed.
+/// </summary>
+public class PendingConversionsProcessedEventArgs(int convertedCount) : EventArgs
+{
+    /// <summary>
+    /// The number of transactions that were successfully converted.
+    /// </summary>
+    public int ConvertedCount { get; } = convertedCount;
 }

--- a/ArgoBooks.Core/Services/PendingConversionService.cs
+++ b/ArgoBooks.Core/Services/PendingConversionService.cs
@@ -1,0 +1,281 @@
+using ArgoBooks.Core.Data;
+using ArgoBooks.Core.Models.Common;
+using ArgoBooks.Core.Models.Transactions;
+using ArgoBooks.Core.Platform;
+
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Manages a persistent queue of transactions saved offline that need USD conversion.
+/// Uses two-layer persistence: app-data file (immediate) + CompanyData (on save).
+/// </summary>
+public class PendingConversionService
+{
+    private const string QueueFileName = "pending_conversions.json";
+
+    private readonly IPlatformService _platformService;
+    private readonly IErrorLogger? _errorLogger;
+    private readonly List<PendingConversion> _queue = [];
+    private readonly Lock _lock = new();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Singleton instance.
+    /// </summary>
+    public static PendingConversionService? Instance { get; private set; }
+
+    /// <summary>
+    /// Fired after pending conversions are successfully processed.
+    /// UI should refresh transaction lists and charts.
+    /// </summary>
+    public event EventHandler? PendingConversionsProcessed;
+
+    public PendingConversionService(IErrorLogger? errorLogger = null)
+        : this(PlatformServiceFactory.GetPlatformService(), errorLogger)
+    {
+    }
+
+    public PendingConversionService(IPlatformService platformService, IErrorLogger? errorLogger = null)
+    {
+        _platformService = platformService;
+        _errorLogger = errorLogger;
+        Instance ??= this;
+    }
+
+    /// <summary>
+    /// Number of pending conversions in the queue.
+    /// </summary>
+    public int PendingCount
+    {
+        get
+        {
+            lock (_lock) return _queue.Count;
+        }
+    }
+
+    /// <summary>
+    /// Whether there are any pending conversions.
+    /// </summary>
+    public bool HasPendingConversions => PendingCount > 0;
+
+    /// <summary>
+    /// Checks if a specific transaction is pending conversion.
+    /// </summary>
+    public bool IsTransactionPending(string transactionId)
+    {
+        lock (_lock) return _queue.Any(p => p.TransactionId == transactionId);
+    }
+
+    /// <summary>
+    /// Adds a pending conversion entry and immediately persists to disk.
+    /// </summary>
+    public async Task AddPendingConversionAsync(PendingConversion entry)
+    {
+        lock (_lock)
+        {
+            // Avoid duplicates
+            if (_queue.Any(p => p.TransactionId == entry.TransactionId))
+                return;
+            _queue.Add(entry);
+        }
+
+        await SaveToDiskAsync();
+    }
+
+    /// <summary>
+    /// Loads the queue from the app-data directory file.
+    /// </summary>
+    public async Task LoadAsync()
+    {
+        if (!_platformService.SupportsFileSystem)
+            return;
+
+        var filePath = GetQueueFilePath();
+        if (!File.Exists(filePath))
+            return;
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(filePath);
+            var entries = JsonSerializer.Deserialize<List<PendingConversion>>(json, JsonOptions);
+            if (entries != null)
+            {
+                lock (_lock)
+                {
+                    _queue.Clear();
+                    _queue.AddRange(entries);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _errorLogger?.LogWarning($"Failed to load pending conversions: {ex.Message}", "PendingConversionService");
+        }
+    }
+
+    /// <summary>
+    /// Reconciles the in-memory queue with the CompanyData's PendingConversions list.
+    /// Merges entries from both sources (app-data file may have entries not yet in .argo file and vice versa).
+    /// Also removes entries for transactions that have already been converted (IsPendingConversion = false).
+    /// </summary>
+    public async Task ReconcileWithCompanyDataAsync(CompanyData companyData)
+    {
+        lock (_lock)
+        {
+            // Build a set of all known transaction IDs
+            var existingIds = new HashSet<string>(_queue.Select(p => p.TransactionId));
+
+            // Add any entries from CompanyData that we don't already have
+            foreach (var entry in companyData.PendingConversions)
+            {
+                if (existingIds.Add(entry.TransactionId))
+                {
+                    _queue.Add(entry);
+                }
+            }
+
+            // Remove entries for transactions that have already been converted
+            _queue.RemoveAll(p =>
+            {
+                var transaction = FindTransaction(companyData, p.TransactionId, p.TransactionType);
+                return transaction != null && !transaction.IsPendingConversion;
+            });
+
+            // Sync back to CompanyData
+            companyData.PendingConversions.Clear();
+            companyData.PendingConversions.AddRange(_queue);
+        }
+
+        await SaveToDiskAsync();
+    }
+
+    /// <summary>
+    /// Attempts to process all pending conversions by fetching exchange rates.
+    /// Only processes entries where rates are available (online).
+    /// </summary>
+    public async Task ProcessPendingConversionsAsync(CompanyData companyData)
+    {
+        var exchangeService = ExchangeRateService.Instance;
+        if (exchangeService == null)
+            return;
+
+        List<PendingConversion> toProcess;
+        lock (_lock)
+        {
+            toProcess = [.. _queue];
+        }
+
+        if (toProcess.Count == 0)
+            return;
+
+        var processed = new List<PendingConversion>();
+
+        foreach (var entry in toProcess)
+        {
+            try
+            {
+                // Try to get the exchange rate (will fetch from API if missing)
+                var rate = await exchangeService.GetExchangeRateAsync(
+                    entry.OriginalCurrency, "USD", entry.TransactionDate, fetchIfMissing: true);
+
+                if (rate <= 0)
+                    continue; // Still offline or rate unavailable — skip
+
+                // Find the transaction and apply the conversion
+                var transaction = FindTransaction(companyData, entry.TransactionId, entry.TransactionType);
+                if (transaction == null)
+                {
+                    // Transaction was deleted — remove from queue
+                    processed.Add(entry);
+                    continue;
+                }
+
+                // Apply USD conversion
+                transaction.TotalUSD = Math.Round(entry.Total * rate, 2);
+                transaction.TaxAmountUSD = Math.Round(entry.TaxAmount * rate, 2);
+                transaction.ShippingCostUSD = Math.Round(entry.ShippingCost * rate, 2);
+                transaction.DiscountUSD = Math.Round(entry.Discount * rate, 2);
+                transaction.FeeUSD = Math.Round(entry.Fee * rate, 2);
+                transaction.UnitPriceUSD = Math.Round(entry.UnitPrice * rate, 2);
+                transaction.IsPendingConversion = false;
+
+                processed.Add(entry);
+            }
+            catch (Exception ex)
+            {
+                _errorLogger?.LogWarning($"Failed to process pending conversion for {entry.TransactionId}: {ex.Message}", "PendingConversionService");
+            }
+        }
+
+        if (processed.Count > 0)
+        {
+            lock (_lock)
+            {
+                foreach (var entry in processed)
+                {
+                    _queue.RemoveAll(p => p.TransactionId == entry.TransactionId);
+                }
+
+                // Sync back to CompanyData
+                companyData.PendingConversions.Clear();
+                companyData.PendingConversions.AddRange(_queue);
+            }
+
+            await SaveToDiskAsync();
+
+            // Mark company data as changed so the next save includes the updated USD values
+            companyData.MarkAsModified();
+
+            PendingConversionsProcessed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private static Transaction? FindTransaction(CompanyData companyData, string id, string type)
+    {
+        return type switch
+        {
+            "Expense" => companyData.Expenses.FirstOrDefault(e => e.Id == id),
+            "Revenue" => companyData.Revenues.FirstOrDefault(r => r.Id == id),
+            _ => null
+        };
+    }
+
+    private async Task SaveToDiskAsync()
+    {
+        if (!_platformService.SupportsFileSystem)
+            return;
+
+        try
+        {
+            List<PendingConversion> snapshot;
+            lock (_lock)
+            {
+                snapshot = [.. _queue];
+            }
+
+            var filePath = GetQueueFilePath();
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                _platformService.EnsureDirectoryExists(directory);
+            }
+
+            var json = JsonSerializer.Serialize(snapshot, JsonOptions);
+            await File.WriteAllTextAsync(filePath, json);
+        }
+        catch (Exception ex)
+        {
+            _errorLogger?.LogWarning($"Failed to save pending conversions: {ex.Message}", "PendingConversionService");
+        }
+    }
+
+    private string GetQueueFilePath()
+    {
+        return _platformService.CombinePaths(_platformService.GetAppDataPath(), QueueFileName);
+    }
+}

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -749,6 +749,30 @@ public class App : Application
             // Wire up company manager events
             WireCompanyManagerEvents();
 
+            // Wire up pending conversion events
+            if (PendingConversionService != null)
+            {
+                PendingConversionService.PendingConversionsProcessed += (_, args) =>
+                {
+                    if (args is PendingConversionsProcessedEventArgs e && e.ConvertedCount > 0)
+                    {
+                        var message = e.ConvertedCount == 1
+                            ? "1 offline transaction has been converted to USD.".Translate()
+                            : $"{e.ConvertedCount} offline transactions have been converted to USD.";
+                        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                        {
+                            AddNotification(
+                                "Back Online".Translate(),
+                                message,
+                                NotificationType.Success);
+
+                            // Refresh the current page to update status badges and amounts
+                            NavigationService?.RefreshCurrentPage();
+                        });
+                    }
+                };
+            }
+
             // Wire up modal change events (separate from company manager)
             WireModalChangeEvents();
 

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -758,8 +758,8 @@ public class App : Application
                     if (args is PendingConversionsProcessedEventArgs e && e.ConvertedCount > 0)
                     {
                         var message = e.ConvertedCount == 1
-                            ? "1 offline transaction has been converted to USD.".Translate()
-                            : $"{e.ConvertedCount} offline transactions have been converted to USD.";
+                            ? "1 pending transaction has been processed successfully.".Translate()
+                            : string.Format("{0} pending transactions have been processed successfully.".Translate(), e.ConvertedCount);
                         Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                         {
                             AddNotification(
@@ -1375,7 +1375,7 @@ public class App : Application
             if (PendingConversionService != null && CompanyManager.CompanyData != null)
             {
                 await PendingConversionService.ReconcileWithCompanyDataAsync(CompanyManager.CompanyData);
-                _ = PendingConversionService.ProcessPendingConversionsAsync(CompanyManager.CompanyData);
+                await PendingConversionService.ProcessPendingConversionsAsync(CompanyManager.CompanyData);
             }
 
             // Start periodic timer to process pending conversions when connectivity returns

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -562,6 +562,7 @@ public class App : Application
     private static AppShellViewModel? _appShellViewModel;
     private static WelcomeScreenViewModel? _welcomeScreenViewModel;
     private static IdleDetectionService? _idleDetectionService;
+    private static System.Threading.Timer? _pendingConversionTimer;
 
     // Cached page ViewModels to improve performance and prevent memory leaks from event subscriptions
     private static DashboardPageViewModel? _dashboardPageViewModel;
@@ -1154,6 +1155,49 @@ public class App : Application
     }
 
     /// <summary>
+    /// Starts a periodic timer that checks for pending conversions and processes them
+    /// when connectivity is restored. Runs every 45 seconds.
+    /// </summary>
+    private static void StartPendingConversionTimer()
+    {
+        // Dispose any existing timer
+        _pendingConversionTimer?.Dispose();
+
+        _pendingConversionTimer = new System.Threading.Timer(async _ =>
+        {
+            try
+            {
+                if (PendingConversionService == null || !PendingConversionService.HasPendingConversions)
+                    return;
+
+                if (CompanyManager?.CompanyData == null)
+                    return;
+
+                // Check if we're online before attempting to process
+                var connectivityService = new ConnectivityService();
+                var isOnline = await connectivityService.IsInternetAvailableAsync();
+                if (!isOnline)
+                    return;
+
+                await PendingConversionService.ProcessPendingConversionsAsync(CompanyManager.CompanyData);
+            }
+            catch (Exception ex)
+            {
+                ErrorLogger?.LogWarning($"Pending conversion timer error: {ex.Message}", "App");
+            }
+        }, null, TimeSpan.FromSeconds(45), TimeSpan.FromSeconds(45));
+    }
+
+    /// <summary>
+    /// Stops the pending conversion timer.
+    /// </summary>
+    private static void StopPendingConversionTimer()
+    {
+        _pendingConversionTimer?.Dispose();
+        _pendingConversionTimer = null;
+    }
+
+    /// <summary>
     /// Registers file type associations for .argo files on Windows.
     /// Extracts the embedded icon to disk and associates it with the file extension.
     /// </summary>
@@ -1334,6 +1378,9 @@ public class App : Application
                 _ = PendingConversionService.ProcessPendingConversionsAsync(CompanyManager.CompanyData);
             }
 
+            // Start periodic timer to process pending conversions when connectivity returns
+            StartPendingConversionTimer();
+
             // Check for low stock and overdue invoice notifications
             CheckAndSendNotifications();
 
@@ -1358,6 +1405,9 @@ public class App : Application
             EventLogService?.Clear();
             ChangeTrackingService?.ClearAllChanges();
             _appShellViewModel.HeaderViewModel.ClearNotifications();
+
+            // Stop pending conversion timer when company is closed
+            StopPendingConversionTimer();
 
             // Clear cached page ViewModels to ensure fresh state when opening a new company
             ClearPageCaches();

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -660,6 +660,11 @@ public class App : Application
     /// </summary>
     public static ChangeTrackingService? ChangeTrackingService { get; private set; }
 
+    /// <summary>
+    /// Gets the pending conversion service for processing offline transactions.
+    /// </summary>
+    public static PendingConversionService? PendingConversionService { get; private set; }
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -710,6 +715,7 @@ public class App : Application
             UnsavedChangesDialog = new UnsavedChangesDialogViewModel();
             ReceiptViewerModal = new ReceiptViewerModalViewModel();
             ChangeTrackingService = new ChangeTrackingService();
+            PendingConversionService = new PendingConversionService(errorLogger);
             _idleDetectionService = new IdleDetectionService();
 
             // Create app shell with navigation service and optional update service
@@ -929,6 +935,12 @@ public class App : Application
 
             // Initialize exchange rate service for currency conversion
             await InitializeExchangeRateServiceAsync();
+
+            // Load pending conversion queue from disk
+            if (PendingConversionService != null)
+            {
+                await PendingConversionService.LoadAsync();
+            }
 
             // Load and apply saved license status
             if (LicenseService != null && _appShellViewModel != null)
@@ -1289,6 +1301,13 @@ public class App : Application
                         await SettingsService.SaveGlobalSettingsAsync();
                     }
                 }
+            }
+
+            // Reconcile and process any pending currency conversions
+            if (PendingConversionService != null && CompanyManager.CompanyData != null)
+            {
+                await PendingConversionService.ReconcileWithCompanyDataAsync(CompanyManager.CompanyData);
+                _ = PendingConversionService.ProcessPendingConversionsAsync(CompanyManager.CompanyData);
             }
 
             // Check for low stock and overdue invoice notifications

--- a/ArgoBooks/ViewModels/ExpenseModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ExpenseModalsViewModel.cs
@@ -6,6 +6,7 @@ using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Tracking;
 using ArgoBooks.Core.Models.Transactions;
+using ArgoBooks.Core.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -521,8 +522,29 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
             FeeUSD = ConvertedFee?.AmountUSD ?? ModalFee,
             UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0
                 ? Math.Round(ConvertedTotal.AmountUSD / Total * averageUnitPrice, 2)
-                : averageUnitPrice
+                : averageUnitPrice,
+            IsPendingConversion = IsPendingConversion
         };
+
+        // Queue for offline conversion if pending
+        if (IsPendingConversion)
+        {
+            var pendingEntry = new PendingConversion
+            {
+                TransactionId = expenseId,
+                TransactionType = "Expense",
+                OriginalCurrency = ConvertedTotal?.OriginalCurrency ?? "USD",
+                TransactionDate = expense.Date,
+                Total = Total,
+                TaxAmount = TaxAmount,
+                ShippingCost = ModalShipping,
+                Discount = ModalDiscount,
+                Fee = ModalFee,
+                UnitPrice = averageUnitPrice
+            };
+            companyData.PendingConversions.Add(pendingEntry);
+            _ = PendingConversionService.Instance?.AddPendingConversionAsync(pendingEntry);
+        }
 
         // Create Receipt if file was attached
         Receipt? receipt = null;
@@ -607,6 +629,34 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
         expense.UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0
             ? Math.Round(ConvertedTotal.AmountUSD / Total * averageUnitPrice, 2)
             : averageUnitPrice;
+        expense.IsPendingConversion = IsPendingConversion;
+
+        // Queue for offline conversion if pending
+        if (IsPendingConversion)
+        {
+            var pendingEntry = new PendingConversion
+            {
+                TransactionId = expense.Id,
+                TransactionType = "Expense",
+                OriginalCurrency = ConvertedTotal?.OriginalCurrency ?? "USD",
+                TransactionDate = expense.Date,
+                Total = Total,
+                TaxAmount = TaxAmount,
+                ShippingCost = ModalShipping,
+                Discount = ModalDiscount,
+                Fee = ModalFee,
+                UnitPrice = averageUnitPrice
+            };
+            // Remove any existing entry for this transaction before adding updated one
+            companyData.PendingConversions.RemoveAll(p => p.TransactionId == expense.Id);
+            companyData.PendingConversions.Add(pendingEntry);
+            _ = PendingConversionService.Instance?.AddPendingConversionAsync(pendingEntry);
+        }
+        else if (original.IsPendingConversion)
+        {
+            // Was pending, now converted — remove from queue
+            companyData.PendingConversions.RemoveAll(p => p.TransactionId == expense.Id);
+        }
 
         // Handle receipt
         Receipt? newReceipt = null;
@@ -722,7 +772,8 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
             PaymentMethod = expense.PaymentMethod,
             Notes = expense.Notes,
             ReferenceNumber = expense.ReferenceNumber,
-            ReceiptId = expense.ReceiptId
+            ReceiptId = expense.ReceiptId,
+            IsPendingConversion = expense.IsPendingConversion
         };
     }
 
@@ -745,6 +796,7 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
         expense.Notes = state.Notes;
         expense.ReferenceNumber = state.ReferenceNumber;
         expense.ReceiptId = state.ReceiptId;
+        expense.IsPendingConversion = state.IsPendingConversion;
     }
 
     #endregion
@@ -788,4 +840,5 @@ internal class TransactionState
     public string Notes { get; set; } = string.Empty;
     public string ReferenceNumber { get; set; } = string.Empty;
     public string? ReceiptId { get; set; }
+    public bool IsPendingConversion { get; set; }
 }

--- a/ArgoBooks/ViewModels/ExpensesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ExpensesPageViewModel.cs
@@ -445,7 +445,7 @@ public partial class ExpensesPageViewModel : SortablePageViewModelBase
             var categoryId = product?.CategoryId;
             var category = categoryId != null ? companyData?.GetCategory(categoryId) : null;
             var accountant = companyData?.GetAccountant(purchase.AccountantId ?? "");
-            var statusDisplay = GetStatusDisplay(purchase, companyData);
+            var statusDisplay = purchase.IsPendingConversion ? "Pending" : GetStatusDisplay(purchase, companyData);
             var (productName, productMoreText) = FormatProductDescription(purchase);
             var hasReceipt = !string.IsNullOrEmpty(purchase.ReceiptId);
             var receipt = hasReceipt ? companyData?.Receipts.FirstOrDefault(r => r.Id == purchase.ReceiptId) : null;

--- a/ArgoBooks/ViewModels/ExpensesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ExpensesPageViewModel.cs
@@ -483,7 +483,9 @@ public partial class ExpensesPageViewModel : SortablePageViewModelBase
                 Quantity = (int)purchase.Quantity,
                 UnitPrice = purchase.UnitPrice,
                 PaymentMethod = purchase.PaymentMethod,
-                IsHighlighted = purchase.Id == HighlightTransactionId
+                IsHighlighted = purchase.Id == HighlightTransactionId,
+                IsPendingConversion = purchase.IsPendingConversion,
+                OriginalCurrency = purchase.OriginalCurrency
             };
         }).ToList();
 
@@ -772,15 +774,35 @@ public partial class ExpenseDisplayItem : ObservableObject
     [ObservableProperty]
     private PaymentMethod _paymentMethod;
 
+    [ObservableProperty]
+    private bool _isPendingConversion;
+
+    [ObservableProperty]
+    private string _originalCurrency = "USD";
+
     public string DateFormatted => DateFormatService.Format(Date);
-    public string TotalFormatted => CurrencyService.FormatFromUSD(TotalUSD, Date);
-    public string AmountFormatted => CurrencyService.FormatFromUSD(AmountUSD, Date);
-    public string TaxAmountFormatted => CurrencyService.FormatFromUSD(TaxAmountUSD, Date);
+    public string TotalFormatted => IsPendingConversion
+        ? CurrencyService.Format(Total)
+        : CurrencyService.FormatFromUSD(TotalUSD, Date);
+    public string AmountFormatted => IsPendingConversion
+        ? CurrencyService.Format(Amount)
+        : CurrencyService.FormatFromUSD(AmountUSD, Date);
+    public string TaxAmountFormatted => IsPendingConversion
+        ? CurrencyService.Format(TaxAmount)
+        : CurrencyService.FormatFromUSD(TaxAmountUSD, Date);
     public string TaxRateFormatted => $"{TaxRate:N1}%";
-    public string ShippingCostFormatted => CurrencyService.FormatFromUSD(ShippingCostUSD, Date);
-    public string DiscountFormatted => $"-{CurrencyService.FormatFromUSD(DiscountUSD, Date)}";
-    public string FeeFormatted => CurrencyService.FormatFromUSD(FeeUSD, Date);
-    public string UnitPriceFormatted => CurrencyService.FormatFromUSD(UnitPriceUSD, Date);
+    public string ShippingCostFormatted => IsPendingConversion
+        ? CurrencyService.Format(ShippingCost)
+        : CurrencyService.FormatFromUSD(ShippingCostUSD, Date);
+    public string DiscountFormatted => IsPendingConversion
+        ? $"-{CurrencyService.Format(Discount)}"
+        : $"-{CurrencyService.FormatFromUSD(DiscountUSD, Date)}";
+    public string FeeFormatted => IsPendingConversion
+        ? CurrencyService.Format(Fee)
+        : CurrencyService.FormatFromUSD(FeeUSD, Date);
+    public string UnitPriceFormatted => IsPendingConversion
+        ? CurrencyService.Format(UnitPrice)
+        : CurrencyService.FormatFromUSD(UnitPriceUSD, Date);
     public string ReceiptIcon => HasReceipt ? "✓" : "✗";
 
     public bool IsReturned => StatusDisplay == "Returned";

--- a/ArgoBooks/ViewModels/RevenueModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenueModalsViewModel.cs
@@ -6,6 +6,7 @@ using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Tracking;
 using ArgoBooks.Core.Models.Transactions;
+using ArgoBooks.Core.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -522,8 +523,29 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
             FeeUSD = ConvertedFee?.AmountUSD ?? ModalFee,
             UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0
                 ? Math.Round(ConvertedTotal.AmountUSD / Total * averageUnitPrice, 2)
-                : averageUnitPrice
+                : averageUnitPrice,
+            IsPendingConversion = IsPendingConversion
         };
+
+        // Queue for offline conversion if pending
+        if (IsPendingConversion)
+        {
+            var pendingEntry = new PendingConversion
+            {
+                TransactionId = revenueId,
+                TransactionType = "Revenue",
+                OriginalCurrency = ConvertedTotal?.OriginalCurrency ?? "USD",
+                TransactionDate = revenue.Date,
+                Total = Total,
+                TaxAmount = TaxAmount,
+                ShippingCost = ModalShipping,
+                Discount = ModalDiscount,
+                Fee = ModalFee,
+                UnitPrice = averageUnitPrice
+            };
+            companyData.PendingConversions.Add(pendingEntry);
+            _ = PendingConversionService.Instance?.AddPendingConversionAsync(pendingEntry);
+        }
 
         // Create Receipt if file was attached
         Receipt? receipt = null;
@@ -609,6 +631,32 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
         revenue.UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0
             ? Math.Round(ConvertedTotal.AmountUSD / Total * averageUnitPrice, 2)
             : averageUnitPrice;
+        revenue.IsPendingConversion = IsPendingConversion;
+
+        // Queue for offline conversion if pending
+        if (IsPendingConversion)
+        {
+            var pendingEntry = new PendingConversion
+            {
+                TransactionId = revenue.Id,
+                TransactionType = "Revenue",
+                OriginalCurrency = ConvertedTotal?.OriginalCurrency ?? "USD",
+                TransactionDate = revenue.Date,
+                Total = Total,
+                TaxAmount = TaxAmount,
+                ShippingCost = ModalShipping,
+                Discount = ModalDiscount,
+                Fee = ModalFee,
+                UnitPrice = averageUnitPrice
+            };
+            companyData.PendingConversions.RemoveAll(p => p.TransactionId == revenue.Id);
+            companyData.PendingConversions.Add(pendingEntry);
+            _ = PendingConversionService.Instance?.AddPendingConversionAsync(pendingEntry);
+        }
+        else if (original.IsPendingConversion)
+        {
+            companyData.PendingConversions.RemoveAll(p => p.TransactionId == revenue.Id);
+        }
 
         // Handle receipt
         Receipt? newReceipt = null;
@@ -726,7 +774,8 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
             PaymentStatus = revenue.PaymentStatus,
             Notes = revenue.Notes,
             ReferenceNumber = revenue.ReferenceNumber,
-            ReceiptId = revenue.ReceiptId
+            ReceiptId = revenue.ReceiptId,
+            IsPendingConversion = revenue.IsPendingConversion
         };
     }
 
@@ -750,6 +799,7 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
         revenue.Notes = state.Notes;
         revenue.ReferenceNumber = state.ReferenceNumber;
         revenue.ReceiptId = state.ReceiptId;
+        revenue.IsPendingConversion = state.IsPendingConversion;
     }
 
     #endregion

--- a/ArgoBooks/ViewModels/RevenuePageViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenuePageViewModel.cs
@@ -434,7 +434,7 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
             var categoryId = product?.CategoryId;
             var category = categoryId != null ? companyData?.GetCategory(categoryId) : null;
             var accountant = companyData?.GetAccountant(revenue.AccountantId ?? "");
-            var statusDisplay = GetStatusDisplay(revenue, companyData);
+            var statusDisplay = revenue.IsPendingConversion ? "Pending" : GetStatusDisplay(revenue, companyData);
             var (productName, productMoreText) = FormatProductDescription(revenue);
 
             var hasReceipt = !string.IsNullOrEmpty(revenue.ReceiptId);

--- a/ArgoBooks/ViewModels/RevenuePageViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenuePageViewModel.cs
@@ -473,7 +473,9 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
                 HasReceipt = hasReceipt,
                 ReceiptFilePath = receiptFilePath,
                 IsHighlighted = revenue.Id == HighlightTransactionId,
-                InvoiceId = revenue.InvoiceId ?? string.Empty
+                InvoiceId = revenue.InvoiceId ?? string.Empty,
+                IsPendingConversion = revenue.IsPendingConversion,
+                OriginalCurrency = revenue.OriginalCurrency
             };
         }).ToList();
 
@@ -778,14 +780,32 @@ public partial class RevenueDisplayItem : ObservableObject
     [ObservableProperty]
     private PaymentMethod _paymentMethod;
 
+    [ObservableProperty]
+    private bool _isPendingConversion;
+
+    [ObservableProperty]
+    private string _originalCurrency = "USD";
+
     public string DateFormatted => DateFormatService.Format(Date);
-    public string TotalFormatted => CurrencyService.FormatFromUSD(TotalUSD, Date);
-    public string AmountFormatted => CurrencyService.FormatFromUSD(AmountUSD, Date);
-    public string TaxAmountFormatted => CurrencyService.FormatFromUSD(TaxAmountUSD, Date);
+    public string TotalFormatted => IsPendingConversion
+        ? CurrencyService.Format(Total)
+        : CurrencyService.FormatFromUSD(TotalUSD, Date);
+    public string AmountFormatted => IsPendingConversion
+        ? CurrencyService.Format(Amount)
+        : CurrencyService.FormatFromUSD(AmountUSD, Date);
+    public string TaxAmountFormatted => IsPendingConversion
+        ? CurrencyService.Format(TaxAmount)
+        : CurrencyService.FormatFromUSD(TaxAmountUSD, Date);
     public string TaxRateFormatted => $"{TaxRate:N1}%";
-    public string ShippingCostFormatted => CurrencyService.FormatFromUSD(ShippingCostUSD, Date);
-    public string DiscountFormatted => $"-{CurrencyService.FormatFromUSD(DiscountUSD, Date)}";
-    public string UnitPriceFormatted => CurrencyService.FormatFromUSD(UnitPriceUSD, Date);
+    public string ShippingCostFormatted => IsPendingConversion
+        ? CurrencyService.Format(ShippingCost)
+        : CurrencyService.FormatFromUSD(ShippingCostUSD, Date);
+    public string DiscountFormatted => IsPendingConversion
+        ? $"-{CurrencyService.Format(Discount)}"
+        : $"-{CurrencyService.FormatFromUSD(DiscountUSD, Date)}";
+    public string UnitPriceFormatted => IsPendingConversion
+        ? CurrencyService.Format(UnitPrice)
+        : CurrencyService.FormatFromUSD(UnitPriceUSD, Date);
 
     public string CustomerInitials
     {

--- a/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
+++ b/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
@@ -828,26 +828,42 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
             IsSavingTransaction = true;
             try
             {
-                // Check if exchange rate is available FIRST before any conversion
-                var exchangeService = ExchangeRateService.Instance;
-                if (exchangeService == null)
-                {
-                    IsSavingTransaction = false;
-                    HasSaveError = true;
-                    SaveErrorMessage = "Exchange rate service is not available. Please restart the application.".Translate();
-                    return;
-                }
+                // Check connectivity FIRST — cached rates from previous sessions
+                // would bypass offline detection if we checked the cache first
+                var connectivityService = new ConnectivityService();
+                var isOnline = await connectivityService.IsInternetAvailableAsync();
 
-                // Try to get the exchange rate (this will attempt to fetch if missing)
-                var rate = await exchangeService.GetExchangeRateAsync(currentCurrency, "USD", transactionDate, fetchIfMissing: true);
-                if (rate > 0)
+                if (isOnline)
                 {
-                    // Online — convert amounts to USD normally
-                    ConvertedTotal = await CurrencyService.CreateMonetaryValueAsync(Total, transactionDate);
-                    ConvertedTaxAmount = await CurrencyService.CreateMonetaryValueAsync(TaxAmount, transactionDate);
-                    ConvertedShippingCost = await CurrencyService.CreateMonetaryValueAsync(ShippingAmount, transactionDate);
-                    ConvertedDiscount = await CurrencyService.CreateMonetaryValueAsync(DiscountAmount, transactionDate);
-                    ConvertedFee = await CurrencyService.CreateMonetaryValueAsync(FeeAmount, transactionDate);
+                    var exchangeService = ExchangeRateService.Instance;
+                    if (exchangeService == null)
+                    {
+                        IsSavingTransaction = false;
+                        HasSaveError = true;
+                        SaveErrorMessage = "Exchange rate service is not available. Please restart the application.".Translate();
+                        return;
+                    }
+
+                    // Online — fetch rate and convert amounts to USD
+                    var rate = await exchangeService.GetExchangeRateAsync(currentCurrency, "USD", transactionDate, fetchIfMissing: true);
+                    if (rate > 0)
+                    {
+                        ConvertedTotal = await CurrencyService.CreateMonetaryValueAsync(Total, transactionDate);
+                        ConvertedTaxAmount = await CurrencyService.CreateMonetaryValueAsync(TaxAmount, transactionDate);
+                        ConvertedShippingCost = await CurrencyService.CreateMonetaryValueAsync(ShippingAmount, transactionDate);
+                        ConvertedDiscount = await CurrencyService.CreateMonetaryValueAsync(DiscountAmount, transactionDate);
+                        ConvertedFee = await CurrencyService.CreateMonetaryValueAsync(FeeAmount, transactionDate);
+                    }
+                    else
+                    {
+                        // Online but rate unavailable — treat as pending
+                        IsPendingConversion = true;
+                        ConvertedTotal = new MonetaryValue(Total, currentCurrency, 0, transactionDate);
+                        ConvertedTaxAmount = new MonetaryValue(TaxAmount, currentCurrency, 0, transactionDate);
+                        ConvertedShippingCost = new MonetaryValue(ShippingAmount, currentCurrency, 0, transactionDate);
+                        ConvertedDiscount = new MonetaryValue(DiscountAmount, currentCurrency, 0, transactionDate);
+                        ConvertedFee = new MonetaryValue(FeeAmount, currentCurrency, 0, transactionDate);
+                    }
                 }
                 else
                 {

--- a/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
+++ b/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
@@ -224,6 +224,12 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
     protected MonetaryValue? ConvertedDiscount;
     protected MonetaryValue? ConvertedFee;
 
+    /// <summary>
+    /// Set to true when saving a transaction offline without USD conversion.
+    /// Passed through to the transaction model's IsPendingConversion flag.
+    /// </summary>
+    protected bool IsPendingConversion;
+
     public ObservableCollection<CounterpartyOption> CounterpartyOptions { get; } = [];
     public ObservableCollection<CategoryOption> CategoryOptions { get; } = [];
     public ObservableCollection<ProductOption> ProductOptions { get; } = [];
@@ -815,15 +821,13 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
         var currentCurrency = CurrencyService.CurrentCurrencyCode;
         var transactionDate = ModalDate?.DateTime ?? DateTime.Now;
 
+        IsPendingConversion = false;
+
         if (!string.Equals(currentCurrency, "USD", StringComparison.OrdinalIgnoreCase))
         {
             IsSavingTransaction = true;
             try
             {
-                // Check connectivity first to provide better error message
-                var connectivityService = new ConnectivityService();
-                var hasInternet = await connectivityService.IsInternetAvailableAsync();
-
                 // Check if exchange rate is available FIRST before any conversion
                 var exchangeService = ExchangeRateService.Instance;
                 if (exchangeService == null)
@@ -836,30 +840,35 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
 
                 // Try to get the exchange rate (this will attempt to fetch if missing)
                 var rate = await exchangeService.GetExchangeRateAsync(currentCurrency, "USD", transactionDate, fetchIfMissing: true);
-                if (rate <= 0)
+                if (rate > 0)
                 {
-                    // Rate fetch failed
-                    IsSavingTransaction = false;
-                    HasSaveError = true;
-                    SaveErrorMessage = hasInternet
-                        ? "Unable to fetch exchange rates. Please try again.".Translate()
-                        : "No internet connection. Exchange rates are required for non-USD currencies.".Translate();
-                    return;
+                    // Online — convert amounts to USD normally
+                    ConvertedTotal = await CurrencyService.CreateMonetaryValueAsync(Total, transactionDate);
+                    ConvertedTaxAmount = await CurrencyService.CreateMonetaryValueAsync(TaxAmount, transactionDate);
+                    ConvertedShippingCost = await CurrencyService.CreateMonetaryValueAsync(ShippingAmount, transactionDate);
+                    ConvertedDiscount = await CurrencyService.CreateMonetaryValueAsync(DiscountAmount, transactionDate);
+                    ConvertedFee = await CurrencyService.CreateMonetaryValueAsync(FeeAmount, transactionDate);
                 }
-
-                // Now convert amounts to USD (rate is guaranteed to be available)
-                ConvertedTotal = await CurrencyService.CreateMonetaryValueAsync(Total, transactionDate);
-                ConvertedTaxAmount = await CurrencyService.CreateMonetaryValueAsync(TaxAmount, transactionDate);
-                ConvertedShippingCost = await CurrencyService.CreateMonetaryValueAsync(ShippingAmount, transactionDate);
-                ConvertedDiscount = await CurrencyService.CreateMonetaryValueAsync(DiscountAmount, transactionDate);
-                ConvertedFee = await CurrencyService.CreateMonetaryValueAsync(FeeAmount, transactionDate);
+                else
+                {
+                    // Offline — save without USD conversion, queue for later
+                    IsPendingConversion = true;
+                    ConvertedTotal = new MonetaryValue(Total, currentCurrency, 0, transactionDate);
+                    ConvertedTaxAmount = new MonetaryValue(TaxAmount, currentCurrency, 0, transactionDate);
+                    ConvertedShippingCost = new MonetaryValue(ShippingAmount, currentCurrency, 0, transactionDate);
+                    ConvertedDiscount = new MonetaryValue(DiscountAmount, currentCurrency, 0, transactionDate);
+                    ConvertedFee = new MonetaryValue(FeeAmount, currentCurrency, 0, transactionDate);
+                }
             }
             catch (Exception)
             {
-                IsSavingTransaction = false;
-                HasSaveError = true;
-                SaveErrorMessage = "Failed to convert currency. Please check your internet connection and try again.".Translate();
-                return;
+                // Network error — treat as offline, save with pending conversion
+                IsPendingConversion = true;
+                ConvertedTotal = new MonetaryValue(Total, currentCurrency, 0, transactionDate);
+                ConvertedTaxAmount = new MonetaryValue(TaxAmount, currentCurrency, 0, transactionDate);
+                ConvertedShippingCost = new MonetaryValue(ShippingAmount, currentCurrency, 0, transactionDate);
+                ConvertedDiscount = new MonetaryValue(DiscountAmount, currentCurrency, 0, transactionDate);
+                ConvertedFee = new MonetaryValue(FeeAmount, currentCurrency, 0, transactionDate);
             }
             finally
             {
@@ -944,6 +953,7 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
         ConvertedShippingCost = null;
         ConvertedDiscount = null;
         ConvertedFee = null;
+        IsPendingConversion = false;
         ClearValidationErrors();
     }
 

--- a/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
+++ b/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
@@ -910,14 +910,17 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
             SaveNewTransaction(companyData);
         }
 
+        // Capture pending state before CloseAddEditModal resets it via ResetForm
+        var wasPendingConversion = IsPendingConversion;
+
         CloseAddEditModal();
 
         // Show offline warning after modal closes
-        if (IsPendingConversion)
+        if (wasPendingConversion)
         {
             _ = App.ShowWarningMessageBoxAsync(
                 "Offline Mode".Translate(),
-                "You are currently offline. This transaction has been saved, but the USD conversion is pending. It will be automatically converted when you reconnect to the internet.".Translate());
+                "You are currently offline. This transaction has been saved and will be fully processed when you reconnect to the internet.".Translate());
         }
     }
 

--- a/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
+++ b/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
@@ -895,6 +895,14 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
         }
 
         CloseAddEditModal();
+
+        // Show offline warning after modal closes
+        if (IsPendingConversion)
+        {
+            _ = App.ShowWarningMessageBoxAsync(
+                "Offline Mode".Translate(),
+                "You are currently offline. This transaction has been saved, but the USD conversion is pending. It will be automatically converted when you reconnect to the internet.".Translate());
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
This PR implements a persistent queue system for transactions saved offline without USD conversion, allowing users to work without internet connectivity and automatically process conversions when connectivity is restored.

## Key Changes

### New Services & Models
- **PendingConversionService**: Manages a two-layer persistent queue (app-data file + CompanyData backup) of transactions awaiting USD conversion
  - Loads/saves queue from disk using JSON serialization
  - Reconciles in-memory queue with CompanyData on load
  - Processes pending conversions when exchange rates become available
  - Fires `PendingConversionsProcessed` event to trigger UI refresh
  
- **PendingConversion Model**: Stores transaction metadata needed for deferred conversion (transaction ID, type, original currency, date, and original amounts)

### Transaction Handling
- Added `IsPendingConversion` flag to `Transaction` base class
  - Effective USD properties return 0 when pending to prevent cross-currency contamination in aggregations
- Modified `TransactionModalsViewModelBase` to detect offline state and allow saving without conversion
  - Checks connectivity first (before checking cached rates) to properly detect offline scenarios
  - Sets `IsPendingConversion = true` when offline or when rates are unavailable
  - Creates `MonetaryValue` objects with 0 USD amounts for pending transactions

### UI Updates
- **ExpenseModalsViewModel** & **RevenueModalsViewModel**: Queue pending conversions and add entries to CompanyData
- **ExpensesPageViewModel** & **RevenuePageViewModel**: Display "Pending" status for unconverted transactions and show original currency amounts instead of USD conversions

### App Initialization
- Initialize `PendingConversionService` on app startup
- Load pending queue from disk during initialization
- Reconcile queue with CompanyData when company is loaded
- Start periodic timer (45-second interval) to attempt processing pending conversions when connectivity returns
- Wire up event handler to show success notification and refresh UI when conversions complete

## Implementation Details
- Thread-safe queue using `Lock` for concurrent access
- Two-layer persistence: immediate disk save (app-data) + CompanyData backup (survives between sessions)
- Duplicate prevention when adding entries
- Automatic cleanup of entries for deleted transactions
- Exchange rate fetching with `fetchIfMissing: true` to attempt online conversion
- Graceful fallback: transactions remain pending if rates still unavailable even when online

https://claude.ai/code/session_01JTAV94iNt7UnG5fS9qegtV