### PR TITLE
Enable AI receipt scanning for all users with usage limits

### DIFF
--- a/ArgoBooks.Core/Services/AzureReceiptScannerService.cs
+++ b/ArgoBooks.Core/Services/AzureReceiptScannerService.cs
@@ -29,7 +29,7 @@ public class AzureReceiptScannerService : IReceiptScannerService
     }
 
     /// <inheritdoc />
-    public bool IsConfigured => _licenseService?.GetLicenseKey() != null;
+    public bool IsConfigured => _licenseService?.GetLicenseKey() != null || _licenseService?.GetDeviceId() != null;
 
     /// <inheritdoc />
     public async Task<ReceiptScanResult> ScanReceiptAsync(byte[] imageData, string fileName, CancellationToken cancellationToken = default)
@@ -40,9 +40,10 @@ public class AzureReceiptScannerService : IReceiptScannerService
         try
         {
             var licenseKey = _licenseService?.GetLicenseKey();
-            if (string.IsNullOrEmpty(licenseKey))
+            var deviceId = _licenseService?.GetDeviceId();
+            if (string.IsNullOrEmpty(licenseKey) && string.IsNullOrEmpty(deviceId))
             {
-                return ReceiptScanResult.Failed("No active license key found. Please activate your premium subscription.");
+                return ReceiptScanResult.Failed("No active license key or device ID found.");
             }
 
             // Validate file size (4MB limit)
@@ -67,8 +68,15 @@ public class AzureReceiptScannerService : IReceiptScannerService
 
             using var request = new HttpRequestMessage(HttpMethod.Post, ScanEndpoint);
             request.Content = content;
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", licenseKey);
-            request.Headers.Add("X-License-Key", licenseKey);
+            if (!string.IsNullOrEmpty(licenseKey))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", licenseKey);
+                request.Headers.Add("X-License-Key", licenseKey);
+            }
+            if (!string.IsNullOrEmpty(deviceId))
+            {
+                request.Headers.Add("X-Device-Id", deviceId);
+            }
 
             var response = await _httpClient.SendAsync(request, cancellationToken);
 

--- a/ArgoBooks.Core/Services/ReceiptUsageService.cs
+++ b/ArgoBooks.Core/Services/ReceiptUsageService.cs
@@ -44,13 +44,14 @@ public class ReceiptUsageService : IReceiptUsageService
     /// <inheritdoc />
     public async Task<UsageCheckResult> CheckUsageAsync(CancellationToken cancellationToken = default)
     {
-        var licenseKey = _licenseService?.GetLicenseKey();
-        if (string.IsNullOrEmpty(licenseKey))
+        var licenseKey = _licenseService?.GetLicenseKey() ?? "";
+        var deviceId = _licenseService?.GetDeviceId() ?? "";
+        if (string.IsNullOrEmpty(licenseKey) && string.IsNullOrEmpty(deviceId))
         {
             return new UsageCheckResult
             {
                 CanScan = false,
-                ErrorMessage = "No license key found. Please activate your license.",
+                ErrorMessage = "No license key or device ID found.",
                 ScanCount = 0,
                 MonthlyLimit = 0,
                 Remaining = 0
@@ -164,13 +165,14 @@ public class ReceiptUsageService : IReceiptUsageService
     /// <inheritdoc />
     public async Task<UsageIncrementResult> IncrementUsageAsync(CancellationToken cancellationToken = default)
     {
-        var licenseKey = _licenseService?.GetLicenseKey();
-        if (string.IsNullOrEmpty(licenseKey))
+        var licenseKey = _licenseService?.GetLicenseKey() ?? "";
+        var deviceId = _licenseService?.GetDeviceId() ?? "";
+        if (string.IsNullOrEmpty(licenseKey) && string.IsNullOrEmpty(deviceId))
         {
             return new UsageIncrementResult
             {
                 Success = false,
-                ErrorMessage = "No license key found"
+                ErrorMessage = "No license key or device ID found"
             };
         }
 
@@ -273,9 +275,11 @@ public class ReceiptUsageService : IReceiptUsageService
 
     private async Task<UsageApiResponse> CallApiAsync(string action, string licenseKey, CancellationToken cancellationToken)
     {
+        var deviceId = _licenseService?.GetDeviceId() ?? "";
         var requestBody = new
         {
             license_key = licenseKey,
+            device_id = deviceId,
             action
         };
 

--- a/ArgoBooks/Modals/ReceiptsModals.axaml
+++ b/ArgoBooks/Modals/ReceiptsModals.axaml
@@ -838,8 +838,15 @@
                             BorderBrush="{DynamicResource BorderBrush}"
                             BorderThickness="0,1,0,0"
                             IsVisible="{Binding HasScanResult}">
-                        <Grid ColumnDefinitions="*,Auto,Auto">
-                            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
+                        <Grid ColumnDefinitions="Auto,*,Auto,Auto">
+                            <TextBlock Grid.Column="0"
+                                       Text="{loc:Loc 'Please enter all required fields'}"
+                                       Foreground="{DynamicResource ErrorBrush}"
+                                       FontSize="13"
+                                       VerticalAlignment="Center"
+                                       IsVisible="{Binding HasValidationMessage}" />
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8"
+                                        IsVisible="{Binding !HasValidationMessage}">
                                 <PathIcon Data="{x:Static icons:Icons.Info}"
                                           Width="16" Height="16"
                                           Foreground="{DynamicResource TextTertiaryBrush}" />
@@ -848,12 +855,12 @@
                                            Foreground="{DynamicResource TextTertiaryBrush}"
                                            VerticalAlignment="Center" />
                             </StackPanel>
-                            <Button Grid.Column="1"
+                            <Button Grid.Column="2"
                                     Content="{loc:Loc Cancel}"
                                     Classes="secondary-button"
                                     Margin="0,0,12,0"
                                     Command="{Binding RequestCloseScanReviewModalCommand}" />
-                            <Button Grid.Column="2"
+                            <Button Grid.Column="3"
                                     Classes="primary-button"
                                     Command="{Binding CreateTransactionCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -1267,10 +1267,12 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
     }
 
     [RelayCommand]
-    private void ScanReceipt()
+    private async Task ScanReceipt()
     {
+        if (App.ReceiptsModalsViewModel == null) return;
+        if (!await App.ReceiptsModalsViewModel.CanScanOrShowLimitAsync()) return;
+
         App.NavigationService?.NavigateTo("Receipts");
-        // Note: Scan modal requires a file path, so just navigate to receipts page
     }
 
     [RelayCommand]

--- a/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
@@ -507,7 +507,7 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
                 {
                     ScansUsed = incrementResult.ScanCount;
                     ScansRemaining = incrementResult.Remaining;
-                    IsNearLimit = incrementResult.Remaining <= 50 && incrementResult.Remaining > 0;
+                    IsNearLimit = incrementResult.MonthlyLimit > 0 && incrementResult.Remaining > 0 && incrementResult.Remaining <= incrementResult.MonthlyLimit / 10;
                 }
             }
 
@@ -533,7 +533,7 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
         ScansRemaining = usageCheck.Remaining;
         UsageTier = usageCheck.Tier;
         ResetsAt = usageCheck.ResetsAt;
-        IsNearLimit = usageCheck.Remaining <= 50 && usageCheck.Remaining > 0;
+        IsNearLimit = usageCheck.MonthlyLimit > 0 && usageCheck.Remaining > 0 && usageCheck.Remaining <= usageCheck.MonthlyLimit / 10;
     }
 
     private async void PopulateScanResults(ReceiptScanResult result)

--- a/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
@@ -325,6 +325,9 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
     [ObservableProperty]
     private string _supplierErrorMessage = string.Empty;
 
+    [ObservableProperty]
+    private bool _hasValidationMessage;
+
     partial void OnSelectedSupplierChanged(SupplierOption? value)
     {
         if (value != null)
@@ -662,6 +665,7 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
     private async Task CreateTransactionAsync()
     {
         // Validate
+        HasValidationMessage = false;
         HasTotalError = false;
         HasSupplierError = false;
         HasLineItemsError = false;
@@ -709,6 +713,7 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
             }
         }
 
+        HasValidationMessage = hasErrors;
         if (hasErrors)
             return;
 
@@ -1474,6 +1479,7 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
         SelectedPaymentMethod = "Cash";
         Notes = string.Empty;
         IsRevenue = false;
+        HasValidationMessage = false;
         HasTotalError = false;
         HasSupplierError = false;
         HasLineItemsError = false;

--- a/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
@@ -334,6 +334,26 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
         {
             HasSupplierError = false;
             SupplierErrorMessage = string.Empty;
+            ClearValidationMessageIfNoErrors();
+        }
+    }
+
+    partial void OnHasTotalErrorChanged(bool value)
+    {
+        if (!value) ClearValidationMessageIfNoErrors();
+    }
+
+    partial void OnHasLineItemsErrorChanged(bool value)
+    {
+        if (!value) ClearValidationMessageIfNoErrors();
+    }
+
+    private void ClearValidationMessageIfNoErrors()
+    {
+        if (!HasTotalError && !HasSupplierError && !HasLineItemsError &&
+            LineItems.All(li => !li.HasProductError))
+        {
+            HasValidationMessage = false;
         }
     }
 
@@ -587,6 +607,7 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
                 // Try to match to existing product
                 TryMatchProduct(lineItem, item.Description);
 
+                lineItem.OnProductErrorCleared = ClearValidationMessageIfNoErrors;
                 LineItems.Add(lineItem);
             }
 
@@ -648,7 +669,8 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
             UnitPrice = "0.00",
             TotalPrice = "0.00",
             Confidence = 1.0,
-            IsManuallyAdded = true
+            IsManuallyAdded = true,
+            OnProductErrorCleared = ClearValidationMessageIfNoErrors
         });
     }
 
@@ -1601,6 +1623,11 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
 /// </summary>
 public partial class ScannedLineItemViewModel : ObservableObject
 {
+    /// <summary>
+    /// Callback invoked when a product error is cleared.
+    /// </summary>
+    public Action? OnProductErrorCleared { get; set; }
+
     [ObservableProperty]
     private ProductOption? _selectedProduct;
 
@@ -1653,6 +1680,7 @@ public partial class ScannedLineItemViewModel : ObservableObject
             HasProductError = false;
             ProductErrorMessage = string.Empty;
             ShowCreateProductSuggestion = false;
+            OnProductErrorCleared?.Invoke();
         }
         RecalculateTotal();
     }

--- a/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsModalsViewModel.cs
@@ -396,6 +396,26 @@ public partial class ReceiptsModalsViewModel : ViewModelBase
     #region AI Scan Commands
 
     /// <summary>
+    /// Checks whether the user can scan a receipt. If the limit is reached,
+    /// shows the upgrade prompt and returns false.
+    /// Call this before opening a file picker.
+    /// </summary>
+    public async Task<bool> CanScanOrShowLimitAsync()
+    {
+        _usageService ??= CreateUsageService();
+        var usageCheck = await _usageService.CheckUsageAsync();
+        if (!usageCheck.CanScan)
+        {
+            await UpgradePromptHelper.ShowReceiptScanLimitPromptAsync(
+                usageCheck.ScanCount,
+                usageCheck.MonthlyLimit,
+                usageCheck.ResetsAt);
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
     /// Opens the scan review modal and starts scanning.
     /// </summary>
     public async Task OpenScanModalAsync(string filePath)

--- a/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
@@ -344,8 +344,10 @@ public partial class ReceiptsPageViewModel : ViewModelBase
     public async Task HandleFileSelectedAsync(string filePath)
     {
         if (string.IsNullOrEmpty(filePath)) return;
+        if (App.ReceiptsModalsViewModel == null) return;
+        if (!await App.ReceiptsModalsViewModel.CanScanOrShowLimitAsync()) return;
 
-        await App.ReceiptsModalsViewModel!.OpenScanModalAsync(filePath);
+        await App.ReceiptsModalsViewModel.OpenScanModalAsync(filePath);
     }
 
     /// <summary>
@@ -655,8 +657,11 @@ public partial class ReceiptsPageViewModel : ViewModelBase
     #region Action Commands
 
     [RelayCommand]
-    private void AiScanReceipt()
+    private async Task AiScanReceipt()
     {
+        if (App.ReceiptsModalsViewModel == null) return;
+        if (!await App.ReceiptsModalsViewModel.CanScanOrShowLimitAsync()) return;
+
         // Trigger file picker in the view
         ScanFileRequested?.Invoke(this, EventArgs.Empty);
     }

--- a/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
@@ -345,14 +345,6 @@ public partial class ReceiptsPageViewModel : ViewModelBase
     {
         if (string.IsNullOrEmpty(filePath)) return;
 
-        if (!HasPremium)
-        {
-            await App.ShowWarningMessageBoxAsync(
-                Loc.Tr("Premium Feature"),
-                Loc.Tr("AI Receipt Scanning requires a Premium subscription."));
-            return;
-        }
-
         await App.ReceiptsModalsViewModel!.OpenScanModalAsync(filePath);
     }
 

--- a/ArgoBooks/ViewModels/UpgradeModalViewModel.cs
+++ b/ArgoBooks/ViewModels/UpgradeModalViewModel.cs
@@ -100,7 +100,8 @@ public partial class UpgradeModalViewModel : ViewModelBase
         "Real-time analytics",
         "Receipt management",
         "5 invoices / month",
-        "AI spreadsheet import (100/month)"
+        "AI spreadsheet import (100/month)",
+        "AI receipt scanning (5/month)"
     ];
 
     private static readonly string[] DefaultPremiumFeatures =

--- a/ArgoBooks/ViewModels/UpgradePromptHelper.cs
+++ b/ArgoBooks/ViewModels/UpgradePromptHelper.cs
@@ -81,7 +81,7 @@ public static class UpgradePromptHelper
         {
             Title = "Scan Limit Reached".Translate(),
             Message = string.Format(
-                "You've used all {0} of your {1} receipt scans this month. Your limit resets on {2}.\n\nUpgrade to Premium for 500 scans per month, unlimited invoices, and predictive analytics.".Translate(),
+                "You've used all {0} of your {1} receipt scans this month. Your limit resets on {2}.\n\nUpgrade to Premium for 500 scans per month, unlimited invoices, predictive analytics, and more.".Translate(),
                 scanCount, monthlyLimit, resetDate),
             PrimaryButtonText = "Upgrade Now".Translate(),
             CancelButtonText = "Maybe Later".Translate(),

--- a/ArgoBooks/Views/AppShell.axaml.cs
+++ b/ArgoBooks/Views/AppShell.axaml.cs
@@ -125,6 +125,9 @@ public partial class AppShell : UserControl
     {
         try
         {
+            if (App.ReceiptsModalsViewModel == null) return;
+            if (!await App.ReceiptsModalsViewModel.CanScanOrShowLimitAsync()) return;
+
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel == null) return;
 

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -225,8 +225,7 @@
                         <!-- Scan Receipt -->
                         <Button Classes="quick-action-compact" Margin="6" Width="165"
                                 Command="{Binding ScanReceiptCommand}"
-                                IsVisible="{Binding ShowScanReceipt}"
-                                IsEnabled="{Binding HasPremium}">
+                                IsVisible="{Binding ShowScanReceipt}">
                             <StackPanel Orientation="Horizontal" Spacing="10">
                                 <Border Width="32" Height="32" CornerRadius="6" Background="{DynamicResource InfoIconBgBrush}">
                                     <PathIcon Data="{x:Static local:Icons.ScanReceipt}"

--- a/ArgoBooks/Views/ExpensesPage.axaml
+++ b/ArgoBooks/Views/ExpensesPage.axaml
@@ -79,7 +79,6 @@
                             Classes="primary-button"
                             Classes.compact="{Binding ResponsiveHeader.IsCompactMode}"
                             Classes.medium="{Binding ResponsiveHeader.IsMediumMode}"
-                            IsEnabled="{Binding HasPremium}"
                             Click="OnAiScanButtonClick"
                             ToolTip.Tip="{loc:Loc 'AI Scan Receipt'}">
                         <StackPanel Orientation="Horizontal" Spacing="8">

--- a/ArgoBooks/Views/ExpensesPage.axaml.cs
+++ b/ArgoBooks/Views/ExpensesPage.axaml.cs
@@ -35,6 +35,9 @@ public partial class ExpensesPage : UserControl
     {
         try
         {
+            if (App.ReceiptsModalsViewModel == null) return;
+            if (!await App.ReceiptsModalsViewModel.CanScanOrShowLimitAsync()) return;
+
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel == null) return;
 

--- a/ArgoBooks/Views/ReceiptsPage.axaml
+++ b/ArgoBooks/Views/ReceiptsPage.axaml
@@ -117,7 +117,7 @@
                                 AddCommand="{Binding AiScanReceiptCommand}"
                                 AddButtonText="{loc:Loc 'AI Scan Receipt'}"
                                 AddButtonTooltip="{loc:Loc 'AI Scan Receipt'}"
-                                IsAddButtonEnabled="{Binding HasPremium}"
+                                IsAddButtonEnabled="True"
                                 ColumnWidthsManager="{Binding ColumnWidths}"
                                 CurrentPage="{Binding CurrentPage, Mode=TwoWay}"
                                 TotalPages="{Binding TotalPages}"

--- a/ArgoBooks/Views/RevenuePage.axaml
+++ b/ArgoBooks/Views/RevenuePage.axaml
@@ -79,7 +79,6 @@
                             Classes="primary-button"
                             Classes.compact="{Binding ResponsiveHeader.IsCompactMode}"
                             Classes.medium="{Binding ResponsiveHeader.IsMediumMode}"
-                            IsEnabled="{Binding HasPremium}"
                             Click="OnAiScanButtonClick"
                             ToolTip.Tip="{loc:Loc 'AI Scan Receipt'}">
                         <StackPanel Orientation="Horizontal" Spacing="8">

--- a/ArgoBooks/Views/RevenuePage.axaml.cs
+++ b/ArgoBooks/Views/RevenuePage.axaml.cs
@@ -35,6 +35,9 @@ public partial class RevenuePage : UserControl
     {
         try
         {
+            if (App.ReceiptsModalsViewModel == null) return;
+            if (!await App.ReceiptsModalsViewModel.CanScanOrShowLimitAsync()) return;
+
             var topLevel = TopLevel.GetTopLevel(this);
             if (topLevel == null) return;
 


### PR DESCRIPTION
## Summary
This PR removes the Premium subscription requirement for AI receipt scanning and implements a usage-based access model instead. All users can now access AI receipt scanning features with monthly limits enforced through the usage tracking system.

## Key Changes

- **Removed Premium gating**: Eliminated `HasPremium` checks from receipt scanning UI components (DashboardPage, ReceiptsPage, ExpensesPage, RevenuePage)
- **Enhanced usage validation**: Updated `CheckUsageAsync()` and `IncrementUsageAsync()` in `ReceiptUsageService` to accept either a license key OR device ID for authentication, allowing device-based usage tracking for non-premium users
- **API request updates**: Modified `CallApiAsync()` to include `device_id` in API requests alongside `license_key`
- **Updated feature lists**: Added "AI receipt scanning (5/month)" to the free tier features in `UpgradeModalViewModel`
- **Removed premium check**: Deleted the premium subscription warning from `HandleFileSelectedAsync()` in `ReceiptsPageViewModel`
- **Updated messaging**: Modified upgrade prompt to reference "500 scans per month" and added "and more" to encourage upgrades

## Implementation Details

- The usage service now treats missing license keys and device IDs with an OR condition rather than requiring a license key specifically
- Error messages updated to reflect "No license key or device ID found" instead of just "No license key"
- Device ID is now passed to the backend API for tracking usage across non-premium users
- Free tier users get 5 scans/month, premium users get 500 scans/month (enforced server-side)

https://claude.ai/code/session_0143AS4HVFNSejCjLqRGwAcC