### PR TITLE
Add multi-currency support with USD conversion for accounting reports

### DIFF
--- a/ArgoBooks.Core/Services/AccountingReportDataService.cs
+++ b/ArgoBooks.Core/Services/AccountingReportDataService.cs
@@ -130,8 +130,21 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
     }
 
     /// <summary>
+    /// Gets the USD conversion ratio for a transaction's original currency amounts.
+    /// Returns the multiplier to convert original currency values to USD equivalents.
+    /// </summary>
+    private static decimal GetUSDRatio(Models.Transactions.Transaction txn)
+    {
+        if (txn.IsPendingConversion) return 0;
+        if (txn.Total != 0 && txn.TotalUSD > 0)
+            return txn.TotalUSD / txn.Total;
+        return 1m; // Legacy data or USD transactions
+    }
+
+    /// <summary>
     /// Groups transaction pre-tax totals by category, derived from line items' product IDs.
     /// Uses Subtotal (pre-tax) because sales tax is a liability, not revenue/expense.
+    /// All amounts are converted to USD for consistent cross-currency aggregation.
     /// </summary>
     private Dictionary<string, decimal> GroupTransactionsByCategory(
         IEnumerable<Models.Transactions.Transaction> transactions)
@@ -142,19 +155,27 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
         {
             if (txn.LineItems.Count > 0)
             {
+                // Convert line item amounts to USD using the transaction's conversion ratio
+                var lineItemsTotal = txn.LineItems.Sum(li => li.Subtotal);
+                var subtotalUSD = txn.EffectiveSubtotalUSD;
+
                 foreach (var lineItem in txn.LineItems)
                 {
                     var categoryName = GetCategoryNameForProduct(lineItem.ProductId);
                     result.TryAdd(categoryName, 0);
-                    result[categoryName] += lineItem.Subtotal;
+                    // Proportionally allocate USD subtotal across line items
+                    var lineItemUSD = lineItemsTotal != 0
+                        ? Math.Round(lineItem.Subtotal / lineItemsTotal * subtotalUSD, 2)
+                        : 0;
+                    result[categoryName] += lineItemUSD;
                 }
             }
             else
             {
-                // No line items — use the transaction amount (pre-tax) and try to infer category
+                // No line items — use the USD-converted pre-tax amount
                 var categoryName = "Uncategorized";
                 result.TryAdd(categoryName, 0);
-                result[categoryName] += txn.Amount;
+                result[categoryName] += txn.EffectiveSubtotalUSD;
             }
         }
 
@@ -637,21 +658,27 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
         // Build a list of all ledger entries grouped by category
         var entries = new Dictionary<string, List<LedgerEntry>>();
 
-        // Revenue transactions (credits)
+        // Revenue transactions (credits) — all amounts in USD
         foreach (var rev in companyData.Revenues.Where(r => IsInDateRange(r.Date)))
         {
             if (rev.LineItems.Count > 0)
             {
+                var lineItemsTotal = rev.LineItems.Sum(li => li.Subtotal);
+                var subtotalUSD = rev.EffectiveSubtotalUSD;
+
                 foreach (var li in rev.LineItems)
                 {
                     var catName = GetCategoryNameForProduct(li.ProductId);
+                    var lineItemUSD = lineItemsTotal != 0
+                        ? Math.Round(li.Subtotal / lineItemsTotal * subtotalUSD, 2)
+                        : 0;
                     AddLedgerEntry(entries, catName, new LedgerEntry
                     {
                         Date = rev.Date,
                         Description = li.Description.Length > 0 ? li.Description : rev.Description,
                         Reference = rev.Id,
                         Debit = 0,
-                        Credit = li.Subtotal
+                        Credit = lineItemUSD
                     });
                 }
             }
@@ -668,20 +695,26 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
             }
         }
 
-        // Expense transactions (debits)
+        // Expense transactions (debits) — all amounts in USD
         foreach (var exp in companyData.Expenses.Where(e => IsInDateRange(e.Date)))
         {
             if (exp.LineItems.Count > 0)
             {
+                var lineItemsTotal = exp.LineItems.Sum(li => li.Subtotal);
+                var subtotalUSD = exp.EffectiveSubtotalUSD;
+
                 foreach (var li in exp.LineItems)
                 {
                     var catName = GetCategoryNameForProduct(li.ProductId);
+                    var lineItemUSD = lineItemsTotal != 0
+                        ? Math.Round(li.Subtotal / lineItemsTotal * subtotalUSD, 2)
+                        : 0;
                     AddLedgerEntry(entries, catName, new LedgerEntry
                     {
                         Date = exp.Date,
                         Description = li.Description.Length > 0 ? li.Description : exp.Description,
                         Reference = exp.Id,
-                        Debit = li.Subtotal,
+                        Debit = lineItemUSD,
                         Credit = 0
                     });
                 }
@@ -1099,6 +1132,7 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
         }
 
         // Tax collected from revenue, grouped by tax rate
+        // All amounts converted to USD for consistent cross-currency aggregation
         var filteredRevenues = companyData.Revenues
             .Where(r => IsInDateRange(r.Date))
             .ToList();
@@ -1107,6 +1141,7 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
         var taxCollectedByRate = new Dictionary<decimal, decimal>();
         foreach (var rev in filteredRevenues)
         {
+            var usdRatio = GetUSDRatio(rev);
             if (rev.LineItems.Count > 0)
             {
                 foreach (var li in rev.LineItems)
@@ -1115,19 +1150,21 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
                     {
                         var rate = Math.Round(li.TaxRate, 2);
                         taxCollectedByRate.TryAdd(rate, 0);
-                        taxCollectedByRate[rate] += li.TaxAmount;
+                        taxCollectedByRate[rate] += Math.Round(li.TaxAmount * usdRatio, 2);
                     }
                 }
             }
             else if (rev.TaxRate > 0)
             {
                 var rate = Math.Round(rev.TaxRate, 2);
+                var taxAmountUSD = rev.TaxAmountUSD > 0 ? rev.TaxAmountUSD : rev.TaxAmount;
                 taxCollectedByRate.TryAdd(rate, 0);
-                taxCollectedByRate[rate] += rev.TaxAmount;
+                taxCollectedByRate[rate] += taxAmountUSD;
             }
         }
 
         // Tax paid on expenses, grouped by tax rate
+        // All amounts converted to USD for consistent cross-currency aggregation
         var filteredExpenses = companyData.Expenses
             .Where(e => IsInDateRange(e.Date))
             .ToList();
@@ -1135,6 +1172,7 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
         var taxPaidByRate = new Dictionary<decimal, decimal>();
         foreach (var exp in filteredExpenses)
         {
+            var usdRatio = GetUSDRatio(exp);
             if (exp.LineItems.Count > 0)
             {
                 foreach (var li in exp.LineItems)
@@ -1143,15 +1181,16 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
                     {
                         var rate = Math.Round(li.TaxRate, 2);
                         taxPaidByRate.TryAdd(rate, 0);
-                        taxPaidByRate[rate] += li.TaxAmount;
+                        taxPaidByRate[rate] += Math.Round(li.TaxAmount * usdRatio, 2);
                     }
                 }
             }
             else if (exp.TaxRate > 0)
             {
                 var rate = Math.Round(exp.TaxRate, 2);
+                var taxAmountUSD = exp.TaxAmountUSD > 0 ? exp.TaxAmountUSD : exp.TaxAmount;
                 taxPaidByRate.TryAdd(rate, 0);
-                taxPaidByRate[rate] += exp.TaxAmount;
+                taxPaidByRate[rate] += taxAmountUSD;
             }
         }
 

--- a/ArgoBooks/Services/ChartLoaderService.cs
+++ b/ArgoBooks/Services/ChartLoaderService.cs
@@ -2895,7 +2895,7 @@ public class ChartLoaderService
                 Name = TruncateLegendLabel(item.Label),
                 Fill = new SolidColorPaint(SKColor.Parse(colorHex)),
                 Pushout = 0,
-                ToolTipLabelFormatter = point => $"${point.Coordinate.PrimaryValue:N2}"
+                ToolTipLabelFormatter = point => CurrencyService.Format((decimal)point.Coordinate.PrimaryValue)
             });
 
             legendItems.Add(new PieLegendItem
@@ -2920,7 +2920,7 @@ public class ChartLoaderService
                 Name = LanguageService.Instance.Translate("Other"),
                 Fill = new SolidColorPaint(SKColor.Parse(otherColorHex)),
                 Pushout = 0,
-                ToolTipLabelFormatter = point => $"${point.Coordinate.PrimaryValue:N2}"
+                ToolTipLabelFormatter = point => CurrencyService.Format((decimal)point.Coordinate.PrimaryValue)
             });
 
             var itemsText = LanguageService.Instance.Translate("items");

--- a/ArgoBooks/Services/ChartLoaderService.cs
+++ b/ArgoBooks/Services/ChartLoaderService.cs
@@ -2895,7 +2895,7 @@ public class ChartLoaderService
                 Name = TruncateLegendLabel(item.Label),
                 Fill = new SolidColorPaint(SKColor.Parse(colorHex)),
                 Pushout = 0,
-                ToolTipLabelFormatter = point => CurrencyService.Format((decimal)point.Coordinate.PrimaryValue)
+                ToolTipLabelFormatter = point => CurrencyService.FormatFromUSD((decimal)point.Coordinate.PrimaryValue, DateTime.Now)
             });
 
             legendItems.Add(new PieLegendItem
@@ -2920,7 +2920,7 @@ public class ChartLoaderService
                 Name = LanguageService.Instance.Translate("Other"),
                 Fill = new SolidColorPaint(SKColor.Parse(otherColorHex)),
                 Pushout = 0,
-                ToolTipLabelFormatter = point => CurrencyService.Format((decimal)point.Coordinate.PrimaryValue)
+                ToolTipLabelFormatter = point => CurrencyService.FormatFromUSD((decimal)point.Coordinate.PrimaryValue, DateTime.Now)
             });
 
             var itemsText = LanguageService.Instance.Translate("items");

--- a/ArgoBooks/ViewModels/CustomersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomersPageViewModel.cs
@@ -950,6 +950,6 @@ public class CustomerHistoryItem
     public string Status { get; set; } = string.Empty;
 
     public string DateFormatted => Date.ToString("MMM d, yyyy");
-    public string AmountFormatted => Amount < 0 ? $"-${Math.Abs(Amount):N2}" : $"${Amount:N2}";
+    public string AmountFormatted => Amount < 0 ? $"-{CurrencyService.Format(Math.Abs(Amount))}" : CurrencyService.Format(Amount);
 }
 

--- a/ArgoBooks/ViewModels/ExpenseModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ExpenseModalsViewModel.cs
@@ -520,7 +520,7 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
             ShippingCostUSD = ConvertedShippingCost?.AmountUSD ?? ModalShipping,
             DiscountUSD = ConvertedDiscount?.AmountUSD ?? ModalDiscount,
             FeeUSD = ConvertedFee?.AmountUSD ?? ModalFee,
-            UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0
+            UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0 && Total != 0
                 ? Math.Round(ConvertedTotal.AmountUSD / Total * averageUnitPrice, 2)
                 : averageUnitPrice,
             IsPendingConversion = IsPendingConversion
@@ -626,7 +626,7 @@ public partial class ExpenseModalsViewModel : TransactionModalsViewModelBase<Exp
         expense.ShippingCostUSD = ConvertedShippingCost?.AmountUSD ?? ModalShipping;
         expense.DiscountUSD = ConvertedDiscount?.AmountUSD ?? ModalDiscount;
         expense.FeeUSD = ConvertedFee?.AmountUSD ?? ModalFee;
-        expense.UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0
+        expense.UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0 && Total != 0
             ? Math.Round(ConvertedTotal.AmountUSD / Total * averageUnitPrice, 2)
             : averageUnitPrice;
         expense.IsPendingConversion = IsPendingConversion;

--- a/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
@@ -7,6 +7,7 @@ using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Invoices;
 using ArgoBooks.Core.Models.Transactions;
 using ArgoBooks.Core.Models.Portal;
+using ArgoBooks.Core.Services;
 using ArgoBooks.Core.Services.InvoiceTemplates;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -300,12 +301,12 @@ public partial class InvoiceModalsViewModel : ViewModelBase
     public decimal DiscountCalculated => DiscountIsPercent ? Subtotal * (DiscountAmount / 100m) : DiscountAmount;
     public decimal Total => Subtotal + TaxAmount + SecurityDeposit + CustomFeeCalculated - DiscountCalculated;
 
-    public string SubtotalFormatted => $"${Subtotal:N2}";
-    public string TaxAmountFormatted => $"${TaxAmount:N2}";
-    public string SecurityDepositFormatted => $"${SecurityDeposit:N2}";
-    public string CustomFeeCalculatedFormatted => $"+${CustomFeeCalculated:N2}";
-    public string DiscountCalculatedFormatted => $"-${DiscountCalculated:N2}";
-    public string TotalFormatted => $"${Total:N2}";
+    public string SubtotalFormatted => CurrencyService.Format(Subtotal);
+    public string TaxAmountFormatted => CurrencyService.Format(TaxAmount);
+    public string SecurityDepositFormatted => CurrencyService.Format(SecurityDeposit);
+    public string CustomFeeCalculatedFormatted => $"+{CurrencyService.Format(CustomFeeCalculated)}";
+    public string DiscountCalculatedFormatted => $"-{CurrencyService.Format(DiscountCalculated)}";
+    public string TotalFormatted => CurrencyService.Format(Total);
 
     public bool HasSecurityDeposit => SecurityDeposit > 0;
     public bool HasCustomFee => CustomFeeAmount > 0;
@@ -1306,6 +1307,28 @@ public partial class InvoiceModalsViewModel : ViewModelBase
         invoice.Total = invoice.Subtotal + invoice.TaxAmount + invoice.SecurityDeposit + feeCalc - discCalc;
         invoice.Balance = invoice.Total - invoice.AmountPaid;
 
+        // Set currency fields for multi-currency support
+        var invoiceCurrency = CurrencyService.CurrentCurrencyCode;
+        invoice.OriginalCurrency = invoiceCurrency;
+        if (!string.Equals(invoiceCurrency, "USD", StringComparison.OrdinalIgnoreCase))
+        {
+            var exchangeService = ExchangeRateService.Instance;
+            if (exchangeService != null)
+            {
+                var rate = exchangeService.GetExchangeRate(invoiceCurrency, "USD", invoice.IssueDate);
+                if (rate > 0)
+                {
+                    invoice.TotalUSD = Math.Round(invoice.Total * rate, 2);
+                    invoice.BalanceUSD = Math.Round(invoice.Balance * rate, 2);
+                }
+            }
+        }
+        else
+        {
+            invoice.TotalUSD = invoice.Total;
+            invoice.BalanceUSD = invoice.Balance;
+        }
+
         // Publish and send: portal handles both publishing and email delivery via sendEmail: true.
         // When portal is not configured, fall back to desktop email sending.
         if (PortalSettings.IsConfigured)
@@ -1581,6 +1604,28 @@ public partial class InvoiceModalsViewModel : ViewModelBase
             }).ToList()
         };
 
+        // Set currency fields for multi-currency support
+        var draftCurrency = CurrencyService.CurrentCurrencyCode;
+        invoice.OriginalCurrency = draftCurrency;
+        if (!string.Equals(draftCurrency, "USD", StringComparison.OrdinalIgnoreCase))
+        {
+            var exchangeService = ExchangeRateService.Instance;
+            if (exchangeService != null)
+            {
+                var rate = exchangeService.GetExchangeRate(draftCurrency, "USD", invoice.IssueDate);
+                if (rate > 0)
+                {
+                    invoice.TotalUSD = Math.Round(invoice.Total * rate, 2);
+                    invoice.BalanceUSD = Math.Round(invoice.Balance * rate, 2);
+                }
+            }
+        }
+        else
+        {
+            invoice.TotalUSD = invoice.Total;
+            invoice.BalanceUSD = invoice.Balance;
+        }
+
         // Add the invoice and link to rentals
         companyData.Invoices.Add(invoice);
         LinkInvoiceToRentals(invoice, companyData);
@@ -1806,7 +1851,7 @@ public partial class LineItemDisplayModel : ObservableObject
     private string? _revenueRecordId;
 
     public decimal Amount => (Quantity ?? 0) * (UnitPrice ?? 0);
-    public string AmountFormatted => $"${Amount:N2}";
+    public string AmountFormatted => CurrencyService.Format(Amount);
 
     partial void OnSelectedProductChanged(ProductOption? value)
     {

--- a/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
@@ -1315,7 +1315,7 @@ public partial class InvoiceModalsViewModel : ViewModelBase
             var exchangeService = ExchangeRateService.Instance;
             if (exchangeService != null)
             {
-                var rate = exchangeService.GetExchangeRate(invoiceCurrency, "USD", invoice.IssueDate);
+                var rate = await exchangeService.GetExchangeRateAsync(invoiceCurrency, "USD", invoice.IssueDate);
                 if (rate > 0)
                 {
                     invoice.TotalUSD = Math.Round(invoice.Total * rate, 2);
@@ -1612,7 +1612,7 @@ public partial class InvoiceModalsViewModel : ViewModelBase
             var exchangeService = ExchangeRateService.Instance;
             if (exchangeService != null)
             {
-                var rate = exchangeService.GetExchangeRate(draftCurrency, "USD", invoice.IssueDate);
+                var rate = await exchangeService.GetExchangeRateAsync(draftCurrency, "USD", invoice.IssueDate);
                 if (rate > 0)
                 {
                     invoice.TotalUSD = Math.Round(invoice.Total * rate, 2);

--- a/ArgoBooks/ViewModels/LostDamagedPageViewModel.cs
+++ b/ArgoBooks/ViewModels/LostDamagedPageViewModel.cs
@@ -258,7 +258,7 @@ public partial class LostDamagedPageViewModel : ViewModelBase
         LostItems = _allItems.Count(item => item.Reason == LostDamagedReason.Lost || item.Reason == LostDamagedReason.Stolen);
         DamagedItems = _allItems.Count(item => item.Reason == LostDamagedReason.Damaged || item.Reason == LostDamagedReason.Expired);
         var totalValue = _allItems.Sum(item => item.ValueLost);
-        TotalLossValue = $"${totalValue:N2}";
+        TotalLossValue = CurrencyService.Format(totalValue);
     }
 
     [RelayCommand]
@@ -484,7 +484,7 @@ public partial class LostDamagedDisplayItem : ObservableObject
 
     // Computed properties for display
     public string DateFormatted => DateDiscovered.ToString("MMM d, yyyy");
-    public string ValueLostFormatted => $"${ValueLost:N2}";
+    public string ValueLostFormatted => CurrencyService.Format(ValueLost);
     public string QuantityFormatted => $"{Quantity} unit(s)";
 
     public bool IsLost => ItemType == "Lost";

--- a/ArgoBooks/ViewModels/PaymentModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/PaymentModalsViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models;
 using ArgoBooks.Core.Models.Transactions;
+using ArgoBooks.Core.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -329,17 +330,38 @@ public partial class PaymentModalsViewModel : ViewModelBase
             _ => PaymentMethod.Cash
         };
 
+        var parsedAmount = decimal.Parse(ModalAmount);
+        var currentCurrency = CurrencyService.CurrentCurrencyCode;
+        var paymentDate = ModalDate?.DateTime ?? DateTime.Today;
+
+        // Convert payment amount to USD for consistent reporting
+        decimal amountUSD = parsedAmount;
+        if (!string.Equals(currentCurrency, "USD", StringComparison.OrdinalIgnoreCase))
+        {
+            var exchangeService = ExchangeRateService.Instance;
+            if (exchangeService != null)
+            {
+                var rate = exchangeService.GetExchangeRate(currentCurrency, "USD", paymentDate);
+                if (rate > 0)
+                {
+                    amountUSD = Math.Round(parsedAmount * rate, 2);
+                }
+            }
+        }
+
         var newPayment = new Payment
         {
             Id = newId,
             InvoiceId = ModalInvoiceId ?? string.Empty,
             CustomerId = ModalCustomerId ?? string.Empty,
-            Date = ModalDate?.DateTime ?? DateTime.Today,
-            Amount = decimal.Parse(ModalAmount),
+            Date = paymentDate,
+            Amount = parsedAmount,
             PaymentMethod = paymentMethod,
             ReferenceNumber = string.IsNullOrWhiteSpace(ModalReferenceNumber) ? null : ModalReferenceNumber.Trim(),
             Notes = ModalNotes.Trim(),
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow,
+            OriginalCurrency = currentCurrency,
+            AmountUSD = amountUSD
         };
 
         companyData.Payments.Add(newPayment);
@@ -495,6 +517,23 @@ public partial class PaymentModalsViewModel : ViewModelBase
         var newCustomerId = ModalCustomerId ?? string.Empty;
         var newDate = ModalDate?.DateTime ?? DateTime.Today;
         var newAmount = decimal.Parse(ModalAmount);
+
+        // Convert to USD for consistent reporting
+        var editCurrentCurrency = CurrencyService.CurrentCurrencyCode;
+        decimal newAmountUSD = newAmount;
+        if (!string.Equals(editCurrentCurrency, "USD", StringComparison.OrdinalIgnoreCase))
+        {
+            var exchangeService = ExchangeRateService.Instance;
+            if (exchangeService != null)
+            {
+                var rate = exchangeService.GetExchangeRate(editCurrentCurrency, "USD", newDate);
+                if (rate > 0)
+                {
+                    newAmountUSD = Math.Round(newAmount * rate, 2);
+                }
+            }
+        }
+
         var newPaymentMethod = ModalPaymentMethod switch
         {
             "Cash" => PaymentMethod.Cash,
@@ -529,6 +568,9 @@ public partial class PaymentModalsViewModel : ViewModelBase
         if (oldReferenceNumber != newReferenceNumber) changes2["Reference"] = new FieldChange { OldValue = oldReferenceNumber ?? "", NewValue = newReferenceNumber ?? "" };
         if (oldNotesVal != newNotesVal) changes2["Notes"] = new FieldChange { OldValue = oldNotesVal, NewValue = newNotesVal };
         if (changes2.Count > 0) App.EventLogService?.SetPendingChanges(changes2);
+        var oldOriginalCurrency = paymentToEdit2.OriginalCurrency;
+        var oldAmountUSD = paymentToEdit2.AmountUSD;
+
         paymentToEdit2.InvoiceId = newInvoiceId;
         paymentToEdit2.CustomerId = newCustomerId;
         paymentToEdit2.Date = newDate;
@@ -536,6 +578,8 @@ public partial class PaymentModalsViewModel : ViewModelBase
         paymentToEdit2.PaymentMethod = newPaymentMethod;
         paymentToEdit2.ReferenceNumber = newReferenceNumber;
         paymentToEdit2.Notes = newNotesVal;
+        paymentToEdit2.OriginalCurrency = editCurrentCurrency;
+        paymentToEdit2.AmountUSD = newAmountUSD;
 
         companyData.MarkAsModified();
 
@@ -550,6 +594,8 @@ public partial class PaymentModalsViewModel : ViewModelBase
                 paymentToEdit2.PaymentMethod = oldPaymentMethod;
                 paymentToEdit2.ReferenceNumber = oldReferenceNumber;
                 paymentToEdit2.Notes = oldNotesVal;
+                paymentToEdit2.OriginalCurrency = oldOriginalCurrency;
+                paymentToEdit2.AmountUSD = oldAmountUSD;
                 companyData.MarkAsModified();
                 PaymentSaved?.Invoke(this, EventArgs.Empty);
             },
@@ -562,6 +608,8 @@ public partial class PaymentModalsViewModel : ViewModelBase
                 paymentToEdit2.PaymentMethod = newPaymentMethod;
                 paymentToEdit2.ReferenceNumber = newReferenceNumber;
                 paymentToEdit2.Notes = newNotesVal;
+                paymentToEdit2.OriginalCurrency = editCurrentCurrency;
+                paymentToEdit2.AmountUSD = newAmountUSD;
                 companyData.MarkAsModified();
                 PaymentSaved?.Invoke(this, EventArgs.Empty);
             }));

--- a/ArgoBooks/ViewModels/PaymentModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/PaymentModalsViewModel.cs
@@ -311,7 +311,7 @@ public partial class PaymentModalsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    public void SaveNewPayment()
+    public async Task SaveNewPayment()
     {
         if (!ValidateModal())
             return;
@@ -341,7 +341,7 @@ public partial class PaymentModalsViewModel : ViewModelBase
             var exchangeService = ExchangeRateService.Instance;
             if (exchangeService != null)
             {
-                var rate = exchangeService.GetExchangeRate(currentCurrency, "USD", paymentDate);
+                var rate = await exchangeService.GetExchangeRateAsync(currentCurrency, "USD", paymentDate);
                 if (rate > 0)
                 {
                     amountUSD = Math.Round(parsedAmount * rate, 2);
@@ -450,7 +450,7 @@ public partial class PaymentModalsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    public void SaveEditedPayment()
+    public async Task SaveEditedPayment()
     {
         if (_editingPayment == null)
             return;
@@ -526,7 +526,7 @@ public partial class PaymentModalsViewModel : ViewModelBase
             var exchangeService = ExchangeRateService.Instance;
             if (exchangeService != null)
             {
-                var rate = exchangeService.GetExchangeRate(editCurrentCurrency, "USD", newDate);
+                var rate = await exchangeService.GetExchangeRateAsync(editCurrentCurrency, "USD", newDate);
                 if (rate > 0)
                 {
                     newAmountUSD = Math.Round(newAmount * rate, 2);

--- a/ArgoBooks/ViewModels/PurchaseOrdersModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/PurchaseOrdersModalsViewModel.cs
@@ -148,12 +148,12 @@ public partial class PurchaseOrdersModalsViewModel : ViewModelBase
     /// <summary>
     /// Subtotal display string.
     /// </summary>
-    public string SubtotalDisplay => $"${CalculatedSubtotal:N2}";
+    public string SubtotalDisplay => CurrencyService.Format(CalculatedSubtotal);
 
     /// <summary>
     /// Total display string.
     /// </summary>
-    public string TotalDisplay => $"${CalculatedTotal:N2}";
+    public string TotalDisplay => CurrencyService.Format(CalculatedTotal);
 
     /// <summary>
     /// Modal title based on mode.
@@ -1092,7 +1092,7 @@ public partial class OrderLineItemViewModel : ObservableObject
     /// <summary>
     /// Total display string.
     /// </summary>
-    public string TotalDisplay => $"${Total:N2}";
+    public string TotalDisplay => CurrencyService.Format(Total);
 
     partial void OnQuantityChanged(string value)
     {
@@ -1118,8 +1118,8 @@ public class ViewLineItemDisplay
     public int QuantityReceived { get; set; }
     public decimal UnitCost { get; set; }
     public decimal Total { get; set; }
-    public string UnitCostDisplay => $"${UnitCost:N2}";
-    public string TotalDisplay => $"${Total:N2}";
+    public string UnitCostDisplay => CurrencyService.Format(UnitCost);
+    public string TotalDisplay => CurrencyService.Format(Total);
     public string QuantityDisplay => $"{QuantityReceived}/{Quantity}";
 }
 

--- a/ArgoBooks/ViewModels/PurchaseOrdersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/PurchaseOrdersPageViewModel.cs
@@ -3,6 +3,7 @@ using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core;
 using ArgoBooks.Helpers;
+using ArgoBooks.Services;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Inventory;
 using ArgoBooks.Utilities;
@@ -402,7 +403,7 @@ public partial class PurchaseOrdersPageViewModel : SortablePageViewModelBase
                 Subtotal = order.Subtotal,
                 ShippingCost = order.ShippingCost,
                 Total = order.Total,
-                TotalDisplay = $"${order.Total:N2}",
+                TotalDisplay = CurrencyService.Format(order.Total),
                 Status = order.Status,
                 StatusDisplay = FormatStatus(order.Status),
                 ExpectedDeliveryDate = order.ExpectedDeliveryDate,

--- a/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
@@ -3,6 +3,7 @@ using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Models.Portal;
 using ArgoBooks.Core.Models.Tracking;
 using ArgoBooks.Helpers;
+using ArgoBooks.Services;
 using ArgoBooks.Localization;
 using ArgoBooks.Utilities;
 using ArgoBooks.Views;
@@ -869,7 +870,7 @@ public partial class ReceiptDisplayItem : ObservableObject
 
     // Computed properties for display
     public string DateFormatted => Date.ToString("MMM d, yyyy");
-    public string AmountFormatted => $"${Amount:N2}";
+    public string AmountFormatted => CurrencyService.Format(Amount);
     public string FileSizeFormatted => FormatFileSize(FileSize);
 
     public bool IsExpense => TransactionType == "Expense";

--- a/ArgoBooks/ViewModels/RentalInventoryModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalInventoryModalsViewModel.cs
@@ -201,7 +201,7 @@ public partial class RentalInventoryModalsViewModel : ViewModelBase
                 _ => 0
             };
 
-            return $"${total:N2}";
+            return CurrencyService.Format(total);
         }
     }
 

--- a/ArgoBooks/ViewModels/RentalInventoryPageViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalInventoryPageViewModel.cs
@@ -3,6 +3,7 @@ using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Helpers;
+using ArgoBooks.Services;
 using ArgoBooks.Core.Models.Rentals;
 using ArgoBooks.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -480,8 +481,8 @@ public partial class RentalItemDisplayItem : ObservableObject
     [ObservableProperty]
     private bool _isAvailable;
 
-    public string DailyRateFormatted => $"${DailyRate:N2}";
-    public string WeeklyRateFormatted => $"${WeeklyRate:N2}";
-    public string MonthlyRateFormatted => $"${MonthlyRate:N2}";
-    public string DepositFormatted => $"${SecurityDeposit:N2}";
+    public string DailyRateFormatted => CurrencyService.Format(DailyRate);
+    public string WeeklyRateFormatted => CurrencyService.Format(WeeklyRate);
+    public string MonthlyRateFormatted => CurrencyService.Format(MonthlyRate);
+    public string DepositFormatted => CurrencyService.Format(SecurityDeposit);
 }

--- a/ArgoBooks/ViewModels/RentalRecordsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalRecordsModalsViewModel.cs
@@ -142,8 +142,8 @@ public partial class RentalRecordsModalsViewModel : ViewModelBase
     {
         var totalDeposit = RentalLineItems.Sum(li => decimal.TryParse(li.SecurityDeposit, out var d) ? d : 0);
         var totalAmount = RentalLineItems.Sum(li => li.Amount);
-        TotalSecurityDeposit = $"${totalDeposit:N2}";
-        TotalEstimatedAmount = $"${totalAmount:N2}";
+        TotalSecurityDeposit = CurrencyService.Format(totalDeposit);
+        TotalEstimatedAmount = CurrencyService.Format(totalAmount);
     }
 
     [RelayCommand]
@@ -207,9 +207,9 @@ public partial class RentalRecordsModalsViewModel : ViewModelBase
 
     private RentalRecord? _returningRecord;
 
-    public string ReturnRateFormatted => $"${ReturnRateAmount:N2}/{ReturnRateType}";
-    public string ReturnTotalCostFormatted => $"${ReturnTotalCost:N2}";
-    public string ReturnDepositFormatted => $"${ReturnDeposit:N2}";
+    public string ReturnRateFormatted => $"{CurrencyService.Format(ReturnRateAmount)}/{ReturnRateType}";
+    public string ReturnTotalCostFormatted => CurrencyService.Format(ReturnTotalCost);
+    public string ReturnDepositFormatted => CurrencyService.Format(ReturnDeposit);
 
     #endregion
 
@@ -271,9 +271,9 @@ public partial class RentalRecordsModalsViewModel : ViewModelBase
     /// </summary>
     public ObservableCollection<RentalViewLineItemDisplay> ViewLineItems { get; } = [];
 
-    public string ViewRateFormatted => $"${ViewRateAmount:N2}/{ViewRateType}";
-    public string ViewDepositFormatted => $"${ViewSecurityDeposit:N2}";
-    public string ViewTotalCostFormatted => $"${ViewTotalCost:N2}";
+    public string ViewRateFormatted => $"{CurrencyService.Format(ViewRateAmount)}/{ViewRateType}";
+    public string ViewDepositFormatted => CurrencyService.Format(ViewSecurityDeposit);
+    public string ViewTotalCostFormatted => CurrencyService.Format(ViewTotalCost);
     public string ViewStartDateFormatted => ViewStartDate.ToString("MMMM d, yyyy");
     public string ViewDueDateFormatted => ViewDueDate.ToString("MMMM d, yyyy");
     public string ViewReturnDateFormatted => ViewReturnDate?.ToString("MMMM d, yyyy") ?? "Not returned";
@@ -1455,9 +1455,9 @@ public partial class RentalModalLineItem : ObservableObject
         }
     }
 
-    public string AmountFormatted => $"${Amount:N2}";
-    public string RateAmountDisplay => decimal.TryParse(RateAmount, out var r) ? $"${r:N2}" : "-";
-    public string SecurityDepositDisplay => decimal.TryParse(SecurityDeposit, out var d) ? $"${d:N2}" : "-";
+    public string AmountFormatted => CurrencyService.Format(Amount);
+    public string RateAmountDisplay => decimal.TryParse(RateAmount, out var r) ? CurrencyService.Format(r) : "-";
+    public string SecurityDepositDisplay => decimal.TryParse(SecurityDeposit, out var d) ? CurrencyService.Format(d) : "-";
 
     partial void OnSelectedItemChanged(RentalItemOption? value)
     {
@@ -1535,7 +1535,7 @@ public class RentalViewLineItemDisplay
     public string RateType { get; set; } = string.Empty;
     public decimal RateAmount { get; set; }
     public decimal SecurityDeposit { get; set; }
-    public string RateFormatted => $"${RateAmount:N2}/{RateType}";
-    public string DepositFormatted => $"${SecurityDeposit:N2}";
-    public string AmountFormatted => $"${Quantity * RateAmount:N2}";
+    public string RateFormatted => $"{CurrencyService.Format(RateAmount)}/{RateType}";
+    public string DepositFormatted => CurrencyService.Format(SecurityDeposit);
+    public string AmountFormatted => CurrencyService.Format(Quantity * RateAmount);
 }

--- a/ArgoBooks/ViewModels/RentalRecordsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalRecordsPageViewModel.cs
@@ -36,7 +36,7 @@ public partial class RentalRecordsPageViewModel : SortablePageViewModelBase
     [ObservableProperty]
     private decimal _totalRevenue;
 
-    public string TotalRevenueFormatted => $"${TotalRevenue:N2}";
+    public string TotalRevenueFormatted => CurrencyService.Format(TotalRevenue);
 
     #endregion
 
@@ -671,9 +671,9 @@ public partial class RentalRecordDisplayItem : ObservableObject
     public string StartDateFormatted => StartDate.ToString("MMM d, yyyy");
     public string DueDateFormatted => DueDate.ToString("MMM d, yyyy");
     public string ReturnDateFormatted => ReturnDate?.ToString("MMM d, yyyy") ?? "-";
-    public string RateFormatted => $"${RateAmount:N2}/{RateType}";
-    public string TotalCostFormatted => $"${TotalCost:N2}";
-    public string DepositFormatted => $"${SecurityDeposit:N2}";
+    public string RateFormatted => $"{CurrencyService.Format(RateAmount)}/{RateType}";
+    public string TotalCostFormatted => CurrencyService.Format(TotalCost);
+    public string DepositFormatted => CurrencyService.Format(SecurityDeposit);
     public string DaysOverdueText => DaysOverdue > 0 ? $"{DaysOverdue} days" : "-";
     public bool CanGenerateInvoice => !Paid && !HasInvoices;
     public bool CanMarkAsPaid => !Paid && !IsActive;

--- a/ArgoBooks/ViewModels/ReturnsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReturnsPageViewModel.cs
@@ -268,7 +268,7 @@ public partial class ReturnsPageViewModel : ViewModelBase
         ExpenseReturns = _allReturns.Count(r => r.ReturnType == "Expense");
         CustomerReturns = _allReturns.Count(r => r.ReturnType == "Customer");
         var totalRefundedValue = _allReturns.Sum(r => r.NetRefund);
-        TotalRefunded = $"${totalRefundedValue:N2}";
+        TotalRefunded = CurrencyService.Format(totalRefundedValue);
     }
 
     [RelayCommand]
@@ -529,5 +529,5 @@ public partial class ReturnDisplayItem : ObservableObject
 
     // Computed properties for display
     public string DateFormatted => ReturnDate.ToString("MMM d, yyyy");
-    public string RefundAmountFormatted => $"${RefundAmount:N2}";
+    public string RefundAmountFormatted => CurrencyService.Format(RefundAmount);
 }

--- a/ArgoBooks/ViewModels/RevenueModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenueModalsViewModel.cs
@@ -538,7 +538,7 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
             ShippingCostUSD = ConvertedShippingCost?.AmountUSD ?? ModalShipping,
             DiscountUSD = ConvertedDiscount?.AmountUSD ?? ModalDiscount,
             FeeUSD = ConvertedFee?.AmountUSD ?? ModalFee,
-            UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0
+            UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0 && Total != 0
                 ? Math.Round(ConvertedTotal.AmountUSD / Total * averageUnitPrice, 2)
                 : averageUnitPrice,
             IsPendingConversion = IsPendingConversion
@@ -645,7 +645,7 @@ public partial class RevenueModalsViewModel : TransactionModalsViewModelBase<Rev
         revenue.ShippingCostUSD = ConvertedShippingCost?.AmountUSD ?? ModalShipping;
         revenue.DiscountUSD = ConvertedDiscount?.AmountUSD ?? ModalDiscount;
         revenue.FeeUSD = ConvertedFee?.AmountUSD ?? ModalFee;
-        revenue.UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0
+        revenue.UnitPriceUSD = ConvertedTotal != null && ConvertedTotal.OriginalCurrency != "USD" && Subtotal > 0 && Total != 0
             ? Math.Round(ConvertedTotal.AmountUSD / Total * averageUnitPrice, 2)
             : averageUnitPrice;
         revenue.IsPendingConversion = IsPendingConversion;

--- a/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
+++ b/ArgoBooks/ViewModels/TransactionModalsViewModelBase.cs
@@ -322,12 +322,12 @@ public abstract partial class TransactionModalsViewModelBase<TDisplayItem, TLine
     public decimal FeeAmount => ModalFee;
     public decimal Total => Subtotal + TaxAmount + ShippingAmount + FeeAmount - DiscountAmount;
 
-    public string SubtotalFormatted => $"${Subtotal:N2}";
-    public string TaxAmountFormatted => $"${TaxAmount:N2}";
-    public string DiscountAmountFormatted => $"-${DiscountAmount:N2}";
-    public string ShippingAmountFormatted => $"${ShippingAmount:N2}";
-    public string FeeAmountFormatted => $"${FeeAmount:N2}";
-    public string TotalFormatted => $"${Total:N2}";
+    public string SubtotalFormatted => CurrencyService.Format(Subtotal);
+    public string TaxAmountFormatted => CurrencyService.Format(TaxAmount);
+    public string DiscountAmountFormatted => $"-{CurrencyService.Format(DiscountAmount)}";
+    public string ShippingAmountFormatted => CurrencyService.Format(ShippingAmount);
+    public string FeeAmountFormatted => CurrencyService.Format(FeeAmount);
+    public string TotalFormatted => CurrencyService.Format(Total);
 
     partial void OnModalQuantityChanged(decimal value) => UpdateTotals();
     partial void OnModalUnitPriceChanged(decimal value) => UpdateTotals();
@@ -1131,7 +1131,7 @@ public abstract partial class TransactionLineItemBase : ObservableObject
     private bool _hasProductError;
 
     public decimal Amount => (Quantity ?? 0) * (UnitPrice ?? 0);
-    public string AmountFormatted => $"${Amount:N2}";
+    public string AmountFormatted => CurrencyService.Format(Amount);
 
     partial void OnSelectedProductChanged(ProductOption? value)
     {


### PR DESCRIPTION
## Summary
This PR implements comprehensive multi-currency support throughout the application, with all accounting reports and financial displays now converting to USD for consistent cross-currency aggregation. Currency formatting is centralized through `CurrencyService`, and transaction/payment models now track both original currency amounts and USD equivalents.

## Key Changes

### Accounting Report Data Service
- Added `GetUSDRatio()` helper method to calculate USD conversion multipliers from transaction data
- Updated `GroupTransactionsByCategory()` to convert all line item amounts to USD using proportional allocation
- Modified `GetGeneralLedgerData()` to convert revenue and expense line items to USD for ledger entries
- Enhanced `GetTaxSummaryData()` to convert tax amounts to USD for consistent cross-currency tax reporting
- Added comments clarifying that all amounts in reports are USD-converted for consistency

### Invoice & Payment Processing
- Added currency field tracking (`OriginalCurrency`, `TotalUSD`, `BalanceUSD`) to invoices in `InvoiceModalsViewModel`
- Implemented USD conversion logic in `CreateAndSendInvoice()` and `SaveAsDraft()` using `ExchangeRateService`
- Updated `PaymentModalsViewModel` to capture original currency and calculate `AmountUSD` for both new and edited payments
- Added undo/redo support for currency fields in payment editing

### Currency Formatting Standardization
- Replaced all hardcoded `$` formatting (e.g., `$"{value:N2}"`) with `CurrencyService.Format()` calls across:
  - `InvoiceModalsViewModel`, `TransactionModalsViewModelBase`, `PaymentModalsViewModel`
  - `RentalRecordsModalsViewModel`, `PurchaseOrdersModalsViewModel`
  - `RentalInventoryPageViewModel`, `RentalRecordsPageViewModel`
  - `LostDamagedPageViewModel`, `ReturnsPageViewModel`, `ReceiptsPageViewModel`
  - `CustomersPageViewModel`, `ChartLoaderService`
- Ensures consistent currency display across all UI elements

### Bug Fixes
- Added division-by-zero checks in `ExpenseModalsViewModel` and `RevenueModalsViewModel` when calculating `UnitPriceUSD` (only convert when `Total != 0`)

## Implementation Details
- USD conversion uses exchange rates from `ExchangeRateService` based on transaction date
- Proportional allocation ensures line item amounts sum correctly when converted to USD
- Pending conversions are handled gracefully (return 0 ratio)
- Legacy data and USD transactions default to 1:1 ratio
- All accounting aggregations now use USD amounts for accurate cross-currency reporting

https://claude.ai/code/session_01B4d8aazCr7KbJTnSgshx6s