### PR TITLE
Fix Insights page premium upsell modal shown for premium users

### DIFF
--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -4227,7 +4227,12 @@ public class App : Application
             }
             return new AnalyticsPage { DataContext = _analyticsPageViewModel };
         });
-        navigationService.RegisterPage("Insights", _ => new InsightsPage { DataContext = _insightsPageViewModel ??= new InsightsPageViewModel() });
+        navigationService.RegisterPage("Insights", _ =>
+        {
+            _insightsPageViewModel ??= new InsightsPageViewModel();
+            _insightsPageViewModel.HasPremium = _appShellViewModel?.SidebarViewModel.HasPremium ?? false;
+            return new InsightsPage { DataContext = _insightsPageViewModel };
+        });
         navigationService.RegisterPage("Reports", _ => new ReportsPage { DataContext = _reportsPageViewModel ??= new ReportsPageViewModel() });
 
         // Transactions Section

--- a/ArgoBooks/ViewModels/AppShellViewModel.cs
+++ b/ArgoBooks/ViewModels/AppShellViewModel.cs
@@ -812,6 +812,9 @@ public partial class AppShellViewModel : ViewModelBase
         UserPanelViewModel.HasPremium = hasPremium;
         if (App.InvoiceModalsViewModel != null)
             App.InvoiceModalsViewModel.HasPremium = hasPremium;
+
+        // Notify lazily-created page ViewModels (e.g., InsightsPageViewModel)
+        App.RaisePlanStatusChanged(hasPremium);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Two bugs causing the "Unlock Predictive Analytics" modal to incorrectly appear for premium users:

- **Bug 1 — Modal shown on navigation:** The Insights page registration in `App.axaml.cs` was the only page that did not set `HasPremium` on its ViewModel during navigation. Since the ViewModel is created lazily, `HasPremium` defaulted to `false` and the `PlanStatusChanged` event had already fired before the ViewModel existed.
- **Bug 2 — Modal not dismissed on mid-session upgrade:** `SetPremiumStatus()` (called after license key activation) did not raise `PlanStatusChanged`, unlike `SetPlanStatus()` (called on startup). So upgrading while on the Insights page never notified the ViewModel.

## Test plan

- [ ] Open app with a premium license and navigate to the Insights page — the modal should NOT appear
- [ ] Upgrade to premium while on the Insights page — the modal should dismiss immediately
- [ ] Open app without premium and navigate to Insights — the modal should still appear
- [ ] Downgrade/invalidate license while on Insights — the modal should appear

https://claude.ai/code/session_01Rpf1RThnozkM8UYcJd27NU