### PR TITLE
Refactor null checks and remove unused code in ViewModels

### DIFF
--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -2579,15 +2579,15 @@ public partial class ReportsPageViewModel : ViewModelBase
         foreach (var chart in lossCharts) AvailableCharts.Add(chart);
 
         // Create category groups for grouped display
-        ChartCategories.Add(new ChartCategoryGroup("Revenue", revenueColor, revenueCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
-        ChartCategories.Add(new ChartCategoryGroup("Expenses", expenseColor, expenseCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
-        ChartCategories.Add(new ChartCategoryGroup("Financial", financialColor, financialCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
-        ChartCategories.Add(new ChartCategoryGroup("Transactions", transactionColor, transactionCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
-        ChartCategories.Add(new ChartCategoryGroup("Geographic", geographicColor, geographicCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
-        ChartCategories.Add(new ChartCategoryGroup("Personnel", accountantColor, accountantCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
-        ChartCategories.Add(new ChartCategoryGroup("Customers", customerColor, customerCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
-        ChartCategories.Add(new ChartCategoryGroup("Returns", returnColor, returnCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
-        ChartCategories.Add(new ChartCategoryGroup("Losses", lossColor, lossCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Revenue", revenueCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Expenses", expenseCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Financial", financialCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Transactions", transactionCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Geographic", geographicCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Personnel", accountantCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Customers", customerCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Returns", returnCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
+        ChartCategories.Add(new ChartCategoryGroup("Losses", lossCharts, () => OnPropertyChanged(nameof(HasSelectedCharts))));
     }
 
     private void LoadTemplate(string templateName)
@@ -2916,7 +2916,7 @@ public partial class ChartOption(
 /// </summary>
 public class ChartCategoryGroup : ObservableObject
 {
-    public ChartCategoryGroup(string name, string _, ObservableCollection<ChartOption> charts, Action onSelectionChanged)
+    public ChartCategoryGroup(string name, ObservableCollection<ChartOption> charts, Action onSelectionChanged)
     {
         Name = name;
         Charts = charts;

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -248,8 +248,9 @@ public partial class ReportsPageViewModel : ViewModelBase
     public bool IsTemplatesTabSelected => Step1TabIndex == 0;
     public bool IsChartsTabSelected => Step1TabIndex == 1;
 
-    partial void OnStep1TabIndexChanged(int _)
+    partial void OnStep1TabIndexChanged(int value)
     {
+        _ = value;
         OnPropertyChanged(nameof(IsTemplatesTabSelected));
         OnPropertyChanged(nameof(IsChartsTabSelected));
 
@@ -741,8 +742,9 @@ public partial class ReportsPageViewModel : ViewModelBase
 
     public bool CanGoToNextPage => CurrentDesignerPage < Configuration.PageCount;
 
-    partial void OnCurrentDesignerPageChanged(int _)
+    partial void OnCurrentDesignerPageChanged(int value)
     {
+        _ = value;
         OnPropertyChanged(nameof(CurrentDesignerPageDisplay));
         OnPropertyChanged(nameof(CanGoToPreviousPage));
         OnPropertyChanged(nameof(CanGoToNextPage));
@@ -981,8 +983,9 @@ public partial class ReportsPageViewModel : ViewModelBase
         NotifySelectionChanged();
     }
 
-    partial void OnConfigurationChanged(ReportConfiguration _)
+    partial void OnConfigurationChanged(ReportConfiguration value)
     {
+        _ = value;
         UpdateCanvasDimensions();
     }
 

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -248,7 +248,7 @@ public partial class ReportsPageViewModel : ViewModelBase
     public bool IsTemplatesTabSelected => Step1TabIndex == 0;
     public bool IsChartsTabSelected => Step1TabIndex == 1;
 
-    partial void OnStep1TabIndexChanged(int value)
+    partial void OnStep1TabIndexChanged(int _)
     {
         OnPropertyChanged(nameof(IsTemplatesTabSelected));
         OnPropertyChanged(nameof(IsChartsTabSelected));
@@ -336,7 +336,6 @@ public partial class ReportsPageViewModel : ViewModelBase
     [ObservableProperty]
     private TransactionType _selectedTransactionType = TransactionType.Revenue;
 
-    public ObservableCollection<string> TemplateNames { get; } = [];
     public ObservableCollection<CustomTemplateOption> CustomTemplateNames { get; } = [];
     public ObservableCollection<DatePresetOption> DatePresets { get; } = [];
 
@@ -618,10 +617,10 @@ public partial class ReportsPageViewModel : ViewModelBase
     public ChartReportElement SelectedChartElement => (SelectedElement as ChartReportElement) ?? EmptyChart;
     public LabelReportElement SelectedLabelElement => (SelectedElement as LabelReportElement) ?? EmptyLabel;
     public ImageReportElement SelectedImageElement => (SelectedElement as ImageReportElement) ?? EmptyImage;
-    public string SelectedImageFileName => string.IsNullOrEmpty(SelectedImageElement?.ImagePath)
+    public string SelectedImageFileName => string.IsNullOrEmpty(SelectedImageElement.ImagePath)
         ? string.Empty
         : Path.GetFileName(SelectedImageElement.ImagePath);
-    public bool HasSelectedImage => !string.IsNullOrEmpty(SelectedImageElement?.ImagePath);
+    public bool HasSelectedImage => !string.IsNullOrEmpty(SelectedImageElement.ImagePath);
     public TableReportElement SelectedTableElement => (SelectedElement as TableReportElement) ?? EmptyTable;
 
     public bool IsSelectedTableMaxRowsUnlimited
@@ -682,7 +681,7 @@ public partial class ReportsPageViewModel : ViewModelBase
     /// <summary>
     /// Whether the selected chart is a distribution/pie chart that benefits from legend display.
     /// </summary>
-    public bool IsDistributionChartSelected => SelectedChartElement?.ChartType is
+    public bool IsDistributionChartSelected => SelectedChartElement.ChartType is
         ChartDataType.WorldMap or
         ChartDataType.RevenueDistribution or
         ChartDataType.ExpensesDistribution or
@@ -742,7 +741,7 @@ public partial class ReportsPageViewModel : ViewModelBase
 
     public bool CanGoToNextPage => CurrentDesignerPage < Configuration.PageCount;
 
-    partial void OnCurrentDesignerPageChanged(int value)
+    partial void OnCurrentDesignerPageChanged(int _)
     {
         OnPropertyChanged(nameof(CurrentDesignerPageDisplay));
         OnPropertyChanged(nameof(CanGoToPreviousPage));
@@ -910,53 +909,6 @@ public partial class ReportsPageViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isRedoDropdownOpen;
 
-    public ObservableCollection<UndoRedoHistoryItem> UndoHistoryItems { get; } = [];
-    public ObservableCollection<UndoRedoHistoryItem> RedoHistoryItems { get; } = [];
-
-    [RelayCommand]
-    private void ToggleUndoDropdown()
-    {
-        if (!UndoRedoManager.CanUndo) return;
-        IsRedoDropdownOpen = false;
-        IsUndoDropdownOpen = !IsUndoDropdownOpen;
-        if (IsUndoDropdownOpen)
-        {
-            RefreshUndoHistory();
-        }
-    }
-
-    [RelayCommand]
-    private void ToggleRedoDropdown()
-    {
-        if (!UndoRedoManager.CanRedo) return;
-        IsUndoDropdownOpen = false;
-        IsRedoDropdownOpen = !IsRedoDropdownOpen;
-        if (IsRedoDropdownOpen)
-        {
-            RefreshRedoHistory();
-        }
-    }
-
-    private void RefreshUndoHistory()
-    {
-        UndoHistoryItems.Clear();
-        int index = 0;
-        foreach (var desc in UndoRedoManager.UndoHistory)
-        {
-            UndoHistoryItems.Add(new UndoRedoHistoryItem { Index = index++, Description = desc });
-        }
-    }
-
-    private void RefreshRedoHistory()
-    {
-        RedoHistoryItems.Clear();
-        int index = 0;
-        foreach (var desc in UndoRedoManager.RedoHistory)
-        {
-            RedoHistoryItems.Add(new UndoRedoHistoryItem { Index = index++, Description = desc });
-        }
-    }
-
     [RelayCommand]
     private void UndoToIndex(int index)
     {
@@ -1029,7 +981,7 @@ public partial class ReportsPageViewModel : ViewModelBase
         NotifySelectionChanged();
     }
 
-    partial void OnConfigurationChanged(ReportConfiguration value)
+    partial void OnConfigurationChanged(ReportConfiguration _)
     {
         UpdateCanvasDimensions();
     }
@@ -1409,7 +1361,7 @@ public partial class ReportsPageViewModel : ViewModelBase
     [RelayCommand]
     private async Task BrowseImagePathAsync()
     {
-        if (SelectedImageElement == null) return;
+        if (SelectedElement is not ImageReportElement) return;
 
         var topLevel = Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
             ? desktop.MainWindow
@@ -1446,7 +1398,7 @@ public partial class ReportsPageViewModel : ViewModelBase
     [RelayCommand]
     private void RemoveImage()
     {
-        if (SelectedImageElement == null) return;
+        if (SelectedElement is not ImageReportElement) return;
         SelectedImageElement.ImagePath = string.Empty;
         OnPropertyChanged(nameof(SelectedImageElement));
         OnPropertyChanged(nameof(SelectedImageFileName));
@@ -1946,12 +1898,12 @@ public partial class ReportsPageViewModel : ViewModelBase
     /// </summary>
     public ChartDataTypeOption? SelectedChartDataTypeOption
     {
-        get => SelectedChartElement != null
+        get => SelectedElement is ChartReportElement
             ? ChartTypeOptions.FirstOrDefault(o => o.Value == SelectedChartElement.ChartType)
             : null;
         set
         {
-            if (SelectedChartElement != null && value != null)
+            if (SelectedElement is ChartReportElement && value != null)
             {
                 SelectedChartElement.ChartType = value.Value;
                 OnPropertyChanged();
@@ -2464,12 +2416,6 @@ public partial class ReportsPageViewModel : ViewModelBase
 
     private void InitializeCollections()
     {
-        // Load built-in templates
-        foreach (var name in ReportTemplateFactory.GetBuiltInTemplateNames())
-        {
-            TemplateNames.Add(name);
-        }
-
         // Load custom templates
         LoadCustomTemplates();
 
@@ -2660,7 +2606,7 @@ public partial class ReportsPageViewModel : ViewModelBase
             {
                 var config = await _templateStorage.LoadTemplateAsync(templateName);
                 // Update configuration and page settings on UI thread
-                Avalonia.Threading.Dispatcher.UIThread.Post(async () =>
+                await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
                 {
                     if (config == null)
                     {
@@ -2970,10 +2916,9 @@ public partial class ChartOption(
 /// </summary>
 public class ChartCategoryGroup : ObservableObject
 {
-    public ChartCategoryGroup(string name, string accentColor, ObservableCollection<ChartOption> charts, Action onSelectionChanged)
+    public ChartCategoryGroup(string name, string _, ObservableCollection<ChartOption> charts, Action onSelectionChanged)
     {
         Name = name;
-        AccentColor = accentColor;
         Charts = charts;
         var onSelectionChanged1 = onSelectionChanged;
 
@@ -2993,7 +2938,6 @@ public class ChartCategoryGroup : ObservableObject
     }
 
     public string Name { get; }
-    public string AccentColor { get; }
     public ObservableCollection<ChartOption> Charts { get; }
 
     /// <summary>

--- a/ArgoBooks/ViewModels/RevenuePageViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenuePageViewModel.cs
@@ -379,9 +379,9 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
         var returnedIds = new HashSet<string>(
             companyData?.Returns
                 .Where(r => r.Status == ReturnStatus.Completed)
-                .Select(r => r.OriginalTransactionId ?? "") ?? []);
+                .Select(r => r.OriginalTransactionId) ?? []);
         var returnIds = new HashSet<string>(
-            companyData?.Returns.Select(r => r.OriginalTransactionId ?? "") ?? []);
+            companyData?.Returns.Select(r => r.OriginalTransactionId) ?? []);
 
         IEnumerable<Revenue> filtered = _allRevenue;
 


### PR DESCRIPTION
## Summary
This PR refactors null-checking patterns and removes unused code from the ReportsPageViewModel and RevenuePageViewModel to improve code clarity and maintainability.

## Key Changes

### ReportsPageViewModel
- **Null-coalescing operator removal**: Replaced nullable property access (`?.`) with direct property access in `SelectedImageFileName` and `HasSelectedImage` properties, since `SelectedImageElement` is guaranteed to return a non-null default value (`EmptyImage`)
- **Null check refactoring**: Updated `SelectedChartDataTypeOption` property to use `is` pattern matching instead of null comparison for type checking
- **Unused code removal**:
  - Removed unused `TemplateNames` ObservableCollection
  - Removed `UndoHistoryItems` and `RedoHistoryItems` collections and their associated methods (`ToggleUndoDropdown`, `ToggleRedoDropdown`, `RefreshUndoHistory`, `RefreshRedoHistory`)
  - Removed template initialization code that populated the unused `TemplateNames` collection
  - Removed `AccentColor` property and parameter from `ChartCategoryGroup` class
- **Discard parameter usage**: Changed unused parameters in partial methods (`OnStep1TabIndexChanged`, `OnCurrentDesignerPageChanged`, `OnConfigurationChanged`) to use discard operator (`_`)
- **Image element validation**: Simplified null checks in `BrowseImagePathAsync` and `RemoveImage` methods to use `is not` pattern matching
- **Async/await improvement**: Changed `Dispatcher.UIThread.Post` to `Dispatcher.UIThread.InvokeAsync` for better async handling in `LoadTemplate` method

### RevenuePageViewModel
- **Null-coalescing removal**: Removed unnecessary null-coalescing operators (`?? ""`) when selecting `OriginalTransactionId` in `FilterRevenue` method, as the property is already non-nullable

## Implementation Details
These changes maintain the same functionality while improving code readability through modern C# patterns and removing dead code that was no longer being used.

https://claude.ai/code/session_01BV54cBYxBWzWySQ96mMHS1