### PR TITLE
Fix desaturated confidence badge colors in import dialog

### DIFF
--- a/ArgoBooks/Converters/Converters.cs
+++ b/ArgoBooks/Converters/Converters.cs
@@ -37,8 +37,8 @@ public static class Converters
     public static readonly IValueConverter ConfidenceLevelToColor =
         new FuncValueConverter<string, Color>(level => level switch
         {
-            "High" => Color.Parse(AppColors.SuccessText),
-            "Medium" => Color.Parse(AppColors.WarningText),
+            "High" => Color.Parse(AppColors.SuccessDark),
+            "Medium" => Color.Parse(AppColors.WarningDark),
             "Low" => Color.Parse(AppColors.Error),
             _ => Color.Parse(AppColors.GrayText)
         });

--- a/ArgoBooks/Modals/ImportMappingDialog.axaml
+++ b/ArgoBooks/Modals/ImportMappingDialog.axaml
@@ -273,7 +273,7 @@
                                                                 Margin="0,0,8,0"
                                                                 VerticalAlignment="Center">
                                                             <Border.Background>
-                                                                <SolidColorBrush Color="{Binding ConfidenceLevel, Converter={x:Static converters:Converters.ConfidenceLevelToColor}}" Opacity="0.12" />
+                                                                <SolidColorBrush Color="{Binding ConfidenceLevel, Converter={x:Static converters:Converters.ConfidenceLevelToColor}}" Opacity="0.15" />
                                                             </Border.Background>
                                                             <TextBlock Text="{Binding ConfidenceDisplay}"
                                                                        FontSize="11"
@@ -366,7 +366,7 @@
                                                                                 HorizontalAlignment="Right"
                                                                                 VerticalAlignment="Center">
                                                                             <Border.Background>
-                                                                                <SolidColorBrush Color="{Binding ConfidenceLevel, Converter={x:Static converters:Converters.ConfidenceLevelToColor}}" Opacity="0.12" />
+                                                                                <SolidColorBrush Color="{Binding ConfidenceLevel, Converter={x:Static converters:Converters.ConfidenceLevelToColor}}" Opacity="0.15" />
                                                                             </Border.Background>
                                                                             <TextBlock Text="{Binding ConfidenceDisplay}"
                                                                                        FontSize="10"


### PR DESCRIPTION
## Summary
- Replaced `SuccessText` (#166534) and `WarningText` (#92400E) with `SuccessDark` (#16A34A) and `WarningDark` (#D97706) for confidence badge colors in the AI Import Analysis dialog
- Bumped badge background opacity from 0.12 to 0.15 for better contrast
- Affects both light and dark themes since the converter uses hardcoded colors (not theme-aware)

## Problem
The "Match: XX%" confidence badges and "Direct Mapping" tier badges used very dark, desaturated colors (`SuccessText` and `WarningText`) that were originally designed for text-on-colored-backgrounds, not for standalone badge display. This made the green and amber badges look dull and washed out, especially on light theme.

## Test plan
- [ ] Verify confidence badges ("Match: 98%", "Match: 85%") show vibrant green/amber colors in light theme
- [ ] Verify badges look good in dark theme as well
- [ ] Verify low-confidence badges (red) are unaffected

https://claude.ai/code/session_01UopS2UA43bgf4ty6oXXbWU