### PR TITLE
Fix right pagination arrow disabled on initial load

### DIFF
--- a/ArgoBooks/Controls/ArgoTable/ArgoTable.axaml.cs
+++ b/ArgoBooks/Controls/ArgoTable/ArgoTable.axaml.cs
@@ -540,6 +540,8 @@ public partial class ArgoTable : UserControl, INotifyPropertyChanged
         else if (change.Property == TotalPagesProperty)
         {
             RaisePropertyChanged(nameof(ShowPageNumbers));
+            RaisePropertyChanged(nameof(CanGoToPreviousPage));
+            RaisePropertyChanged(nameof(CanGoToNextPage));
             UpdatePageNumbers();
         }
         else if (change.Property == CurrentPageProperty)

--- a/ArgoBooks/ViewModels/SortablePageViewModelBase.cs
+++ b/ArgoBooks/ViewModels/SortablePageViewModelBase.cs
@@ -122,11 +122,6 @@ public abstract partial class SortablePageViewModelBase : ViewModelBase
     /// </summary>
     public bool CanGoToNextPage => CurrentPage < TotalPages;
 
-    partial void OnTotalPagesChanged(int value)
-    {
-        NotifyPaginationChanged();
-    }
-
     partial void OnCurrentPageChanged(int value)
     {
         NotifyPaginationChanged();

--- a/ArgoBooks/ViewModels/SortablePageViewModelBase.cs
+++ b/ArgoBooks/ViewModels/SortablePageViewModelBase.cs
@@ -122,6 +122,11 @@ public abstract partial class SortablePageViewModelBase : ViewModelBase
     /// </summary>
     public bool CanGoToNextPage => CurrentPage < TotalPages;
 
+    partial void OnTotalPagesChanged(int value)
+    {
+        NotifyPaginationChanged();
+    }
+
     partial void OnCurrentPageChanged(int value)
     {
         NotifyPaginationChanged();


### PR DESCRIPTION
## Summary

- Fix the right (next page) pagination arrow being disabled when the page first loads, even when there are multiple pages
- Add `OnTotalPagesChanged` partial method in `SortablePageViewModelBase` to call `NotifyPaginationChanged()` when `TotalPages` updates

## Root Cause

`CanGoToNextPage` is a computed property (`CurrentPage < TotalPages`), but `NotifyPaginationChanged()` was only called from `OnCurrentPageChanged` and `OnPageSizeChanged`. When data loaded and set `TotalPages` (e.g., to 5), no property change notification was raised for `CanGoToNextPage`, so the UI kept the arrow disabled. Clicking a page number would trigger `OnCurrentPageChanged` → `NotifyPaginationChanged()`, which is why the arrow became enabled after interaction.