### PR TITLE
Adjust fullscreen modal top margin to clear title bar

### DIFF
--- a/ArgoBooks/Converters/BoolConverters.cs
+++ b/ArgoBooks/Converters/BoolConverters.cs
@@ -133,10 +133,10 @@ public static class BoolConverters
 
     /// <summary>
     /// Converts bool (isFullscreen) to modal margin.
-    /// Fullscreen = 24px vertical margin only (width is fixed), Normal = 0.
+    /// Fullscreen = 40px top margin (clears title bar) + 24px bottom, Normal = 0.
     /// </summary>
     public static readonly IValueConverter ToFullscreenMargin =
-        new FuncValueConverter<bool, Thickness>(value => value ? new Thickness(0, 24, 0, 24) : new Thickness(0));
+        new FuncValueConverter<bool, Thickness>(value => value ? new Thickness(0, 40, 0, 24) : new Thickness(0));
 
     /// <summary>
     /// Converts bool (isFullscreen) to modal max width.


### PR DESCRIPTION
## Summary
Updated the fullscreen modal margin calculation to provide proper spacing that clears the application's title bar.

## Changes
- Modified `ToFullscreenMargin` converter to use 40px top margin instead of 24px
- Maintains 24px bottom margin for consistent spacing
- Updated documentation to reflect the new margin behavior (40px top for title bar clearance + 24px bottom)

## Details
The fullscreen modal now allocates 40px of top margin to properly clear the title bar, while keeping the bottom margin at 24px. This ensures modals in fullscreen mode don't overlap with the application's title bar and maintain balanced spacing.

https://claude.ai/code/session_01EA3Xw7Y1BifbWDNc6Pdt4G