### PR TITLE
Preserve receipt file types and improve file handling

### DIFF
--- a/ArgoBooks.Core/Services/InvoiceTemplates/InvoicePreviewService.cs
+++ b/ArgoBooks.Core/Services/InvoiceTemplates/InvoicePreviewService.cs
@@ -25,7 +25,9 @@ public static class InvoicePreviewService
             Directory.CreateDirectory(TempDirectory);
 
             // Sanitize the invoiceId to prevent path traversal
-            var safeId = Regex.Replace(invoiceId ?? Guid.NewGuid().ToString("N"), @"[^a-zA-Z0-9\-_]", "");
+            var safeId = Regex.Replace(invoiceId ?? "", @"[^a-zA-Z0-9\-_]", "");
+            if (string.IsNullOrEmpty(safeId))
+                safeId = Guid.NewGuid().ToString("N");
 
             // Generate a filename
             var filename = $"invoice-preview-{safeId}.html";

--- a/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReceiptsPageViewModel.cs
@@ -630,10 +630,11 @@ public partial class ReceiptsPageViewModel : ViewModelBase
             // Create temp file from Base64 data stored in company file
             var tempDir = Path.Combine(Path.GetTempPath(), "ArgoBooks", "Receipts");
             Directory.CreateDirectory(tempDir);
-            var tempPath = Path.Combine(tempDir, Path.ChangeExtension(receipt.FileName, ".jpg"));
+            var tempPath = Path.Combine(tempDir, receipt.FileName);
             var bytes = Convert.FromBase64String(receipt.FileData);
-            var oriented = ReceiptImageHelper.FixOrientation(bytes);
-            File.WriteAllBytes(tempPath, oriented);
+            var isImage = receipt.FileType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true;
+            var output = isImage ? ReceiptImageHelper.FixOrientation(bytes) : bytes;
+            File.WriteAllBytes(tempPath, output);
             return tempPath;
         }
         catch

--- a/ArgoBooks/ViewModels/RevenuePageViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenuePageViewModel.cs
@@ -684,12 +684,11 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
             // Create temp file from Base64 data stored in company file
             var tempDir = Path.Combine(Path.GetTempPath(), "ArgoBooks", "Receipts");
             Directory.CreateDirectory(tempDir);
-            var tempPath = Path.Combine(tempDir, Path.ChangeExtension(receipt.FileName, ".jpg"));
-            if (File.Exists(tempPath))
-                return tempPath;
+            var tempPath = Path.Combine(tempDir, receipt.FileName);
             var bytes = Convert.FromBase64String(receipt.FileData);
-            var oriented = ReceiptImageHelper.FixOrientation(bytes);
-            File.WriteAllBytes(tempPath, oriented);
+            var isImage = receipt.FileType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true;
+            var output = isImage ? ReceiptImageHelper.FixOrientation(bytes) : bytes;
+            File.WriteAllBytes(tempPath, output);
             return tempPath;
         }
         catch


### PR DESCRIPTION
## Summary
This PR improves receipt file handling by preserving original file types instead of forcing all receipts to `.jpg` format, and adds safer invoice ID sanitization.

## Key Changes
- **Receipt file type preservation**: Modified `RevenuePageViewModel` and `ReceiptsPageViewModel` to:
  - Use original `receipt.FileName` instead of forcing `.jpg` extension
  - Only apply image orientation fixes for actual image files (checked via `FileType` MIME type)
  - Write non-image files as-is without processing
  
- **Invoice preview safety**: Enhanced `InvoicePreviewService` to:
  - Sanitize `invoiceId` before using it in filename generation
  - Generate a random GUID when the sanitized ID is empty, preventing potential issues with empty filenames
  - Maintain path traversal attack prevention through regex filtering

## Implementation Details
- Receipt file type detection uses MIME type checking (`receipt.FileType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase)`)
- Image orientation fixing via `ReceiptImageHelper.FixOrientation()` is now conditional, improving performance for non-image receipts
- Invoice ID sanitization now handles edge cases where all characters are filtered out

https://claude.ai/code/session_01S2XbAEFLWXm6hzNvkEkB5N