### PR TITLE
Add color-scheme meta tag to all invoice HTML templates

### DIFF
--- a/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceHtmlTemplates.cs
+++ b/ArgoBooks.Core/Services/InvoiceTemplates/InvoiceHtmlTemplates.cs
@@ -17,6 +17,7 @@ public static class InvoiceHtmlTemplates
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light">
     <title>Invoice {{InvoiceNumber}}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: {{FontFamily}}; background-color: #f3f4f6;">
@@ -246,6 +247,7 @@ public static class InvoiceHtmlTemplates
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light">
     <title>Invoice {{InvoiceNumber}}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: {{FontFamily}}; background-color: #f0f4f8;">
@@ -482,6 +484,7 @@ public static class InvoiceHtmlTemplates
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light">
     <title>Invoice {{InvoiceNumber}}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: {{FontFamily}}; background-color: #ffffff;">
@@ -660,6 +663,7 @@ public static class InvoiceHtmlTemplates
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light">
     <title>Invoice {{InvoiceNumber}}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: {{FontFamily}}; background-color: #f8f9fa;">
@@ -883,6 +887,7 @@ public static class InvoiceHtmlTemplates
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light">
     <title>{{HeaderText}} {{InvoiceNumber}}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: {{FontFamily}}; font-weight: 600; background-color: #f5f5f5; min-height: 100vh; display: flex; justify-content: center; align-items: center; padding: 40px 20px;">


### PR DESCRIPTION
## Summary
Added the `color-scheme: light` meta tag to the HTML head section of all five invoice templates to ensure consistent light mode rendering across different browsers and email clients.

## Changes
- Added `<meta name="color-scheme" content="light">` to the `<head>` section of all invoice HTML templates:
  - Template 1 (Classic)
  - Template 2 (Modern)
  - Template 3 (Minimal)
  - Template 4 (Professional)
  - Template 5 (Corporate)

## Details
The `color-scheme` meta tag explicitly declares that these invoice templates are designed for light mode rendering. This helps prevent browsers and email clients from automatically applying dark mode transformations to the HTML content, which could interfere with the carefully designed invoice styling and readability. This is particularly important for email clients that support dark mode, ensuring invoices display as intended regardless of the user's system preferences.

https://claude.ai/code/session_01FcD94jFcUb9qReorPT9F6X