### PR TITLE
Add invoice template management UI with list view and thumbnails

### DIFF
--- a/ArgoBooks.Core/Models/Invoices/InvoiceTemplate.cs
+++ b/ArgoBooks.Core/Models/Invoices/InvoiceTemplate.cs
@@ -192,6 +192,12 @@ public class InvoiceTemplate
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
+    /// Base64-encoded PNG thumbnail of the template preview.
+    /// </summary>
+    [JsonPropertyName("thumbnailBase64")]
+    public string? ThumbnailBase64 { get; set; }
+
+    /// <summary>
     /// Creates a deep copy of this template.
     /// </summary>
     public InvoiceTemplate Clone()
@@ -228,7 +234,8 @@ public class InvoiceTemplate
             ShowPaymentInstructions = ShowPaymentInstructions,
             ShowDueDateProminent = ShowDueDateProminent,
             CreatedAt = CreatedAt,
-            UpdatedAt = DateTime.UtcNow
+            UpdatedAt = DateTime.UtcNow,
+            ThumbnailBase64 = ThumbnailBase64
         };
     }
 }

--- a/ArgoBooks.Core/Services/FileService.cs
+++ b/ArgoBooks.Core/Services/FileService.cs
@@ -281,6 +281,7 @@ public class FileService(
             LostDamaged = await ReadJsonAsync<List<Models.Tracking.LostDamaged>>(tempDirectory, "lostDamaged.json", cancellationToken) ?? [],
             Receipts = await ReadJsonAsync<List<Models.Tracking.Receipt>>(tempDirectory, "receipts.json", cancellationToken) ?? [],
             ReportTemplates = await ReadJsonAsync<List<Models.Reports.ReportTemplate>>(tempDirectory, "reportTemplates.json", cancellationToken) ?? [],
+            InvoiceTemplates = await ReadJsonAsync<List<Models.Invoices.InvoiceTemplate>>(tempDirectory, "invoiceTemplates.json", cancellationToken) ?? [],
             EventLog = await ReadJsonAsync<List<AuditEvent>>(tempDirectory, "eventLog.json", cancellationToken) ?? [],
             PendingConversions = await ReadJsonAsync<List<PendingConversion>>(tempDirectory, "pendingConversions.json", cancellationToken) ?? []
         };
@@ -325,6 +326,7 @@ public class FileService(
         await WriteJsonAsync(companyDirectory, "lostDamaged.json", data.LostDamaged, cancellationToken);
         await WriteJsonAsync(companyDirectory, "receipts.json", data.Receipts, cancellationToken);
         await WriteJsonAsync(companyDirectory, "reportTemplates.json", data.ReportTemplates, cancellationToken);
+        await WriteJsonAsync(companyDirectory, "invoiceTemplates.json", data.InvoiceTemplates, cancellationToken);
         await WriteJsonAsync(companyDirectory, "eventLog.json", data.EventLog, cancellationToken);
         await WriteJsonAsync(companyDirectory, "pendingConversions.json", data.PendingConversions, cancellationToken);
 

--- a/ArgoBooks/Controls/ColumnVisibilityMenu.axaml
+++ b/ArgoBooks/Controls/ColumnVisibilityMenu.axaml
@@ -25,6 +25,7 @@
                     <Button Grid.Column="1"
                             Classes="reset-columns-button"
                             Command="{Binding ResetCommand, RelativeSource={RelativeSource AncestorType=controls:ColumnVisibilityMenu}}"
+                            Click="OnResetButtonClick"
                             ToolTip.Tip="{loc:Loc 'Reset to Default'}">
                         <PathIcon Data="{x:Static icons:Icons.Refresh}"
                                   Width="14" Height="14" />

--- a/ArgoBooks/Controls/ColumnVisibilityMenu.axaml.cs
+++ b/ArgoBooks/Controls/ColumnVisibilityMenu.axaml.cs
@@ -101,6 +101,11 @@ public partial class ColumnVisibilityMenu : UserControl
         CloseCommand = new RelayCommand(() => IsOpen = false);
     }
 
+    private void OnResetButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        IsOpen = false;
+    }
+
     /// <summary>
     /// Shows the column visibility menu at the specified pointer position.
     /// Call this from the table header's PointerPressed event.

--- a/ArgoBooks/Controls/InvoicePreviewControl.axaml.cs
+++ b/ArgoBooks/Controls/InvoicePreviewControl.axaml.cs
@@ -648,6 +648,33 @@ public partial class InvoicePreviewControl : UserControl
 #endif
     }
 
+    /// <summary>
+    /// Captures the current WebView2 content as a PNG screenshot and returns it as base64.
+    /// Returns null on non-Windows platforms or if the WebView is not initialized.
+    /// </summary>
+    public async Task<string?> CaptureScreenshotBase64Async()
+    {
+#if WINDOWS
+        if (_isWebViewDisposed || !_isWebViewInitialized || _webView?.CoreWebView2 == null)
+            return null;
+
+        try
+        {
+            using var stream = new MemoryStream();
+            await _webView.CoreWebView2.CapturePreviewAsync(
+                Microsoft.Web.WebView2.Core.CoreWebView2CapturePreviewImageFormat.Png, stream);
+            return Convert.ToBase64String(stream.ToArray());
+        }
+        catch
+        {
+            return null;
+        }
+#else
+        await Task.CompletedTask;
+        return null;
+#endif
+    }
+
     private void OpenInBrowserButton_Click(object? sender, RoutedEventArgs e)
     {
         OpenInBrowserCommand?.Execute(null);

--- a/ArgoBooks/Converters/Base64ToImageConverter.cs
+++ b/ArgoBooks/Converters/Base64ToImageConverter.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media.Imaging;
+
+namespace ArgoBooks.Converters;
+
+/// <summary>
+/// Converts a base64-encoded PNG string to a Bitmap for display.
+/// </summary>
+public class Base64ToImageConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string base64 && !string.IsNullOrEmpty(base64))
+        {
+            try
+            {
+                var bytes = System.Convert.FromBase64String(base64);
+                using var stream = new MemoryStream(bytes);
+                return new Bitmap(stream);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/ArgoBooks/Converters/HexColorToBrushConverter.cs
+++ b/ArgoBooks/Converters/HexColorToBrushConverter.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace ArgoBooks.Converters;
+
+/// <summary>
+/// Converts a hex color string (e.g., "#2563EB") to a SolidColorBrush.
+/// </summary>
+public class HexColorToBrushConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string hex && !string.IsNullOrEmpty(hex))
+        {
+            try
+            {
+                return new SolidColorBrush(Color.Parse(hex));
+            }
+            catch
+            {
+                // Fall through to default
+            }
+        }
+
+        return new SolidColorBrush(Colors.Gray);
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/ArgoBooks/Converters/ThemeBorderBrushConverters.cs
+++ b/ArgoBooks/Converters/ThemeBorderBrushConverters.cs
@@ -7,44 +7,6 @@ using Avalonia.Media;
 namespace ArgoBooks.Converters;
 
 /// <summary>
-/// Converter that returns PrimaryBrush if value equals CompareValue, otherwise BorderBrush.
-/// </summary>
-public class ThemeBorderBrushConverter : IValueConverter
-{
-    /// <summary>
-    /// The value to compare against.
-    /// </summary>
-    public string? CompareValue { get; set; }
-
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        bool isSelected = false;
-        if (value is string stringValue)
-        {
-            isSelected = string.Equals(stringValue, CompareValue, StringComparison.OrdinalIgnoreCase);
-        }
-
-        // Get the appropriate brush from Application resources
-        if (Application.Current?.Resources != null)
-        {
-            var resourceKey = isSelected ? "PrimaryBrush" : "BorderBrush";
-            if (Application.Current.Resources.TryGetResource(resourceKey, Application.Current.ActualThemeVariant, out var resource))
-            {
-                return resource;
-            }
-        }
-
-        // Fallback colors
-        return isSelected
-            ? new SolidColorBrush(Color.Parse(AppColors.Primary))
-            : new SolidColorBrush(Color.Parse(AppColors.ChartGrid));
-    }
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => throw new NotSupportedException();
-}
-
-/// <summary>
 /// Multi-value converter that returns PrimaryBrush if the selected theme matches the compare value.
 /// Binds to both SelectedTheme and SelectedAccentColor so it updates when either changes.
 /// Values[0] = SelectedTheme, Values[1] = SelectedAccentColor (used to trigger re-evaluation).

--- a/ArgoBooks/Icons.cs
+++ b/ArgoBooks/Icons.cs
@@ -233,9 +233,6 @@ public static class Icons
     /// <summary>Fingerprint icon.</summary>
     public const string Fingerprint = "M17.81 4.47c-.08 0-.16-.02-.23-.06C15.66 3.42 14 3 12.01 3c-1.98 0-3.86.47-5.57 1.41-.24.13-.54.04-.68-.2-.13-.24-.04-.55.2-.68C7.82 2.52 9.86 2 12.01 2c2.13 0 3.99.47 6.03 1.52.25.13.34.43.21.67-.09.18-.26.28-.44.28zM3.5 9.72a.499.499 0 0 1-.41-.79c.99-1.4 2.25-2.5 3.75-3.27C9.98 4.04 14 4.03 17.15 5.65c1.5.77 2.76 1.86 3.75 3.25a.5.5 0 0 1-.12.7.5.5 0 0 1-.7-.12 9.388 9.388 0 0 0-3.39-2.94c-2.87-1.47-6.54-1.47-9.4.01-1.36.7-2.5 1.7-3.4 2.96-.08.14-.23.21-.39.21zm6.25 12.07a.47.47 0 0 1-.35-.15c-.87-.87-1.34-1.43-2.01-2.64-.69-1.23-1.05-2.73-1.05-4.34 0-2.97 2.54-5.39 5.66-5.39s5.66 2.42 5.66 5.39c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-2.42-2.09-4.39-4.66-4.39-2.57 0-4.66 1.97-4.66 4.39 0 1.44.32 2.77.93 3.85.64 1.15 1.08 1.64 1.85 2.42.19.2.19.51 0 .71-.11.1-.24.15-.37.15zm7.17-1.85c-1.19 0-2.24-.3-3.1-.89-1.49-1.01-2.38-2.65-2.38-4.39 0-.28.22-.5.5-.5s.5.22.5.5c0 1.41.72 2.74 1.94 3.56.71.48 1.54.71 2.54.71.24 0 .64-.03 1.04-.1.27-.05.53.13.58.41.05.27-.13.53-.41.58-.57.11-1.07.12-1.21.12zM14.91 22c-.04 0-.09-.01-.13-.02-1.59-.44-2.63-1.03-3.72-2.1a7.297 7.297 0 0 1-2.17-5.22c0-1.62 1.38-2.94 3.08-2.94 1.7 0 3.08 1.32 3.08 2.94 0 1.07.93 1.94 2.08 1.94s2.08-.87 2.08-1.94c0-3.77-3.25-6.83-7.25-6.83-2.84 0-5.44 1.58-6.61 4.03-.39.81-.59 1.76-.59 2.8 0 .78.07 2.01.67 3.61.1.26-.03.55-.29.64-.26.1-.55-.04-.64-.29a11.14 11.14 0 0 1-.73-3.96c0-1.2.23-2.29.68-3.24 1.33-2.79 4.28-4.6 7.51-4.6 4.55 0 8.25 3.51 8.25 7.83 0 1.62-1.38 2.94-3.08 2.94s-3.08-1.32-3.08-2.94c0-1.07-.93-1.94-2.08-1.94s-2.08.87-2.08 1.94c0 1.71.66 3.31 1.87 4.51.95.94 1.86 1.46 3.27 1.85.27.07.42.35.35.61-.05.23-.26.38-.47.38z";
 
-    /// <summary>Logout/sign out icon.</summary>
-    public const string Logout = "M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z";
-
     #endregion
 
     #region Help & Support
@@ -277,12 +274,6 @@ public static class Icons
     #endregion
 
     #region Email & Communication
-
-    /// <summary>Send/paper plane icon for sending emails.</summary>
-    public const string Send = "M2.01 21L23 12 2.01 3 2 10l15 2-15 2z";
-
-    /// <summary>Email/envelope icon.</summary>
-    public const string Email = "M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z";
 
     /// <summary>Warning/alert triangle icon.</summary>
     public const string Warning = "M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z";
@@ -378,12 +369,6 @@ public static class Icons
     /// <summary>2x2 grid layout icon.</summary>
     public const string Grid2x2 = "M3 3v18h18V3H3zm8 16H5v-6h6v6zm0-8H5V5h6v6zm8 8h-6v-6h6v6zm0-8h-6V5h6v6z";
 
-    /// <summary>Bar chart (alternate style).</summary>
-    public const string BarChartAlt = "M22,21H2V3H4V19H6V10H10V19H12V6H16V19H18V14H22V21Z";
-
-    /// <summary>Line chart with data points.</summary>
-    public const string LineChart = "M16,11.78L20.24,4.45L21.97,5.45L16.74,14.5L10.23,10.75L5.46,19H22V21H2V3H4V17.54L9.5,8L16,11.78Z";
-
     /// <summary>Detailed grid layout icon.</summary>
     public const string GridDetailed = "M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H5v-4h4v4zm0-6H5V7h4v4zm6 6h-4v-4h4v4zm0-6h-4V7h4v4zm4 6h-4v-4h4v4zm0-6h-4V7h4v4z";
 
@@ -423,9 +408,6 @@ public static class Icons
     /// <summary>Smiley/AI insights face icon.</summary>
     public const string SmartInsights = "M9 11.75c-.69 0-1.25.56-1.25 1.25s.56 1.25 1.25 1.25 1.25-.56 1.25-1.25-.56-1.25-1.25-1.25zm6 0c-.69 0-1.25.56-1.25 1.25s.56 1.25 1.25 1.25 1.25-.56 1.25-1.25-.56-1.25-1.25-1.25zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8 0-.29.02-.58.05-.86 2.36-1.05 4.23-2.98 5.21-5.37C11.07 8.33 14.05 10 17.42 10c.78 0 1.53-.09 2.25-.26.21.71.33 1.47.33 2.26 0 4.41-3.59 8-8 8z";
 
-    /// <summary>Robot/AI face icon.</summary>
-    public const string Robot = "M20 9V7c0-1.1-.9-2-2-2h-3c0-1.66-1.34-3-3-3S9 3.34 9 5H6c-1.1 0-2 .9-2 2v2c-1.66 0-3 1.34-3 3s1.34 3 3 3v4c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-4c1.66 0 3-1.34 3-3s-1.34-3-3-3zM7.5 11.5c0-.83.67-1.5 1.5-1.5s1.5.67 1.5 1.5S9.83 13 9 13s-1.5-.67-1.5-1.5zM16 17H8v-2h8v2zm-1-4c-.83 0-1.5-.67-1.5-1.5S14.17 10 15 10s1.5.67 1.5 1.5S15.83 13 15 13z";
-
     /// <summary>Key/password icon.</summary>
     public const string Key = "M12.65 10C11.83 7.67 9.61 6 7 6c-3.31 0-6 2.69-6 6s2.69 6 6 6c2.61 0 4.83-1.67 5.65-4H17v4h4v-4h2v-4H12.65zM7 14c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z";
 
@@ -434,9 +416,6 @@ public static class Icons
 
     /// <summary>Fullscreen with frame border.</summary>
     public const string FullscreenAlt = "M19 12h-2v3h-3v2h5v-5zM7 9h3V7H5v5h2V9zm14-6H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z";
-
-    /// <summary>Speaker/volume icon.</summary>
-    public const string Volume = "M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z";
 
     /// <summary>Dashboard grid layout icon.</summary>
     public const string DashboardGrid = "M4 11h5V5H4v6zm0 7h5v-6H4v6zm6 0h5v-6h-5v6zm6 0h5v-6h-5v6zm-6-7h5V5h-5v6zm6-6v6h5V5h-5z";
@@ -449,9 +428,6 @@ public static class Icons
 
     /// <summary>Copy/duplicate pages icon.</summary>
     public const string Copy = "M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z";
-
-    /// <summary>Table with horizontal rows icon.</summary>
-    public const string TableRows = "M21 3H3C1.9 3 1 3.9 1 5v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14zM5 15h14v2H5zm0-4h14v2H5zm0-4h14v2H5z";
 
     /// <summary>Plus in rounded box icon.</summary>
     public const string AddBox = "M19 3H5c-1.11 0-2 .89-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.11-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z";
@@ -486,59 +462,8 @@ public static class Icons
     /// <summary>Indent left/decrease indent.</summary>
     public const string IndentLeft = "M11 8v3H1v2h10v3l4-4-4-4zM19 4h2v16h-2V4z";
 
-    /// <summary>Pie chart icon.</summary>
-    public const string PieChart = "M21,11H13V3A8,8 0 0,1 21,11M19,13A8,8 0 0,1 3,11A8,8 0 0,1 11,3V13H19Z";
-
-    /// <summary>Image gallery/stack icon.</summary>
-    public const string ImageGallery = "M21,17H7V3H21M21,1H7A2,2 0 0,0 5,3V17A2,2 0 0,0 7,19H21A2,2 0 0,0 23,17V3A2,2 0 0,0 21,1M3,5H1V21A2,2 0 0,0 3,23H19V21H3M15.96,10.29L13.21,13.83L11.25,11.47L8.5,15H19.5L15.96,10.29Z";
-
-    /// <summary>Globe/world map icon (MDI style).</summary>
-    public const string GlobeAlt = "M17.9,17.39C17.64,16.59 16.89,16 16,16H15V13A1,1 0 0,0 14,12H8V10H10A1,1 0 0,0 11,9V7H13A2,2 0 0,0 15,5V4.59C17.93,5.77 20,8.64 20,12C20,14.08 19.2,15.97 17.9,17.39M11,19.93C7.05,19.44 4,16.08 4,12C4,11.38 4.08,10.79 4.21,10.21L9,15V16A2,2 0 0,0 11,18M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z";
-
-    /// <summary>List with bullet items (MDI style).</summary>
-    public const string ListAlt = "M3,13H5V11H3V13M3,17H5V15H3V17M3,9H5V7H3V9M7,13H21V11H7V13M7,17H21V15H7V17M7,7V9H21V7H7Z";
-
-    /// <summary>Chevron left (MDI style).</summary>
-    public const string ChevronLeftAlt = "M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z";
-
-    /// <summary>Chevron right (MDI style).</summary>
-    public const string ChevronRightAlt = "M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z";
-
-    /// <summary>Minus icon (MDI style).</summary>
-    public const string MinusAlt = "M19,13H5V11H19V13Z";
-
     /// <summary>Plus/add icon (MDI style).</summary>
     public const string AddAlt = "M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z";
-
-    /// <summary>Notepad document (MDI style).</summary>
-    public const string NotepadAlt = "M14,17H7V15H14M17,13H7V11H17M17,9H7V7H17M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z";
-
-    /// <summary>Text heading (T format).</summary>
-    public const string Heading = "M5,4V7H10.5V19H13.5V7H19V4H5Z";
-
-    /// <summary>Table with grid cells.</summary>
-    public const string TableGrid = "M5,4H19A2,2 0 0,1 21,6V18A2,2 0 0,1 19,20H5A2,2 0 0,1 3,18V6A2,2 0 0,1 5,4M5,8V12H11V8H5M13,8V12H19V8H13M5,14V18H11V14H5M13,14V18H19V14H13Z";
-
-    /// <summary>Calendar icon (MDI style).</summary>
-    public const string CalendarAlt = "M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1";
-
-    /// <summary>Refresh/reload icon (MDI style).</summary>
-    public const string RefreshMdi = "M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z";
-
-    /// <summary>Warning circle (MDI style).</summary>
-    public const string WarningCircleMdi = "M13,13H11V7H13M13,17H11V15H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z";
-
-    /// <summary>Stacked layers icon.</summary>
-    public const string Layers = "M2,2H16V16H2V2M14,14V4H4V14H14M22,8V22H8V20H20V8H22Z";
-
-    /// <summary>Stacked layers icon (alternate).</summary>
-    public const string LayersAlt = "M4,4H16V16H4V4M6,6V14H14V6H6M20,8V20H8V18H18V8H20Z";
-
-    /// <summary>QR code icon.</summary>
-    public const string QrCode = "M2,2H11V11H2V2M9,4H4V9H9V4M22,13V22H13V13H22M20,15H15V20H20V15M16,8V11H13V8H16M8,16H11V13H8V16Z";
-
-    /// <summary>Square/rectangle shape.</summary>
-    public const string Square = "M6,6H18V18H6V6M8,8V16H16V8H8Z";
 
     /// <summary>Download to file icon.</summary>
     public const string DownloadFile = "M16 13h-3V3h-2v10H8l4 4 4-4zM4 19v2h16v-2H4z";

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
@@ -103,60 +103,109 @@
                               IsVisible="{Binding IsTemplateListMode}">
                             <Grid RowDefinitions="*,Auto">
                                 <ScrollViewer Grid.Row="0" Padding="24,16">
-                                    <StackPanel Spacing="8">
-                                        <ItemsControl ItemsSource="{Binding SavedTemplates}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border Padding="16,12"
-                                                            Background="{DynamicResource SurfaceAltBrush}"
-                                                            CornerRadius="8"
-                                                            BorderBrush="{DynamicResource BorderBrush}"
-                                                            BorderThickness="1"
-                                                            Margin="0,0,0,4">
-                                                        <Grid ColumnDefinitions="*,Auto,Auto">
-                                                            <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
-                                                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <StackPanel Spacing="16">
+                                        <!-- Built-in Templates Section -->
+                                        <StackPanel Spacing="8">
+                                            <TextBlock Text="{loc:Loc 'Built-in Templates'}"
+                                                       FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextSecondaryBrush}" />
+                                            <ItemsControl ItemsSource="{Binding DefaultTemplates}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Padding="16,12"
+                                                                Background="{DynamicResource SurfaceAltBrush}"
+                                                                CornerRadius="8"
+                                                                BorderBrush="{DynamicResource BorderBrush}"
+                                                                BorderThickness="1"
+                                                                Margin="0,0,0,4">
+                                                            <Grid ColumnDefinitions="*,Auto">
+                                                                <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
                                                                     <TextBlock Text="{Binding Name}"
                                                                                FontSize="14"
                                                                                FontWeight="SemiBold"
                                                                                Foreground="{DynamicResource TextPrimaryBrush}" />
-                                                                    <Border Background="{DynamicResource PrimaryBrush}"
-                                                                            CornerRadius="4"
-                                                                            Padding="6,2"
-                                                                            IsVisible="{Binding IsDefault}"
-                                                                            VerticalAlignment="Center">
-                                                                        <TextBlock Text="{loc:Loc Default}"
-                                                                                   FontSize="11"
-                                                                                   Foreground="White" />
-                                                                    </Border>
+                                                                    <TextBlock Text="{Binding BaseTemplate}"
+                                                                               FontSize="12"
+                                                                               Foreground="{DynamicResource TextSecondaryBrush}" />
                                                                 </StackPanel>
-                                                                <TextBlock Text="{Binding BaseTemplate}"
-                                                                           FontSize="12"
-                                                                           Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                            </StackPanel>
-                                                            <Button Grid.Column="1"
-                                                                    Classes="icon-button"
-                                                                    ToolTip.Tip="{loc:Loc Edit}"
-                                                                    Margin="8,0"
-                                                                    Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
-                                                                    CommandParameter="{Binding}">
-                                                                <PathIcon Data="{x:Static icons:Icons.Edit}"
-                                                                          Width="16" Height="16" />
-                                                            </Button>
-                                                            <Button Grid.Column="2"
-                                                                    Classes="icon-button"
-                                                                    ToolTip.Tip="{loc:Loc Delete}"
-                                                                    Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).OpenDeleteTemplateCommand}"
-                                                                    CommandParameter="{Binding}">
-                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
-                                                                          Width="16" Height="16"
-                                                                          Foreground="{DynamicResource ErrorBrush}" />
-                                                            </Button>
-                                                        </Grid>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
+                                                                <Button Grid.Column="1"
+                                                                        Classes="icon-button"
+                                                                        ToolTip.Tip="{loc:Loc Edit}"
+                                                                        Margin="8,0"
+                                                                        Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
+                                                                        CommandParameter="{Binding}">
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
+                                                                              Width="16" Height="16" />
+                                                                </Button>
+                                                            </Grid>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+
+                                        <!-- Custom Templates Section -->
+                                        <StackPanel Spacing="8"
+                                                    IsVisible="{Binding CustomTemplates.Count}">
+                                            <TextBlock Text="{loc:Loc 'My Templates'}"
+                                                       FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextSecondaryBrush}" />
+                                            <ItemsControl ItemsSource="{Binding CustomTemplates}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Padding="16,12"
+                                                                Background="{DynamicResource SurfaceAltBrush}"
+                                                                CornerRadius="8"
+                                                                BorderBrush="{DynamicResource BorderBrush}"
+                                                                BorderThickness="1"
+                                                                Margin="0,0,0,4">
+                                                            <Grid ColumnDefinitions="*,Auto,Auto">
+                                                                <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
+                                                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                                                        <TextBlock Text="{Binding Name}"
+                                                                                   FontSize="14"
+                                                                                   FontWeight="SemiBold"
+                                                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                                                        <Border Background="{DynamicResource PrimaryBrush}"
+                                                                                CornerRadius="4"
+                                                                                Padding="6,2"
+                                                                                IsVisible="{Binding IsDefault}"
+                                                                                VerticalAlignment="Center">
+                                                                            <TextBlock Text="{loc:Loc Default}"
+                                                                                       FontSize="11"
+                                                                                       Foreground="White" />
+                                                                        </Border>
+                                                                    </StackPanel>
+                                                                    <TextBlock Text="{Binding BaseTemplate}"
+                                                                               FontSize="12"
+                                                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                                </StackPanel>
+                                                                <Button Grid.Column="1"
+                                                                        Classes="icon-button"
+                                                                        ToolTip.Tip="{loc:Loc Edit}"
+                                                                        Margin="8,0"
+                                                                        Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
+                                                                        CommandParameter="{Binding}">
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
+                                                                              Width="16" Height="16" />
+                                                                </Button>
+                                                                <Button Grid.Column="2"
+                                                                        Classes="icon-button"
+                                                                        ToolTip.Tip="{loc:Loc Delete}"
+                                                                        Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).OpenDeleteTemplateCommand}"
+                                                                        CommandParameter="{Binding}">
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
+                                                                              Width="16" Height="16"
+                                                                              Foreground="{DynamicResource ErrorBrush}" />
+                                                                </Button>
+                                                            </Grid>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
                                     </StackPanel>
                                 </ScrollViewer>
 

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
@@ -76,12 +76,19 @@
                                                Foreground="{DynamicResource TextPrimaryBrush}" />
                                     <TextBlock Text="{loc:Loc 'Customize your invoice template'}"
                                                FontSize="13"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                               Foreground="{DynamicResource TextSecondaryBrush}"
+                                               IsVisible="{Binding !IsTemplateListMode}" />
+                                    <TextBlock Text="{loc:Loc 'Manage your invoice templates'}"
+                                               FontSize="13"
+                                               Foreground="{DynamicResource TextSecondaryBrush}"
+                                               IsVisible="{Binding IsTemplateListMode}" />
                                 </StackPanel>
-                                <controls:UndoRedoButtonGroup Grid.Column="1"
-                                                              DataContext="{Binding UndoRedoViewModel}"
-                                                              Margin="0,0,12,0"
-                                                              VerticalAlignment="Center" />
+                                <Panel Grid.Column="1"
+                                       IsVisible="{Binding !IsTemplateListMode}">
+                                    <controls:UndoRedoButtonGroup DataContext="{Binding UndoRedoViewModel}"
+                                                                  Margin="0,0,12,0"
+                                                                  VerticalAlignment="Center" />
+                                </Panel>
                                 <Button Grid.Column="2"
                                         Classes="icon-button"
                                         Command="{Binding RequestCloseCommand}">
@@ -91,8 +98,130 @@
                             </Grid>
                         </Border>
 
+                        <!-- Template List (shown when IsTemplateListMode) -->
+                        <Grid Grid.Row="1" Grid.RowSpan="2"
+                              IsVisible="{Binding IsTemplateListMode}">
+                            <Grid RowDefinitions="*,Auto">
+                                <ScrollViewer Grid.Row="0" Padding="24,16">
+                                    <StackPanel Spacing="8">
+                                        <ItemsControl ItemsSource="{Binding SavedTemplates}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Padding="16,12"
+                                                            Background="{DynamicResource SurfaceAltBrush}"
+                                                            CornerRadius="8"
+                                                            BorderBrush="{DynamicResource BorderBrush}"
+                                                            BorderThickness="1"
+                                                            Margin="0,0,0,4">
+                                                        <Grid ColumnDefinitions="*,Auto,Auto">
+                                                            <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
+                                                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                                                    <TextBlock Text="{Binding Name}"
+                                                                               FontSize="14"
+                                                                               FontWeight="SemiBold"
+                                                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                                                                    <Border Background="{DynamicResource PrimaryBrush}"
+                                                                            CornerRadius="4"
+                                                                            Padding="6,2"
+                                                                            IsVisible="{Binding IsDefault}"
+                                                                            VerticalAlignment="Center">
+                                                                        <TextBlock Text="{loc:Loc Default}"
+                                                                                   FontSize="11"
+                                                                                   Foreground="White" />
+                                                                    </Border>
+                                                                </StackPanel>
+                                                                <TextBlock Text="{Binding BaseTemplate}"
+                                                                           FontSize="12"
+                                                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                            </StackPanel>
+                                                            <Button Grid.Column="1"
+                                                                    Classes="icon-button"
+                                                                    ToolTip.Tip="{loc:Loc Edit}"
+                                                                    Margin="8,0"
+                                                                    Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
+                                                                    CommandParameter="{Binding}">
+                                                                <PathIcon Data="{x:Static icons:Icons.Edit}"
+                                                                          Width="16" Height="16" />
+                                                            </Button>
+                                                            <Button Grid.Column="2"
+                                                                    Classes="icon-button"
+                                                                    ToolTip.Tip="{loc:Loc Delete}"
+                                                                    Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).OpenDeleteTemplateCommand}"
+                                                                    CommandParameter="{Binding}">
+                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
+                                                                          Width="16" Height="16"
+                                                                          Foreground="{DynamicResource ErrorBrush}" />
+                                                            </Button>
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </ScrollViewer>
+
+                                <!-- Delete Confirmation -->
+                                <Border Grid.Row="0"
+                                        IsVisible="{Binding IsDeleteConfirmOpen}"
+                                        Background="#80000000"
+                                        VerticalAlignment="Stretch"
+                                        HorizontalAlignment="Stretch">
+                                    <Border Background="{DynamicResource SurfaceBrush}"
+                                            CornerRadius="12"
+                                            Padding="24"
+                                            MaxWidth="400"
+                                            VerticalAlignment="Center"
+                                            HorizontalAlignment="Center"
+                                            BoxShadow="0 4 16 0 #40000000">
+                                        <StackPanel Spacing="16">
+                                            <TextBlock Text="{loc:Loc 'Delete Template?'}"
+                                                       FontSize="16"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextPrimaryBrush}" />
+                                            <TextBlock Text="{loc:Loc 'This template will be permanently deleted. This action cannot be undone.'}"
+                                                       FontSize="13"
+                                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                                       TextWrapping="Wrap" />
+                                            <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Right">
+                                                <Button Classes="secondary-button"
+                                                        Content="{loc:Loc Cancel}"
+                                                        Command="{Binding CloseDeleteConfirmCommand}" />
+                                                <Button Classes="danger-button"
+                                                        Content="{loc:Loc Delete}"
+                                                        Command="{Binding ConfirmDeleteTemplateCommand}" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Border>
+                                </Border>
+
+                                <!-- Footer with Create New button -->
+                                <Border Grid.Row="1"
+                                        Padding="24,16"
+                                        BorderBrush="{DynamicResource BorderBrush}"
+                                        BorderThickness="0,1,0,0">
+                                    <Grid ColumnDefinitions="*,Auto,Auto">
+                                        <Button Grid.Column="1"
+                                                Classes="secondary-button"
+                                                Content="{loc:Loc Close}"
+                                                Margin="0,0,12,0"
+                                                Command="{Binding RequestCloseCommand}" />
+                                        <Button Grid.Column="2"
+                                                Classes="primary-button"
+                                                Command="{Binding CreateNewFromListCommand}">
+                                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                                <PathIcon Data="{x:Static icons:Icons.Add}"
+                                                          Width="14" Height="14" />
+                                                <TextBlock Text="{loc:Loc 'Create Template'}" />
+                                            </StackPanel>
+                                        </Button>
+                                    </Grid>
+                                </Border>
+                            </Grid>
+                        </Grid>
+
                         <!-- Content -->
-                        <Grid Grid.Row="1" ColumnDefinitions="350,*">
+                        <Grid Grid.Row="1" ColumnDefinitions="350,*"
+                              IsVisible="{Binding !IsTemplateListMode}">
                             <!-- Left Panel: Settings -->
                             <Border Grid.Column="0"
                                     BorderBrush="{DynamicResource BorderBrush}"
@@ -374,11 +503,12 @@
                             </Grid>
                         </Grid>
 
-                        <!-- Footer -->
+                        <!-- Footer (designer mode only) -->
                         <Border Grid.Row="2"
                                 Padding="24,16"
                                 BorderBrush="{DynamicResource BorderBrush}"
-                                BorderThickness="0,1,0,0">
+                                BorderThickness="0,1,0,0"
+                                IsVisible="{Binding !IsTemplateListMode}">
                             <Grid ColumnDefinitions="Auto,Auto,*,Auto">
                                 <!-- Fullscreen toggle -->
                                 <Button Grid.Column="0"

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
@@ -103,109 +103,60 @@
                               IsVisible="{Binding IsTemplateListMode}">
                             <Grid RowDefinitions="*,Auto">
                                 <ScrollViewer Grid.Row="0" Padding="24,16">
-                                    <StackPanel Spacing="16">
-                                        <!-- Built-in Templates Section -->
-                                        <StackPanel Spacing="8">
-                                            <TextBlock Text="{loc:Loc 'Built-in Templates'}"
-                                                       FontSize="13"
-                                                       FontWeight="SemiBold"
-                                                       Foreground="{DynamicResource TextSecondaryBrush}" />
-                                            <ItemsControl ItemsSource="{Binding DefaultTemplates}">
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate>
-                                                        <Border Padding="16,12"
-                                                                Background="{DynamicResource SurfaceAltBrush}"
-                                                                CornerRadius="8"
-                                                                BorderBrush="{DynamicResource BorderBrush}"
-                                                                BorderThickness="1"
-                                                                Margin="0,0,0,4">
-                                                            <Grid ColumnDefinitions="*,Auto">
-                                                                <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
+                                    <StackPanel Spacing="8">
+                                        <ItemsControl ItemsSource="{Binding CustomTemplates}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Padding="16,12"
+                                                            Background="{DynamicResource SurfaceAltBrush}"
+                                                            CornerRadius="8"
+                                                            BorderBrush="{DynamicResource BorderBrush}"
+                                                            BorderThickness="1"
+                                                            Margin="0,0,0,4">
+                                                        <Grid ColumnDefinitions="*,Auto,Auto">
+                                                            <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
+                                                                <StackPanel Orientation="Horizontal" Spacing="8">
                                                                     <TextBlock Text="{Binding Name}"
                                                                                FontSize="14"
                                                                                FontWeight="SemiBold"
                                                                                Foreground="{DynamicResource TextPrimaryBrush}" />
-                                                                    <TextBlock Text="{Binding BaseTemplate}"
-                                                                               FontSize="12"
-                                                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                                    <Border Background="{DynamicResource PrimaryBrush}"
+                                                                            CornerRadius="4"
+                                                                            Padding="6,2"
+                                                                            IsVisible="{Binding IsDefault}"
+                                                                            VerticalAlignment="Center">
+                                                                        <TextBlock Text="{loc:Loc Default}"
+                                                                                   FontSize="11"
+                                                                                   Foreground="White" />
+                                                                    </Border>
                                                                 </StackPanel>
-                                                                <Button Grid.Column="1"
-                                                                        Classes="icon-button"
-                                                                        ToolTip.Tip="{loc:Loc Edit}"
-                                                                        Margin="8,0"
-                                                                        Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
-                                                                        CommandParameter="{Binding}">
-                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
-                                                                              Width="16" Height="16" />
-                                                                </Button>
-                                                            </Grid>
-                                                        </Border>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
-                                        </StackPanel>
-
-                                        <!-- Custom Templates Section -->
-                                        <StackPanel Spacing="8"
-                                                    IsVisible="{Binding CustomTemplates.Count}">
-                                            <TextBlock Text="{loc:Loc 'My Templates'}"
-                                                       FontSize="13"
-                                                       FontWeight="SemiBold"
-                                                       Foreground="{DynamicResource TextSecondaryBrush}" />
-                                            <ItemsControl ItemsSource="{Binding CustomTemplates}">
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate>
-                                                        <Border Padding="16,12"
-                                                                Background="{DynamicResource SurfaceAltBrush}"
-                                                                CornerRadius="8"
-                                                                BorderBrush="{DynamicResource BorderBrush}"
-                                                                BorderThickness="1"
-                                                                Margin="0,0,0,4">
-                                                            <Grid ColumnDefinitions="*,Auto,Auto">
-                                                                <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
-                                                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                                                        <TextBlock Text="{Binding Name}"
-                                                                                   FontSize="14"
-                                                                                   FontWeight="SemiBold"
-                                                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
-                                                                        <Border Background="{DynamicResource PrimaryBrush}"
-                                                                                CornerRadius="4"
-                                                                                Padding="6,2"
-                                                                                IsVisible="{Binding IsDefault}"
-                                                                                VerticalAlignment="Center">
-                                                                            <TextBlock Text="{loc:Loc Default}"
-                                                                                       FontSize="11"
-                                                                                       Foreground="White" />
-                                                                        </Border>
-                                                                    </StackPanel>
-                                                                    <TextBlock Text="{Binding BaseTemplate}"
-                                                                               FontSize="12"
-                                                                               Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                                </StackPanel>
-                                                                <Button Grid.Column="1"
-                                                                        Classes="icon-button"
-                                                                        ToolTip.Tip="{loc:Loc Edit}"
-                                                                        Margin="8,0"
-                                                                        Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
-                                                                        CommandParameter="{Binding}">
-                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}"
-                                                                              Width="16" Height="16" />
-                                                                </Button>
-                                                                <Button Grid.Column="2"
-                                                                        Classes="icon-button"
-                                                                        ToolTip.Tip="{loc:Loc Delete}"
-                                                                        Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).OpenDeleteTemplateCommand}"
-                                                                        CommandParameter="{Binding}">
-                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}"
-                                                                              Width="16" Height="16"
-                                                                              Foreground="{DynamicResource ErrorBrush}" />
-                                                                </Button>
-                                                            </Grid>
-                                                        </Border>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
-                                        </StackPanel>
+                                                                <TextBlock Text="{Binding BaseTemplate}"
+                                                                           FontSize="12"
+                                                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                            </StackPanel>
+                                                            <Button Grid.Column="1"
+                                                                    Classes="icon-button"
+                                                                    ToolTip.Tip="{loc:Loc Edit}"
+                                                                    Margin="8,0"
+                                                                    Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
+                                                                    CommandParameter="{Binding}">
+                                                                <PathIcon Data="{x:Static icons:Icons.Edit}"
+                                                                          Width="16" Height="16" />
+                                                            </Button>
+                                                            <Button Grid.Column="2"
+                                                                    Classes="icon-button"
+                                                                    ToolTip.Tip="{loc:Loc Delete}"
+                                                                    Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).OpenDeleteTemplateCommand}"
+                                                                    CommandParameter="{Binding}">
+                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
+                                                                          Width="16" Height="16"
+                                                                          Foreground="{DynamicResource ErrorBrush}" />
+                                                            </Button>
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
                                     </StackPanel>
                                 </ScrollViewer>
 

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
@@ -17,6 +17,7 @@
 
     <UserControl.Resources>
         <local:EqualConverter x:Key="EqualConverter" />
+        <local:HexColorToBrushConverter x:Key="HexToBrush" />
     </UserControl.Resources>
 
     <UserControl.Styles>
@@ -45,6 +46,9 @@
         </Style>
         <Style Selector="Button.property-tab-button.selected /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="{DynamicResource PrimaryBrush}" />
+        </Style>
+        <Style Selector="Border.template-card:pointerover">
+            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
         </Style>
     </UserControl.Styles>
 
@@ -103,61 +107,119 @@
                               IsVisible="{Binding IsTemplateListMode}">
                             <Grid RowDefinitions="*,Auto">
                                 <ScrollViewer Grid.Row="0" Padding="24,16">
-                                    <StackPanel Spacing="8">
-                                        <ItemsControl ItemsSource="{Binding CustomTemplates}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border Padding="16,12"
-                                                            Background="{DynamicResource SurfaceAltBrush}"
-                                                            CornerRadius="8"
-                                                            BorderBrush="{DynamicResource BorderBrush}"
-                                                            BorderThickness="1"
-                                                            Margin="0,0,0,4">
-                                                        <Grid ColumnDefinitions="*,Auto,Auto">
-                                                            <StackPanel Grid.Column="0" VerticalAlignment="Center" Spacing="2">
-                                                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                                                    <TextBlock Text="{Binding Name}"
-                                                                               FontSize="14"
-                                                                               FontWeight="SemiBold"
-                                                                               Foreground="{DynamicResource TextPrimaryBrush}" />
-                                                                    <Border Background="{DynamicResource PrimaryBrush}"
-                                                                            CornerRadius="4"
-                                                                            Padding="6,2"
-                                                                            IsVisible="{Binding IsDefault}"
-                                                                            VerticalAlignment="Center">
-                                                                        <TextBlock Text="{loc:Loc Default}"
-                                                                                   FontSize="11"
-                                                                                   Foreground="White" />
-                                                                    </Border>
+                                    <ItemsControl ItemsSource="{Binding CustomTemplates}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel Orientation="Horizontal" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Width="220"
+                                                        Margin="0,0,16,16"
+                                                        Background="{DynamicResource SurfaceAltBrush}"
+                                                        CornerRadius="8"
+                                                        BorderBrush="{DynamicResource BorderBrush}"
+                                                        BorderThickness="1"
+                                                        Classes="template-card"
+                                                        Cursor="Hand"
+                                                        PointerPressed="OnTemplateCardPressed">
+                                                    <Border.ContextMenu>
+                                                        <ContextMenu>
+                                                            <MenuItem Header="{loc:Loc Edit}"
+                                                                      Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
+                                                                      CommandParameter="{Binding}">
+                                                                <MenuItem.Icon>
+                                                                    <PathIcon Data="{x:Static icons:Icons.Edit}" Width="14" Height="14" />
+                                                                </MenuItem.Icon>
+                                                            </MenuItem>
+                                                            <MenuItem Header="{loc:Loc Delete}"
+                                                                      Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).OpenDeleteTemplateCommand}"
+                                                                      CommandParameter="{Binding}">
+                                                                <MenuItem.Icon>
+                                                                    <PathIcon Data="{x:Static icons:Icons.Delete}" Width="14" Height="14"
+                                                                              Foreground="{DynamicResource ErrorBrush}" />
+                                                                </MenuItem.Icon>
+                                                            </MenuItem>
+                                                        </ContextMenu>
+                                                    </Border.ContextMenu>
+                                                    <Grid RowDefinitions="140,Auto">
+                                                        <!-- Mini Invoice Preview -->
+                                                        <Border Grid.Row="0"
+                                                                Background="{Binding BackgroundColor, Converter={StaticResource HexToBrush}}"
+                                                                CornerRadius="8,8,0,0"
+                                                                ClipToBounds="True"
+                                                                Padding="16,12">
+                                                            <Grid RowDefinitions="Auto,8,Auto,8,Auto,*">
+                                                                <!-- Header bar -->
+                                                                <Border Grid.Row="0"
+                                                                        Background="{Binding PrimaryColor, Converter={StaticResource HexToBrush}}"
+                                                                        CornerRadius="3"
+                                                                        Height="22"
+                                                                        HorizontalAlignment="Stretch">
+                                                                    <TextBlock Text="INVOICE"
+                                                                               FontSize="7"
+                                                                               FontWeight="Bold"
+                                                                               Foreground="White"
+                                                                               VerticalAlignment="Center"
+                                                                               Margin="8,0" />
+                                                                </Border>
+                                                                <!-- Address lines -->
+                                                                <StackPanel Grid.Row="2" Spacing="3">
+                                                                    <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
+                                                                            CornerRadius="2" Height="4" Width="80" HorizontalAlignment="Left" Opacity="0.6" />
+                                                                    <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
+                                                                            CornerRadius="2" Height="4" Width="60" HorizontalAlignment="Left" Opacity="0.6" />
                                                                 </StackPanel>
-                                                                <TextBlock Text="{Binding BaseTemplate}"
-                                                                           FontSize="12"
-                                                                           Foreground="{DynamicResource TextSecondaryBrush}" />
-                                                            </StackPanel>
-                                                            <Button Grid.Column="1"
-                                                                    Classes="icon-button"
-                                                                    ToolTip.Tip="{loc:Loc Edit}"
-                                                                    Margin="8,0"
-                                                                    Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).EditTemplateCommand}"
-                                                                    CommandParameter="{Binding}">
-                                                                <PathIcon Data="{x:Static icons:Icons.Edit}"
-                                                                          Width="16" Height="16" />
-                                                            </Button>
-                                                            <Button Grid.Column="2"
-                                                                    Classes="icon-button"
-                                                                    ToolTip.Tip="{loc:Loc Delete}"
-                                                                    Command="{Binding $parent[ItemsControl].((vm:InvoiceTemplateDesignerViewModel)DataContext).OpenDeleteTemplateCommand}"
-                                                                    CommandParameter="{Binding}">
-                                                                <PathIcon Data="{x:Static icons:Icons.Delete}"
-                                                                          Width="16" Height="16"
-                                                                          Foreground="{DynamicResource ErrorBrush}" />
-                                                            </Button>
-                                                        </Grid>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                    </StackPanel>
+                                                                <!-- Table header -->
+                                                                <Border Grid.Row="4"
+                                                                        Background="{Binding AccentColor, Converter={StaticResource HexToBrush}}"
+                                                                        CornerRadius="2"
+                                                                        Height="10"
+                                                                        Opacity="0.3"
+                                                                        HorizontalAlignment="Stretch" />
+                                                                <!-- Table rows -->
+                                                                <StackPanel Grid.Row="5" Spacing="4" Margin="0,4,0,0">
+                                                                    <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
+                                                                            CornerRadius="1" Height="6" HorizontalAlignment="Stretch" Opacity="0.3" />
+                                                                    <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
+                                                                            CornerRadius="1" Height="6" HorizontalAlignment="Stretch" Opacity="0.3" />
+                                                                    <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
+                                                                            CornerRadius="1" Height="6" HorizontalAlignment="Stretch" Opacity="0.3" />
+                                                                    <Border Background="{Binding PrimaryColor, Converter={StaticResource HexToBrush}}"
+                                                                            CornerRadius="1" Height="6" Width="50" HorizontalAlignment="Right" Opacity="0.7" />
+                                                                </StackPanel>
+                                                            </Grid>
+                                                        </Border>
+                                                        <!-- Card Info -->
+                                                        <StackPanel Grid.Row="1" Margin="12,10,12,12" Spacing="4">
+                                                            <Grid ColumnDefinitions="*,Auto">
+                                                                <TextBlock Grid.Column="0"
+                                                                           Text="{Binding Name}"
+                                                                           FontSize="13"
+                                                                           FontWeight="SemiBold"
+                                                                           Foreground="{DynamicResource TextPrimaryBrush}"
+                                                                           TextTrimming="CharacterEllipsis" />
+                                                                <Border Grid.Column="1"
+                                                                        Background="{DynamicResource PrimaryBrush}"
+                                                                        CornerRadius="4"
+                                                                        Padding="6,2"
+                                                                        IsVisible="{Binding IsDefault}"
+                                                                        VerticalAlignment="Center">
+                                                                    <TextBlock Text="{loc:Loc Default}"
+                                                                               FontSize="10"
+                                                                               Foreground="White" />
+                                                                </Border>
+                                                            </Grid>
+                                                            <TextBlock Text="{Binding BaseTemplate}"
+                                                                       FontSize="11"
+                                                                       Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                        </StackPanel>
+                                                    </Grid>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
                                 </ScrollViewer>
 
                                 <!-- Delete Confirmation -->

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml
@@ -18,6 +18,7 @@
     <UserControl.Resources>
         <local:EqualConverter x:Key="EqualConverter" />
         <local:HexColorToBrushConverter x:Key="HexToBrush" />
+        <local:Base64ToImageConverter x:Key="Base64ToImage" />
     </UserControl.Resources>
 
     <UserControl.Styles>
@@ -143,15 +144,25 @@
                                                             </MenuItem>
                                                         </ContextMenu>
                                                     </Border.ContextMenu>
-                                                    <Grid RowDefinitions="140,Auto">
-                                                        <!-- Mini Invoice Preview -->
+                                                    <Grid RowDefinitions="160,Auto">
+                                                        <!-- Thumbnail Preview -->
+                                                        <Border Grid.Row="0"
+                                                                Background="{DynamicResource SurfaceBrush}"
+                                                                CornerRadius="8,8,0,0"
+                                                                ClipToBounds="True">
+                                                            <!-- Saved thumbnail screenshot -->
+                                                            <Image Source="{Binding ThumbnailBase64, Converter={StaticResource Base64ToImage}}"
+                                                                   Stretch="UniformToFill"
+                                                                   VerticalAlignment="Top" />
+                                                        </Border>
+                                                        <!-- Color fallback when no thumbnail -->
                                                         <Border Grid.Row="0"
                                                                 Background="{Binding BackgroundColor, Converter={StaticResource HexToBrush}}"
                                                                 CornerRadius="8,8,0,0"
                                                                 ClipToBounds="True"
-                                                                Padding="16,12">
+                                                                Padding="16,12"
+                                                                IsVisible="{Binding ThumbnailBase64, Converter={x:Static StringConverters.IsNullOrEmpty}}">
                                                             <Grid RowDefinitions="Auto,8,Auto,8,Auto,*">
-                                                                <!-- Header bar -->
                                                                 <Border Grid.Row="0"
                                                                         Background="{Binding PrimaryColor, Converter={StaticResource HexToBrush}}"
                                                                         CornerRadius="3"
@@ -164,24 +175,16 @@
                                                                                VerticalAlignment="Center"
                                                                                Margin="8,0" />
                                                                 </Border>
-                                                                <!-- Address lines -->
                                                                 <StackPanel Grid.Row="2" Spacing="3">
                                                                     <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
                                                                             CornerRadius="2" Height="4" Width="80" HorizontalAlignment="Left" Opacity="0.6" />
                                                                     <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
                                                                             CornerRadius="2" Height="4" Width="60" HorizontalAlignment="Left" Opacity="0.6" />
                                                                 </StackPanel>
-                                                                <!-- Table header -->
                                                                 <Border Grid.Row="4"
                                                                         Background="{Binding AccentColor, Converter={StaticResource HexToBrush}}"
-                                                                        CornerRadius="2"
-                                                                        Height="10"
-                                                                        Opacity="0.3"
-                                                                        HorizontalAlignment="Stretch" />
-                                                                <!-- Table rows -->
+                                                                        CornerRadius="2" Height="10" Opacity="0.3" HorizontalAlignment="Stretch" />
                                                                 <StackPanel Grid.Row="5" Spacing="4" Margin="0,4,0,0">
-                                                                    <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
-                                                                            CornerRadius="1" Height="6" HorizontalAlignment="Stretch" Opacity="0.3" />
                                                                     <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
                                                                             CornerRadius="1" Height="6" HorizontalAlignment="Stretch" Opacity="0.3" />
                                                                     <Border Background="{Binding SecondaryColor, Converter={StaticResource HexToBrush}}"
@@ -557,7 +560,8 @@
                                 <!-- Preview container using InvoicePreviewControl -->
                                 <!-- IsVisible bound to IsPreviewVisible so WebView is destroyed when modal
                                      closes or when confirmation dialog appears (native WebView airspace issue) -->
-                                <controls:InvoicePreviewControl Grid.Row="1"
+                                <controls:InvoicePreviewControl x:Name="PreviewControl"
+                                                                Grid.Row="1"
                                                                 Grid.RowSpan="2"
                                                                 Html="{Binding PreviewHtml}"
                                                                 OpenInBrowserCommand="{Binding PreviewInBrowserCommand}"
@@ -571,23 +575,32 @@
                                 BorderBrush="{DynamicResource BorderBrush}"
                                 BorderThickness="0,1,0,0"
                                 IsVisible="{Binding !IsTemplateListMode}">
-                            <Grid ColumnDefinitions="Auto,Auto,*,Auto">
-                                <!-- Fullscreen toggle -->
+                            <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto">
+                                <!-- Back to template list -->
                                 <Button Grid.Column="0"
                                         Classes="icon-button"
+                                        ToolTip.Tip="{loc:Loc 'Back to Templates'}"
+                                        Command="{Binding BackToTemplateListCommand}">
+                                    <PathIcon Data="{x:Static icons:Icons.ArrowBack}"
+                                              Width="16" Height="16" />
+                                </Button>
+                                <!-- Fullscreen toggle -->
+                                <Button Grid.Column="1"
+                                        Classes="icon-button"
                                         ToolTip.Tip="{loc:Loc 'Toggle Fullscreen (F)'}"
+                                        Margin="4,0,0,0"
                                         Command="{Binding ToggleFullscreenCommand}">
                                     <PathIcon Data="{Binding IsFullscreen, Converter={x:Static local:BoolConverters.ToFullscreenIcon}}"
                                               Width="16" Height="16" />
                                 </Button>
-                                <TextBlock Grid.Column="1"
+                                <TextBlock Grid.Column="2"
                                            Text="{Binding ValidationMessage}"
                                            Foreground="{DynamicResource ErrorBrush}"
                                            FontSize="13"
                                            Margin="12,0,0,0"
                                            VerticalAlignment="Center"
                                            IsVisible="{Binding HasValidationMessage}" />
-                                <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="12">
+                                <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="12">
                                     <Button Classes="secondary-button"
                                             Content="{loc:Loc Cancel}"
                                             Command="{Binding RequestCloseCommand}" />

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml.cs
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml.cs
@@ -1,7 +1,9 @@
+using ArgoBooks.Controls;
 using ArgoBooks.Core.Models.Invoices;
 using ArgoBooks.ViewModels;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace ArgoBooks.Modals;
 
@@ -14,6 +16,20 @@ public partial class InvoiceTemplateDesignerModal : UserControl
     public InvoiceTemplateDesignerModal()
     {
         InitializeComponent();
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+
+        if (DataContext is InvoiceTemplateDesignerViewModel vm)
+        {
+            var previewControl = this.FindControl<InvoicePreviewControl>("PreviewControl");
+            if (previewControl != null)
+            {
+                vm.CapturePreviewFunc = previewControl.CaptureScreenshotBase64Async;
+            }
+        }
     }
 
     private void OnTemplateCardPressed(object? sender, PointerPressedEventArgs e)

--- a/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml.cs
+++ b/ArgoBooks/Modals/InvoiceTemplateDesignerModal.axaml.cs
@@ -1,4 +1,7 @@
+using ArgoBooks.Core.Models.Invoices;
+using ArgoBooks.ViewModels;
 using Avalonia.Controls;
+using Avalonia.Input;
 
 namespace ArgoBooks.Modals;
 
@@ -11,5 +14,17 @@ public partial class InvoiceTemplateDesignerModal : UserControl
     public InvoiceTemplateDesignerModal()
     {
         InitializeComponent();
+    }
+
+    private void OnTemplateCardPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
+            return;
+
+        if (sender is Border { DataContext: InvoiceTemplate template }
+            && DataContext is InvoiceTemplateDesignerViewModel vm)
+        {
+            vm.EditTemplateCommand.Execute(template);
+        }
     }
 }

--- a/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
@@ -564,16 +564,30 @@ public partial class InvoiceModalsViewModel : ViewModelBase
         TemplateOptions.Clear();
 
         var companyData = App.CompanyManager?.CompanyData;
-        if (companyData?.InvoiceTemplates == null || companyData.InvoiceTemplates.Count == 0)
+        if (companyData == null) return;
+
+        // Ensure default templates are always present
+        if (companyData.InvoiceTemplates.Count == 0)
         {
-            // Create default templates if none exist
             var defaultTemplates = InvoiceTemplateFactory.CreateDefaultTemplates();
             foreach (var template in defaultTemplates)
             {
-                TemplateOptions.Add(template);
+                companyData.InvoiceTemplates.Add(template);
             }
-            SelectedTemplate = TemplateOptions.FirstOrDefault(t => t.IsDefault) ?? TemplateOptions.FirstOrDefault();
-            return;
+            App.CompanyManager?.MarkAsChanged();
+        }
+        else
+        {
+            // Ensure base templates haven't been lost (e.g. only custom templates exist)
+            var defaultTemplates = InvoiceTemplateFactory.CreateDefaultTemplates();
+            foreach (var defaultTemplate in defaultTemplates)
+            {
+                if (companyData.InvoiceTemplates.All(t => t.Id != defaultTemplate.Id))
+                {
+                    companyData.InvoiceTemplates.Add(defaultTemplate);
+                    App.CompanyManager?.MarkAsChanged();
+                }
+            }
         }
 
         foreach (var template in companyData.InvoiceTemplates.OrderBy(t => t.Name))

--- a/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
@@ -35,6 +35,15 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
     private bool _isEditMode;
 
     [ObservableProperty]
+    private bool _isTemplateListMode;
+
+    [ObservableProperty]
+    private string _templateToDelete = string.Empty;
+
+    [ObservableProperty]
+    private bool _isDeleteConfirmOpen;
+
+    [ObservableProperty]
     private string _modalTitle = "Create Invoice Template";
 
     [ObservableProperty]
@@ -286,6 +295,8 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
 
     #region Collections
 
+    public ObservableCollection<InvoiceTemplate> SavedTemplates { get; } = [];
+
     public ObservableCollection<InvoiceTemplateType> BaseTemplateOptions { get; } =
     [
         InvoiceTemplateType.Professional,
@@ -304,6 +315,87 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
         "system-ui, -apple-system, sans-serif",
         "'Courier New', Courier, monospace"
     ];
+
+    #endregion
+
+    #region Template List
+
+    public void OpenTemplateList()
+    {
+        LoadSavedTemplates();
+        IsTemplateListMode = true;
+        IsDeleteConfirmOpen = false;
+        ModalTitle = "Invoice Templates".Translate();
+        IsOpen = true;
+        IsPreviewVisible = false;
+    }
+
+    private void LoadSavedTemplates()
+    {
+        SavedTemplates.Clear();
+        var companyData = App.CompanyManager?.CompanyData;
+        if (companyData == null) return;
+
+        foreach (var template in companyData.InvoiceTemplates.OrderBy(t => t.Name))
+        {
+            SavedTemplates.Add(template);
+        }
+    }
+
+    [RelayCommand]
+    private void EditTemplate(InvoiceTemplate? template)
+    {
+        if (template == null) return;
+        IsTemplateListMode = false;
+        OpenEditModal(template);
+    }
+
+    [RelayCommand]
+    private void OpenDeleteTemplate(InvoiceTemplate? template)
+    {
+        if (template == null) return;
+        TemplateToDelete = template.Id;
+        IsDeleteConfirmOpen = true;
+    }
+
+    [RelayCommand]
+    private void CloseDeleteConfirm()
+    {
+        IsDeleteConfirmOpen = false;
+        TemplateToDelete = string.Empty;
+    }
+
+    [RelayCommand]
+    private void ConfirmDeleteTemplate()
+    {
+        if (string.IsNullOrEmpty(TemplateToDelete)) return;
+
+        var companyData = App.CompanyManager?.CompanyData;
+        var template = companyData?.InvoiceTemplates.FirstOrDefault(t => t.Id == TemplateToDelete);
+        if (template != null)
+        {
+            companyData!.InvoiceTemplates.Remove(template);
+            App.CompanyManager?.MarkAsChanged();
+            LoadSavedTemplates();
+        }
+
+        IsDeleteConfirmOpen = false;
+        TemplateToDelete = string.Empty;
+    }
+
+    [RelayCommand]
+    private void CreateNewFromList()
+    {
+        IsTemplateListMode = false;
+        _suppressUndoRecording = true;
+        ResetForm();
+        _suppressUndoRecording = false;
+        _undoRedoManager.Clear();
+        IsEditMode = false;
+        ModalTitle = "Create Invoice Template".Translate();
+        UpdatePreview();
+        IsPreviewVisible = true;
+    }
 
     #endregion
 
@@ -329,6 +421,7 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
         _suppressUndoRecording = false;
         _undoRedoManager.Clear();
         IsEditMode = true;
+        IsTemplateListMode = false;
         ModalTitle = $"Edit Template: {template.Name}".Translate();
         UpdatePreview();
         IsOpen = true;
@@ -369,6 +462,8 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
     private void Close()
     {
         IsPreviewVisible = false;
+        IsTemplateListMode = false;
+        IsDeleteConfirmOpen = false;
         IsOpen = false;
         IsFullscreen = false;
         ModalClosed?.Invoke(this, EventArgs.Empty);

--- a/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
@@ -295,7 +295,8 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
 
     #region Collections
 
-    public ObservableCollection<InvoiceTemplate> SavedTemplates { get; } = [];
+    public ObservableCollection<InvoiceTemplate> DefaultTemplates { get; } = [];
+    public ObservableCollection<InvoiceTemplate> CustomTemplates { get; } = [];
 
     public ObservableCollection<InvoiceTemplateType> BaseTemplateOptions { get; } =
     [
@@ -332,13 +333,17 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
 
     private void LoadSavedTemplates()
     {
-        SavedTemplates.Clear();
+        DefaultTemplates.Clear();
+        CustomTemplates.Clear();
         var companyData = App.CompanyManager?.CompanyData;
         if (companyData == null) return;
 
         foreach (var template in companyData.InvoiceTemplates.OrderBy(t => t.Name))
         {
-            SavedTemplates.Add(template);
+            if (template.Id.StartsWith("default-"))
+                DefaultTemplates.Add(template);
+            else
+                CustomTemplates.Add(template);
         }
     }
 

--- a/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
@@ -21,6 +21,11 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
     public event EventHandler? ModalClosed;
     public event EventHandler? BrowseLogoRequested;
 
+    /// <summary>
+    /// Function to capture a screenshot of the current preview. Set by the view.
+    /// </summary>
+    public Func<Task<string?>>? CapturePreviewFunc { get; set; }
+
     #endregion
 
     #region Modal State
@@ -478,7 +483,7 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void Save()
+    private async Task Save()
     {
         // Validation
         if (string.IsNullOrWhiteSpace(TemplateName))
@@ -491,6 +496,27 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
         var companyData = App.CompanyManager?.CompanyData;
         if (companyData == null) return;
 
+        // Check for duplicate name (exclude the template being edited)
+        var duplicateName = companyData.InvoiceTemplates
+            .Where(t => !t.Id.StartsWith("default-"))
+            .Any(t => t.Id != _editingTemplateId
+                       && string.Equals(t.Name, TemplateName.Trim(), StringComparison.OrdinalIgnoreCase));
+
+        if (duplicateName)
+        {
+            ValidationMessage = "A template with this name already exists. Please choose a different name.".Translate();
+            HasValidationMessage = true;
+            return;
+        }
+
+        // Capture thumbnail from the live preview before saving
+        string? thumbnail = null;
+        if (CapturePreviewFunc != null)
+        {
+            try { thumbnail = await CapturePreviewFunc(); }
+            catch { /* Ignore capture failures */ }
+        }
+
         if (IsEditMode)
         {
             // Update existing template
@@ -498,6 +524,7 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
             if (template != null)
             {
                 UpdateTemplateFromForm(template);
+                if (thumbnail != null) template.ThumbnailBase64 = thumbnail;
 
                 // If this is being set as default, unset others
                 if (template.IsDefault)
@@ -516,6 +543,7 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
             var template = new InvoiceTemplate { Id = id };
             UpdateTemplateFromForm(template);
             template.CreatedAt = DateTime.UtcNow;
+            if (thumbnail != null) template.ThumbnailBase64 = thumbnail;
 
             // If this is being set as default or is the first template, handle defaults
             if (template.IsDefault || companyData.InvoiceTemplates.Count == 0)
@@ -533,7 +561,23 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
         App.CompanyManager?.MarkAsChanged();
         _undoRedoManager.MarkSaved();
         TemplateSaved?.Invoke(this, EventArgs.Empty);
-        Close();
+        OpenTemplateList();
+    }
+
+    [RelayCommand]
+    private async Task BackToTemplateList()
+    {
+        if (HasUnsavedChanges)
+        {
+            IsPreviewVisible = false;
+            if (!await ConfirmDiscardEditsAsync())
+            {
+                IsPreviewVisible = true;
+                return;
+            }
+        }
+
+        OpenTemplateList();
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceTemplateDesignerViewModel.cs
@@ -295,7 +295,6 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
 
     #region Collections
 
-    public ObservableCollection<InvoiceTemplate> DefaultTemplates { get; } = [];
     public ObservableCollection<InvoiceTemplate> CustomTemplates { get; } = [];
 
     public ObservableCollection<InvoiceTemplateType> BaseTemplateOptions { get; } =
@@ -333,17 +332,15 @@ public partial class InvoiceTemplateDesignerViewModel : ViewModelBase
 
     private void LoadSavedTemplates()
     {
-        DefaultTemplates.Clear();
         CustomTemplates.Clear();
         var companyData = App.CompanyManager?.CompanyData;
         if (companyData == null) return;
 
-        foreach (var template in companyData.InvoiceTemplates.OrderBy(t => t.Name))
+        foreach (var template in companyData.InvoiceTemplates
+                     .Where(t => !t.Id.StartsWith("default-"))
+                     .OrderBy(t => t.Name))
         {
-            if (template.Id.StartsWith("default-"))
-                DefaultTemplates.Add(template);
-            else
-                CustomTemplates.Add(template);
+            CustomTemplates.Add(template);
         }
     }
 

--- a/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
@@ -792,7 +792,7 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
     [RelayCommand]
     private void OpenTemplateDesigner()
     {
-        App.InvoiceTemplateDesignerViewModel?.OpenCreateModal();
+        App.InvoiceTemplateDesignerViewModel?.OpenTemplateList();
     }
 
     #endregion


### PR DESCRIPTION
## Summary
This PR adds a comprehensive template management interface to the invoice template designer, allowing users to view, edit, and delete custom invoice templates. Templates now include thumbnail previews captured from the live preview, and the designer modal has been restructured to support both creation/editing and template list modes.

## Key Changes

- **Template List Mode**: Added `IsTemplateListMode` property to switch between template editing and template management views
- **Template Thumbnails**: 
  - Added `ThumbnailBase64` property to `InvoiceTemplate` model to store PNG screenshots
  - Implemented `CaptureScreenshotBase64Async()` in `InvoicePreviewControl` to capture WebView2 content as base64-encoded PNG
  - Created `Base64ToImageConverter` to display thumbnails in the template list
- **Template Management Commands**:
  - `EditTemplate`: Opens a template for editing
  - `OpenDeleteTemplate` / `ConfirmDeleteTemplate`: Delete templates with confirmation dialog
  - `CreateNewFromList`: Create new template from the list view
  - `BackToTemplateList`: Return to list view with unsaved changes detection
- **Template List UI**: 
  - Grid-based card layout showing template previews with color swatches as fallback
  - Context menu for edit/delete operations
  - Delete confirmation modal with overlay
  - "Create New" button in footer
  - Displays template name, base template type, and default badge
- **Duplicate Name Validation**: Added check to prevent templates with duplicate names
- **Color Conversion**: Created `HexColorToBrushConverter` to convert hex color strings to brushes for preview rendering
- **Modal Flow**: After saving, users are returned to the template list instead of closing the modal
- **Default Template Handling**: Improved logic to ensure default templates are always available in company data

## Implementation Details

- Template thumbnails are captured automatically when saving, providing visual previews without manual configuration
- The template list loads custom templates (excluding default templates) sorted by name
- Unsaved changes are detected when navigating back to the list, with user confirmation
- The preview control's screenshot function is injected into the ViewModel via `CapturePreviewFunc` delegate
- Template card selection uses pointer events to distinguish between left-click (edit) and right-click (context menu)
- Removed unused icon constants from `Icons.cs` (Logout, Send, Email, BarChartAlt, LineChart, Robot, Volume, Table)

https://claude.ai/code/session_01NeuiZz3RLQtR6R8Px2efkd