### PR TITLE
Add global search to header search bar

### DIFF
--- a/ArgoBooks.Core/Enums/NavigationEnums.cs
+++ b/ArgoBooks.Core/Enums/NavigationEnums.cs
@@ -12,8 +12,7 @@ public enum QuickActionName
     OpenImport,
     OpenScanModal,
     OpenEditCompany,
-    OpenCheckForUpdates,
-    ViewSearchResult
+    OpenCheckForUpdates
 }
 
 /// <summary>
@@ -26,9 +25,6 @@ public static class QuickActionNameExtensions
     /// </summary>
     public static QuickActionName? ParseQuickActionName(string? name)
     {
-        if (name != null && name.StartsWith("ViewSearchResult:"))
-            return QuickActionName.ViewSearchResult;
-
         return name switch
         {
             "OpenAddModal" => QuickActionName.OpenAddModal,
@@ -41,16 +37,6 @@ public static class QuickActionNameExtensions
             "OpenCheckForUpdates" => QuickActionName.OpenCheckForUpdates,
             _ => null
         };
-    }
-
-    /// <summary>
-    /// Extracts the entity ID from a ViewSearchResult action name (e.g., "ViewSearchResult:CUST-001" -> "CUST-001").
-    /// </summary>
-    public static string? ParseSearchResultEntityId(string? actionName)
-    {
-        if (actionName == null || !actionName.StartsWith("ViewSearchResult:"))
-            return null;
-        return actionName["ViewSearchResult:".Length..];
     }
 }
 

--- a/ArgoBooks.Core/Enums/NavigationEnums.cs
+++ b/ArgoBooks.Core/Enums/NavigationEnums.cs
@@ -12,7 +12,8 @@ public enum QuickActionName
     OpenImport,
     OpenScanModal,
     OpenEditCompany,
-    OpenCheckForUpdates
+    OpenCheckForUpdates,
+    ViewSearchResult
 }
 
 /// <summary>
@@ -25,6 +26,9 @@ public static class QuickActionNameExtensions
     /// </summary>
     public static QuickActionName? ParseQuickActionName(string? name)
     {
+        if (name != null && name.StartsWith("ViewSearchResult:"))
+            return QuickActionName.ViewSearchResult;
+
         return name switch
         {
             "OpenAddModal" => QuickActionName.OpenAddModal,
@@ -37,6 +41,16 @@ public static class QuickActionNameExtensions
             "OpenCheckForUpdates" => QuickActionName.OpenCheckForUpdates,
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Extracts the entity ID from a ViewSearchResult action name (e.g., "ViewSearchResult:CUST-001" -> "CUST-001").
+    /// </summary>
+    public static string? ParseSearchResultEntityId(string? actionName)
+    {
+        if (actionName == null || !actionName.StartsWith("ViewSearchResult:"))
+            return null;
+        return actionName["ViewSearchResult:".Length..];
     }
 }
 
@@ -54,7 +68,9 @@ public enum NavigationTarget
     Expenses,
     Revenue,
     Payments,
-    Categories
+    Categories,
+    StockLevels,
+    PurchaseOrders
 }
 
 /// <summary>
@@ -79,6 +95,8 @@ public static class NavigationTargetExtensions
             "Revenue" => NavigationTarget.Revenue,
             "Payments" => NavigationTarget.Payments,
             "Categories" => NavigationTarget.Categories,
+            "StockLevels" => NavigationTarget.StockLevels,
+            "PurchaseOrders" => NavigationTarget.PurchaseOrders,
             _ => null
         };
     }

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -4302,6 +4302,7 @@ public class App : Application
                 _invoicesPageViewModel.UpgradeRequested += (_, _) => _appShellViewModel!.UpgradeModalViewModel.OpenCommand.Execute(null);
             }
             _invoicesPageViewModel.HasPremium = _appShellViewModel!.SidebarViewModel.HasPremium;
+            _invoicesPageViewModel.HighlightTransactionId = null;
             if (param is RentalInvoiceNavigationParameter rentalParam)
             {
                 Avalonia.Threading.Dispatcher.UIThread.Post(() =>
@@ -4309,11 +4310,22 @@ public class App : Application
                     InvoiceModalsViewModel?.OpenCreateFromRental(rentalParam.RentalRecordId);
                 });
             }
+            else if (param is TransactionNavigationParameter navParam)
+            {
+                _invoicesPageViewModel.HighlightTransactionId = navParam.TransactionId;
+                _invoicesPageViewModel.ApplyHighlight();
+            }
             return new InvoicesPage { DataContext = _invoicesPageViewModel };
         });
         navigationService.RegisterPage("Payments", param =>
         {
             _paymentsPageViewModel ??= new PaymentsPageViewModel();
+            _paymentsPageViewModel.HighlightTransactionId = null;
+            if (param is TransactionNavigationParameter navParam)
+            {
+                _paymentsPageViewModel.HighlightTransactionId = navParam.TransactionId;
+                _paymentsPageViewModel.ApplyHighlight();
+            }
             _ = AutoSyncPortalPaymentsAsync();
             return new PaymentsPage { DataContext = _paymentsPageViewModel };
         });
@@ -4331,7 +4343,13 @@ public class App : Application
             _productsPageViewModel.HasPremium = _appShellViewModel!.SidebarViewModel.HasPremium;
             // Reset modal state
             _productsPageViewModel.IsAddModalOpen = false;
-            if (param is Dictionary<string, object?> dict)
+            _productsPageViewModel.HighlightTransactionId = null;
+            if (param is TransactionNavigationParameter navParam)
+            {
+                _productsPageViewModel.HighlightTransactionId = navParam.TransactionId;
+                _productsPageViewModel.ApplyHighlight();
+            }
+            else if (param is Dictionary<string, object?> dict)
             {
                 // Check if we should select a specific tab (0 = Expenses, 1 = Revenue)
                 if (dict.TryGetValue("selectedTabIndex", out var tabIndex) && tabIndex is int index)
@@ -4346,7 +4364,17 @@ public class App : Application
             }
             return new ProductsPage { DataContext = _productsPageViewModel };
         });
-        navigationService.RegisterPage("StockLevels", _ => new StockLevelsPage { DataContext = _stockLevelsPageViewModel ??= new StockLevelsPageViewModel() });
+        navigationService.RegisterPage("StockLevels", param =>
+        {
+            _stockLevelsPageViewModel ??= new StockLevelsPageViewModel();
+            _stockLevelsPageViewModel.HighlightTransactionId = null;
+            if (param is TransactionNavigationParameter navParam)
+            {
+                _stockLevelsPageViewModel.HighlightTransactionId = navParam.TransactionId;
+                _stockLevelsPageViewModel.ApplyHighlight();
+            }
+            return new StockLevelsPage { DataContext = _stockLevelsPageViewModel };
+        });
         navigationService.RegisterPage("Locations", param =>
         {
             _locationsPageViewModel ??= new LocationsPageViewModel();
@@ -4358,7 +4386,17 @@ public class App : Application
             return new LocationsPage { DataContext = _locationsPageViewModel };
         });
         navigationService.RegisterPage("StockAdjustments", _ => new StockAdjustmentsPage { DataContext = _stockAdjustmentsPageViewModel ??= new StockAdjustmentsPageViewModel() });
-        navigationService.RegisterPage("PurchaseOrders", _ => new PurchaseOrdersPage { DataContext = _purchaseOrdersPageViewModel ??= new PurchaseOrdersPageViewModel() });
+        navigationService.RegisterPage("PurchaseOrders", param =>
+        {
+            _purchaseOrdersPageViewModel ??= new PurchaseOrdersPageViewModel();
+            _purchaseOrdersPageViewModel.HighlightTransactionId = null;
+            if (param is TransactionNavigationParameter navParam)
+            {
+                _purchaseOrdersPageViewModel.HighlightTransactionId = navParam.TransactionId;
+                _purchaseOrdersPageViewModel.ApplyHighlight();
+            }
+            return new PurchaseOrdersPage { DataContext = _purchaseOrdersPageViewModel };
+        });
         navigationService.RegisterPage("Categories", param =>
         {
             _categoriesPageViewModel ??= new CategoriesPageViewModel();
@@ -4381,8 +4419,28 @@ public class App : Application
         });
 
         // Contacts Section
-        navigationService.RegisterPage("Customers", _ => new CustomersPage { DataContext = _customersPageViewModel ??= new CustomersPageViewModel() });
-        navigationService.RegisterPage("Suppliers", _ => new SuppliersPage { DataContext = _suppliersPageViewModel ??= new SuppliersPageViewModel() });
+        navigationService.RegisterPage("Customers", param =>
+        {
+            _customersPageViewModel ??= new CustomersPageViewModel();
+            _customersPageViewModel.HighlightTransactionId = null;
+            if (param is TransactionNavigationParameter navParam)
+            {
+                _customersPageViewModel.HighlightTransactionId = navParam.TransactionId;
+                _customersPageViewModel.ApplyHighlight();
+            }
+            return new CustomersPage { DataContext = _customersPageViewModel };
+        });
+        navigationService.RegisterPage("Suppliers", param =>
+        {
+            _suppliersPageViewModel ??= new SuppliersPageViewModel();
+            _suppliersPageViewModel.HighlightTransactionId = null;
+            if (param is TransactionNavigationParameter navParam)
+            {
+                _suppliersPageViewModel.HighlightTransactionId = navParam.TransactionId;
+                _suppliersPageViewModel.ApplyHighlight();
+            }
+            return new SuppliersPage { DataContext = _suppliersPageViewModel };
+        });
         navigationService.RegisterPage("Employees", _ => CreatePlaceholderPage("Employees", "Manage employee records"));
         navigationService.RegisterPage("Departments", _ => new DepartmentsPage { DataContext = _departmentsPageViewModel ??= new DepartmentsPageViewModel() });
         navigationService.RegisterPage("Accountants", _ => CreatePlaceholderPage("Accountants", "Manage accountant information"));

--- a/ArgoBooks/Panels/QuickActionsPanel.axaml
+++ b/ArgoBooks/Panels/QuickActionsPanel.axaml
@@ -63,6 +63,47 @@
                               HorizontalScrollBarVisibility="Disabled"
                               Height="380">
                     <StackPanel Spacing="0">
+                        <!-- Data Search Results Section -->
+                        <StackPanel IsVisible="{Binding HasSearchResults}">
+                            <TextBlock Text="{loc:Loc 'Results'}"
+                                       FontSize="11"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextTertiaryBrush}"
+                                       Margin="16,12,16,8" />
+                            <ItemsControl ItemsSource="{Binding SearchResults}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:QuickActionItem">
+                                        <Button Classes="action-item"
+                                                Command="{Binding $parent[UserControl].((vm:QuickActionsViewModel)DataContext).ExecuteActionCommand}"
+                                                CommandParameter="{Binding}">
+                                            <Grid ColumnDefinitions="Auto,*">
+                                                <Border Grid.Column="0"
+                                                        Width="36" Height="36"
+                                                        CornerRadius="8"
+                                                        Background="{DynamicResource PrimaryIconBgBrush}"
+                                                        Margin="0,0,12,0">
+                                                    <PathIcon Data="{Binding IconData}"
+                                                              Width="18" Height="18"
+                                                              Foreground="{DynamicResource PrimaryBrush}" />
+                                                </Border>
+                                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                                                    <TextBlock Text="{Binding Title}"
+                                                               FontSize="14"
+                                                               FontWeight="Medium"
+                                                               Foreground="{DynamicResource TextPrimaryBrush}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding Description}"
+                                                               FontSize="12"
+                                                               Foreground="{DynamicResource TextTertiaryBrush}"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                </StackPanel>
+                                            </Grid>
+                                        </Button>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+
                         <!-- Top Results Section (shown when searching with strong matches) -->
                         <StackPanel IsVisible="{Binding HasTopResults}">
                             <TextBlock Text="{loc:Loc 'Top Results'}"

--- a/ArgoBooks/ViewModels/AppShellViewModel.cs
+++ b/ArgoBooks/ViewModels/AppShellViewModel.cs
@@ -629,6 +629,16 @@ public partial class AppShellViewModel : ViewModelBase
                 case QuickActionName.OpenCheckForUpdates:
                     CheckForUpdateModalViewModel.OpenCommand.Execute(null);
                     break;
+                case QuickActionName.ViewSearchResult:
+                    var entityId = QuickActionNameExtensions.ParseSearchResultEntityId(e.ActionName);
+                    if (entityId != null)
+                    {
+                        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                        {
+                            DispatchSearchResultView(e.NavigationTarget, entityId);
+                        });
+                    }
+                    break;
             }
         };
 
@@ -670,6 +680,56 @@ public partial class AppShellViewModel : ViewModelBase
         {
             _reportsPageViewModel = null;
             ReportModalsViewModel.ReportsPageViewModel = null;
+        }
+    }
+
+    /// <summary>
+    /// Dispatches a search result view action: opens the view/edit modal for the given entity.
+    /// </summary>
+    private void DispatchSearchResultView(string? navigationTarget, string entityId)
+    {
+        var companyData = App.CompanyManager?.CompanyData;
+        if (companyData == null) return;
+
+        switch (NavigationTargetExtensions.ParseNavigationTarget(navigationTarget))
+        {
+            case NavigationTarget.Customers:
+                CustomerModalsViewModel.OpenEditModal(new CustomerDisplayItem { Id = entityId });
+                break;
+            case NavigationTarget.Products:
+                ProductModalsViewModel.OpenEditModal(new ProductDisplayItem { Id = entityId });
+                break;
+            case NavigationTarget.Invoices:
+                InvoiceModalsViewModel.OpenViewInvoice(entityId);
+                break;
+            case NavigationTarget.Expenses:
+                ExpenseModalsViewModel.OpenEditModal(new ExpenseDisplayItem { Id = entityId });
+                break;
+            case NavigationTarget.Revenue:
+                RevenueModalsViewModel.OpenEditModal(new RevenueDisplayItem { Id = entityId });
+                break;
+            case NavigationTarget.Suppliers:
+                SupplierModalsViewModel.OpenEditModal(new SupplierDisplayItem { Id = entityId });
+                break;
+            case NavigationTarget.Payments:
+                PaymentModalsViewModel.OpenEditModal(new PaymentDisplayItem { Id = entityId });
+                break;
+            case NavigationTarget.RentalRecords:
+                var rental = companyData.Rentals.FirstOrDefault(r => r.Id == entityId);
+                if (rental != null)
+                {
+                    var customerName = companyData.Customers.FirstOrDefault(c => c.Id == rental.CustomerId)?.Name ?? "";
+                    RentalRecordsModalsViewModel.OpenViewModal(new RentalRecordDisplayItem { Id = rental.Id, CustomerName = customerName, IsActive = rental.Status == Core.Enums.RentalStatus.Active || rental.Status == Core.Enums.RentalStatus.Overdue });
+                }
+                break;
+            case NavigationTarget.PurchaseOrders:
+                var po = companyData.PurchaseOrders.FirstOrDefault(p => p.Id == entityId);
+                if (po != null)
+                {
+                    var poSupplier = companyData.Suppliers.FirstOrDefault(s => s.Id == po.SupplierId)?.Name ?? "";
+                    App.PurchaseOrdersModalsViewModel?.OpenViewModal(new PurchaseOrderDisplayItem { Id = po.Id, PoNumber = po.PoNumber, SupplierName = poSupplier });
+                }
+                break;
         }
     }
 

--- a/ArgoBooks/ViewModels/AppShellViewModel.cs
+++ b/ArgoBooks/ViewModels/AppShellViewModel.cs
@@ -629,16 +629,6 @@ public partial class AppShellViewModel : ViewModelBase
                 case QuickActionName.OpenCheckForUpdates:
                     CheckForUpdateModalViewModel.OpenCommand.Execute(null);
                     break;
-                case QuickActionName.ViewSearchResult:
-                    var entityId = QuickActionNameExtensions.ParseSearchResultEntityId(e.ActionName);
-                    if (entityId != null)
-                    {
-                        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-                        {
-                            DispatchSearchResultView(e.NavigationTarget, entityId);
-                        });
-                    }
-                    break;
             }
         };
 
@@ -680,56 +670,6 @@ public partial class AppShellViewModel : ViewModelBase
         {
             _reportsPageViewModel = null;
             ReportModalsViewModel.ReportsPageViewModel = null;
-        }
-    }
-
-    /// <summary>
-    /// Dispatches a search result view action: opens the view/edit modal for the given entity.
-    /// </summary>
-    private void DispatchSearchResultView(string? navigationTarget, string entityId)
-    {
-        var companyData = App.CompanyManager?.CompanyData;
-        if (companyData == null) return;
-
-        switch (NavigationTargetExtensions.ParseNavigationTarget(navigationTarget))
-        {
-            case NavigationTarget.Customers:
-                CustomerModalsViewModel.OpenEditModal(new CustomerDisplayItem { Id = entityId });
-                break;
-            case NavigationTarget.Products:
-                ProductModalsViewModel.OpenEditModal(new ProductDisplayItem { Id = entityId });
-                break;
-            case NavigationTarget.Invoices:
-                InvoiceModalsViewModel.OpenViewInvoice(entityId);
-                break;
-            case NavigationTarget.Expenses:
-                ExpenseModalsViewModel.OpenEditModal(new ExpenseDisplayItem { Id = entityId });
-                break;
-            case NavigationTarget.Revenue:
-                RevenueModalsViewModel.OpenEditModal(new RevenueDisplayItem { Id = entityId });
-                break;
-            case NavigationTarget.Suppliers:
-                SupplierModalsViewModel.OpenEditModal(new SupplierDisplayItem { Id = entityId });
-                break;
-            case NavigationTarget.Payments:
-                PaymentModalsViewModel.OpenEditModal(new PaymentDisplayItem { Id = entityId });
-                break;
-            case NavigationTarget.RentalRecords:
-                var rental = companyData.Rentals.FirstOrDefault(r => r.Id == entityId);
-                if (rental != null)
-                {
-                    var customerName = companyData.Customers.FirstOrDefault(c => c.Id == rental.CustomerId)?.Name ?? "";
-                    RentalRecordsModalsViewModel.OpenViewModal(new RentalRecordDisplayItem { Id = rental.Id, CustomerName = customerName, IsActive = rental.Status == Core.Enums.RentalStatus.Active || rental.Status == Core.Enums.RentalStatus.Overdue });
-                }
-                break;
-            case NavigationTarget.PurchaseOrders:
-                var po = companyData.PurchaseOrders.FirstOrDefault(p => p.Id == entityId);
-                if (po != null)
-                {
-                    var poSupplier = companyData.Suppliers.FirstOrDefault(s => s.Id == po.SupplierId)?.Name ?? "";
-                    App.PurchaseOrdersModalsViewModel?.OpenViewModal(new PurchaseOrderDisplayItem { Id = po.Id, PoNumber = po.PoNumber, SupplierName = poSupplier });
-                }
-                break;
         }
     }
 

--- a/ArgoBooks/ViewModels/CustomersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomersPageViewModel.cs
@@ -435,7 +435,8 @@ public partial class CustomersPageViewModel : SortablePageViewModelBase
                 Address = addressString,
                 Country = string.IsNullOrWhiteSpace(customer.Address.Country) ? "-" : customer.Address.Country,
                 LastRental = customer.LastTransactionDate,
-                Status = customer.Status
+                Status = customer.Status,
+                IsHighlighted = customer.Id == HighlightTransactionId
             };
         }).ToList();
 
@@ -455,6 +456,9 @@ public partial class CustomersPageViewModel : SortablePageViewModelBase
                 },
                 c => c.Name);
         }
+
+        // Navigate to highlighted item if set
+        NavigateToHighlightedItem(displayItems, x => x.Id);
 
         // Calculate pagination
         var totalCount = displayItems.Count;
@@ -937,6 +941,9 @@ public partial class CustomerDisplayItem : ObservableObject
     /// Gets the formatted last rental date.
     /// </summary>
     public string LastRentalFormatted => LastRental?.ToString("MMM d, yyyy") ?? "-";
+
+    [ObservableProperty]
+    private bool _isHighlighted;
 }
 
 /// <summary>

--- a/ArgoBooks/ViewModels/HeaderViewModel.cs
+++ b/ArgoBooks/ViewModels/HeaderViewModel.cs
@@ -316,27 +316,6 @@ public partial class HeaderViewModel : ViewModelBase
     #region Commands
 
     /// <summary>
-    /// Performs a global search.
-    /// </summary>
-    [RelayCommand]
-    private void Search()
-    {
-        if (string.IsNullOrWhiteSpace(SearchQuery))
-            return;
-
-        _navigationService?.NavigateTo("Search", new Dictionary<string, object?> { { "query", SearchQuery } });
-    }
-
-    /// <summary>
-    /// Clears the search query.
-    /// </summary>
-    [RelayCommand]
-    private void ClearSearch()
-    {
-        SearchQuery = null;
-    }
-
-    /// <summary>
     /// Opens the quick actions panel.
     /// </summary>
     [RelayCommand]

--- a/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
@@ -662,7 +662,8 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
                 StatusDisplay = statusDisplay,
                 Notes = invoice.Notes,
                 OriginalCurrency = invoice.OriginalCurrency,
-                IsRecurring = !string.IsNullOrEmpty(invoice.RecurringInvoiceId)
+                IsRecurring = !string.IsNullOrEmpty(invoice.RecurringInvoiceId),
+                IsHighlighted = invoice.Id == HighlightTransactionId
             };
         }).ToList();
 
@@ -683,6 +684,9 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
                 },
                 i => i.IssueDate);
         }
+
+        // Navigate to highlighted item if set
+        NavigateToHighlightedItem(displayItems, x => x.Id);
 
         // Calculate pagination
         var totalCount = displayItems.Count;
@@ -907,6 +911,9 @@ public partial class InvoiceDisplayItem : ObservableObject
     /// Whether this invoice can be sent via email (not drafts or cancelled).
     /// </summary>
     public bool CanSend => Status != InvoiceStatus.Draft && Status != InvoiceStatus.Cancelled;
+
+    [ObservableProperty]
+    private bool _isHighlighted;
 }
 
 /// <summary>

--- a/ArgoBooks/ViewModels/PaymentsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/PaymentsPageViewModel.cs
@@ -684,6 +684,7 @@ public partial class PaymentsPageViewModel : SortablePageViewModelBase
                 ReferenceNumber = payment.ReferenceNumber,
                 Notes = payment.Notes,
                 IsFromPortal = payment.Source == "Online",
+                IsHighlighted = payment.Id == HighlightTransactionId
             };
         }).ToList();
 
@@ -705,6 +706,9 @@ public partial class PaymentsPageViewModel : SortablePageViewModelBase
                 },
                 p => p.Date);
         }
+
+        // Navigate to highlighted item if set
+        NavigateToHighlightedItem(displayItems, x => x.Id);
 
         // Calculate pagination
         var totalCount = displayItems.Count;
@@ -851,6 +855,9 @@ public partial class PaymentDisplayItem : ObservableObject
     /// Gets whether the amount is negative (refund).
     /// </summary>
     public bool IsRefund => Amount < 0;
+
+    [ObservableProperty]
+    private bool _isHighlighted;
 }
 
 /// <summary>

--- a/ArgoBooks/ViewModels/ProductsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ProductsPageViewModel.cs
@@ -648,7 +648,8 @@ public partial class ProductsPageViewModel : SortablePageViewModelBase
                 OverstockThreshold = product.TrackInventory && product.OverstockThreshold > 0 ? product.OverstockThreshold.ToString() : "-",
                 UnitPrice = product.UnitPrice,
                 CostPrice = product.CostPrice,
-                TrackInventory = product.TrackInventory
+                TrackInventory = product.TrackInventory,
+                IsHighlighted = product.Id == HighlightTransactionId
             };
         }).ToList();
 
@@ -668,6 +669,9 @@ public partial class ProductsPageViewModel : SortablePageViewModelBase
                 },
                 p => p.Name);
         }
+
+        // Navigate to highlighted item if set
+        NavigateToHighlightedItem(displayItems, x => x.Id);
 
         // Calculate pagination
         var totalCount = displayItems.Count;
@@ -1143,6 +1147,9 @@ public partial class ProductDisplayItem : ObservableObject
     /// CSS-like badge class for item type.
     /// </summary>
     public string TypeBadgeClass => ItemType == "Product" ? "info" : "secondary";
+
+    [ObservableProperty]
+    private bool _isHighlighted;
 }
 
 /// <summary>

--- a/ArgoBooks/ViewModels/PurchaseOrdersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/PurchaseOrdersPageViewModel.cs
@@ -411,7 +411,8 @@ public partial class PurchaseOrdersPageViewModel : SortablePageViewModelBase
                 ExpectedDisplay = order.ExpectedDeliveryDate.ToString("MMM dd, yyyy"),
                 Notes = order.Notes,
                 CreatedAt = order.CreatedAt,
-                UpdatedAt = order.UpdatedAt
+                UpdatedAt = order.UpdatedAt,
+                IsHighlighted = order.Id == HighlightTransactionId
             };
         }).ToList();
 
@@ -433,6 +434,9 @@ public partial class PurchaseOrdersPageViewModel : SortablePageViewModelBase
                 },
                 o => o.OrderDate);
         }
+
+        // Navigate to highlighted item if set
+        NavigateToHighlightedItem(displayItems, x => x.Id);
 
         // Calculate pagination
         var totalCount = displayItems.Count;
@@ -715,4 +719,7 @@ public partial class PurchaseOrderDisplayItem : ObservableObject
     /// Whether the order can be edited.
     /// </summary>
     public bool CanEdit => Status == PurchaseOrderStatus.Draft || Status == PurchaseOrderStatus.Pending;
+
+    [ObservableProperty]
+    private bool _isHighlighted;
 }

--- a/ArgoBooks/ViewModels/QuickActionsViewModel.cs
+++ b/ArgoBooks/ViewModels/QuickActionsViewModel.cs
@@ -398,13 +398,9 @@ public partial class QuickActionsViewModel : ViewModelBase
         if (!string.IsNullOrEmpty(action.NavigationTarget))
         {
             // For search results, navigate with highlight parameter
-            if (action.Type == QuickActionType.SearchResult && action.ActionName != null)
+            if (action.Type == QuickActionType.SearchResult && action.EntityId != null)
             {
-                var entityId = Core.Enums.QuickActionNameExtensions.ParseSearchResultEntityId(action.ActionName);
-                if (entityId != null)
-                {
-                    _navigationService?.NavigateTo(action.NavigationTarget, new TransactionNavigationParameter(entityId));
-                }
+                _navigationService?.NavigateTo(action.NavigationTarget, new TransactionNavigationParameter(action.EntityId));
             }
             else
             {
@@ -412,8 +408,8 @@ public partial class QuickActionsViewModel : ViewModelBase
             }
         }
 
-        // Execute action after navigation if specified
-        if (!string.IsNullOrEmpty(action.ActionName))
+        // Execute action after navigation if specified (not for search results)
+        if (action.Type != QuickActionType.SearchResult && !string.IsNullOrEmpty(action.ActionName))
         {
             ActionRequested?.Invoke(this, new QuickActionEventArgs(action.NavigationTarget, action.ActionName));
         }
@@ -481,7 +477,7 @@ public partial class QuickActionsViewModel : ViewModelBase
         {
             var score = BestScore(query, c.Name, c.CompanyName ?? "", c.Email, c.Phone);
             if (score > 0)
-                results.Add((new QuickActionItem(c.Name, string.IsNullOrWhiteSpace(c.CompanyName) ? c.Email : c.CompanyName, Icons.Customers, QuickActionType.SearchResult, "Customers", $"ViewSearchResult:{c.Id}"), score));
+                results.Add((new QuickActionItem(c.Name, string.IsNullOrWhiteSpace(c.CompanyName) ? c.Email : c.CompanyName, Icons.Customers, QuickActionType.SearchResult, "Customers", entityId: c.Id), score));
         }
 
         // Products
@@ -489,7 +485,7 @@ public partial class QuickActionsViewModel : ViewModelBase
         {
             var score = BestScore(query, p.Name, p.Sku, p.Description);
             if (score > 0)
-                results.Add((new QuickActionItem(p.Name, string.IsNullOrWhiteSpace(p.Sku) ? p.Description : $"SKU: {p.Sku}", Icons.Products, QuickActionType.SearchResult, "Products", $"ViewSearchResult:{p.Id}"), score));
+                results.Add((new QuickActionItem(p.Name, string.IsNullOrWhiteSpace(p.Sku) ? p.Description : $"SKU: {p.Sku}", Icons.Products, QuickActionType.SearchResult, "Products", entityId: p.Id), score));
         }
 
         // Invoices
@@ -498,7 +494,7 @@ public partial class QuickActionsViewModel : ViewModelBase
             var customerName = companyData.Customers.FirstOrDefault(c => c.Id == inv.CustomerId)?.Name ?? "";
             var score = BestScore(query, inv.InvoiceNumber, customerName, inv.Status.ToString());
             if (score > 0)
-                results.Add((new QuickActionItem(inv.InvoiceNumber, $"{customerName} · {inv.Status}", Icons.Invoices, QuickActionType.SearchResult, "Invoices", $"ViewSearchResult:{inv.Id}"), score));
+                results.Add((new QuickActionItem(inv.InvoiceNumber, $"{customerName} · {inv.Status}", Icons.Invoices, QuickActionType.SearchResult, "Invoices", entityId: inv.Id), score));
         }
 
         // Expenses
@@ -506,7 +502,7 @@ public partial class QuickActionsViewModel : ViewModelBase
         {
             var score = BestScore(query, e.Description, e.ReferenceNumber, e.Id);
             if (score > 0)
-                results.Add((new QuickActionItem(e.Description, $"{CurrencyService.Format(e.Amount)} · {e.Date:MMM dd, yyyy}", Icons.Expenses, QuickActionType.SearchResult, "Expenses", $"ViewSearchResult:{e.Id}"), score));
+                results.Add((new QuickActionItem(e.Description, $"{CurrencyService.Format(e.Amount)} · {e.Date:MMM dd, yyyy}", Icons.Expenses, QuickActionType.SearchResult, "Expenses", entityId: e.Id), score));
         }
 
         // Revenues
@@ -514,7 +510,7 @@ public partial class QuickActionsViewModel : ViewModelBase
         {
             var score = BestScore(query, r.Description, r.ReferenceNumber, r.Id);
             if (score > 0)
-                results.Add((new QuickActionItem(r.Description, $"{CurrencyService.Format(r.Amount)} · {r.Date:MMM dd, yyyy}", Icons.Revenue, QuickActionType.SearchResult, "Revenue", $"ViewSearchResult:{r.Id}"), score));
+                results.Add((new QuickActionItem(r.Description, $"{CurrencyService.Format(r.Amount)} · {r.Date:MMM dd, yyyy}", Icons.Revenue, QuickActionType.SearchResult, "Revenue", entityId: r.Id), score));
         }
 
         // Suppliers
@@ -522,7 +518,7 @@ public partial class QuickActionsViewModel : ViewModelBase
         {
             var score = BestScore(query, s.Name, s.ContactPerson, s.Email);
             if (score > 0)
-                results.Add((new QuickActionItem(s.Name, string.IsNullOrWhiteSpace(s.ContactPerson) ? s.Email : s.ContactPerson, Icons.Suppliers, QuickActionType.SearchResult, "Suppliers", $"ViewSearchResult:{s.Id}"), score));
+                results.Add((new QuickActionItem(s.Name, string.IsNullOrWhiteSpace(s.ContactPerson) ? s.Email : s.ContactPerson, Icons.Suppliers, QuickActionType.SearchResult, "Suppliers", entityId: s.Id), score));
         }
 
         // Payments
@@ -530,7 +526,7 @@ public partial class QuickActionsViewModel : ViewModelBase
         {
             var score = BestScore(query, p.Id, p.ReferenceNumber ?? "", p.InvoiceId);
             if (score > 0)
-                results.Add((new QuickActionItem(p.Id, $"{CurrencyService.Format(p.Amount)} · {p.PaymentMethod}", Icons.Payments, QuickActionType.SearchResult, "Payments", $"ViewSearchResult:{p.Id}"), score));
+                results.Add((new QuickActionItem(p.Id, $"{CurrencyService.Format(p.Amount)} · {p.PaymentMethod}", Icons.Payments, QuickActionType.SearchResult, "Payments", entityId: p.Id), score));
         }
 
         // Rental Records
@@ -539,7 +535,7 @@ public partial class QuickActionsViewModel : ViewModelBase
             var customerName = companyData.Customers.FirstOrDefault(c => c.Id == r.CustomerId)?.Name ?? "";
             var score = BestScore(query, r.Id, customerName, r.Status.ToString());
             if (score > 0)
-                results.Add((new QuickActionItem(r.Id, $"{customerName} · {r.Status}", Icons.RentalRecords, QuickActionType.SearchResult, "RentalRecords", $"ViewSearchResult:{r.Id}"), score));
+                results.Add((new QuickActionItem(r.Id, $"{customerName} · {r.Status}", Icons.RentalRecords, QuickActionType.SearchResult, "RentalRecords", entityId: r.Id), score));
         }
 
         // Inventory Items
@@ -550,7 +546,7 @@ public partial class QuickActionsViewModel : ViewModelBase
             var productName = product?.Name ?? "";
             var score = BestScore(query, productName, i.Sku, product?.Sku ?? "", location?.Name ?? "");
             if (score > 0)
-                results.Add((new QuickActionItem($"{productName} @ {location?.Name ?? "Default"}", $"SKU: {i.Sku} · In Stock: {i.InStock}", Icons.StockLevels, QuickActionType.SearchResult, "StockLevels", $"ViewSearchResult:{i.Id}"), score));
+                results.Add((new QuickActionItem($"{productName} @ {location?.Name ?? "Default"}", $"SKU: {i.Sku} · In Stock: {i.InStock}", Icons.StockLevels, QuickActionType.SearchResult, "StockLevels", entityId: i.Id), score));
         }
 
         // Purchase Orders
@@ -559,7 +555,7 @@ public partial class QuickActionsViewModel : ViewModelBase
             var supplierName = companyData.Suppliers.FirstOrDefault(s => s.Id == po.SupplierId)?.Name ?? "";
             var score = BestScore(query, po.PoNumber, supplierName, po.Status.ToString());
             if (score > 0)
-                results.Add((new QuickActionItem(po.PoNumber, $"{supplierName} · {po.Status}", Icons.PurchaseOrders, QuickActionType.SearchResult, "PurchaseOrders", $"ViewSearchResult:{po.Id}"), score));
+                results.Add((new QuickActionItem(po.PoNumber, $"{supplierName} · {po.Status}", Icons.PurchaseOrders, QuickActionType.SearchResult, "PurchaseOrders", entityId: po.Id), score));
         }
 
         // Sort by score and take top results, max 3 per type
@@ -631,9 +627,14 @@ public class QuickActionItem
     public string? ActionName { get; }
 
     /// <summary>
+    /// Entity ID for search results (used for row highlighting on navigation).
+    /// </summary>
+    public string? EntityId { get; }
+
+    /// <summary>
     /// Creates a new QuickActionItem.
     /// </summary>
-    public QuickActionItem(string title, string description, string iconData, QuickActionType type, string? navigationTarget = null, string? actionName = null)
+    public QuickActionItem(string title, string description, string iconData, QuickActionType type, string? navigationTarget = null, string? actionName = null, string? entityId = null)
     {
         Title = title;
         Description = description;
@@ -641,6 +642,7 @@ public class QuickActionItem
         Type = type;
         NavigationTarget = navigationTarget;
         ActionName = actionName;
+        EntityId = entityId;
     }
 }
 

--- a/ArgoBooks/ViewModels/QuickActionsViewModel.cs
+++ b/ArgoBooks/ViewModels/QuickActionsViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using ArgoBooks.Core.Models.Inventory;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
@@ -56,6 +57,16 @@ public partial class QuickActionsViewModel : ViewModelBase
     public ObservableCollection<QuickActionItem> TopResults { get; } = [];
 
     /// <summary>
+    /// Data search results from CompanyData (customers, products, invoices, etc.).
+    /// </summary>
+    public ObservableCollection<QuickActionItem> SearchResults { get; } = [];
+
+    /// <summary>
+    /// Gets whether there are any data search results visible.
+    /// </summary>
+    public bool HasSearchResults => SearchResults.Count > 0;
+
+    /// <summary>
     /// Gets whether there are any top results visible.
     /// </summary>
     public bool HasTopResults => TopResults.Count > 0;
@@ -78,7 +89,7 @@ public partial class QuickActionsViewModel : ViewModelBase
     /// <summary>
     /// Gets whether there are any results at all.
     /// </summary>
-    public bool HasResults => HasTopResults || HasQuickActions || HasNavigationItems || HasToolsItems;
+    public bool HasResults => HasSearchResults || HasTopResults || HasQuickActions || HasNavigationItems || HasToolsItems;
 
     #endregion
 
@@ -223,6 +234,7 @@ public partial class QuickActionsViewModel : ViewModelBase
         NavigationItems.Clear();
         ToolsItems.Clear();
         TopResults.Clear();
+        SearchResults.Clear();
 
         IEnumerable<(QuickActionItem Item, double Score, double TitleScore)> scoredItems;
 
@@ -310,6 +322,13 @@ public partial class QuickActionsViewModel : ViewModelBase
                 ToolsItems.Add(item);
         }
 
+        // Search CompanyData when there's a query
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            SearchCompanyData(query);
+        }
+
+        OnPropertyChanged(nameof(HasSearchResults));
         OnPropertyChanged(nameof(HasTopResults));
         OnPropertyChanged(nameof(HasQuickActions));
         OnPropertyChanged(nameof(HasNavigationItems));
@@ -378,7 +397,19 @@ public partial class QuickActionsViewModel : ViewModelBase
 
         if (!string.IsNullOrEmpty(action.NavigationTarget))
         {
-            _navigationService?.NavigateTo(action.NavigationTarget);
+            // For search results, navigate with highlight parameter
+            if (action.Type == QuickActionType.SearchResult && action.ActionName != null)
+            {
+                var entityId = Core.Enums.QuickActionNameExtensions.ParseSearchResultEntityId(action.ActionName);
+                if (entityId != null)
+                {
+                    _navigationService?.NavigateTo(action.NavigationTarget, new TransactionNavigationParameter(entityId));
+                }
+            }
+            else
+            {
+                _navigationService?.NavigateTo(action.NavigationTarget);
+            }
         }
 
         // Execute action after navigation if specified
@@ -399,7 +430,7 @@ public partial class QuickActionsViewModel : ViewModelBase
     [RelayCommand]
     private void MoveUp()
     {
-        var totalCount = TopResults.Count + QuickActions.Count + NavigationItems.Count + ToolsItems.Count;
+        var totalCount = SearchResults.Count + TopResults.Count + QuickActions.Count + NavigationItems.Count + ToolsItems.Count;
         if (totalCount == 0) return;
         SelectedIndex = (SelectedIndex - 1 + totalCount) % totalCount;
     }
@@ -410,7 +441,7 @@ public partial class QuickActionsViewModel : ViewModelBase
     [RelayCommand]
     private void MoveDown()
     {
-        var totalCount = TopResults.Count + QuickActions.Count + NavigationItems.Count + ToolsItems.Count;
+        var totalCount = SearchResults.Count + TopResults.Count + QuickActions.Count + NavigationItems.Count + ToolsItems.Count;
         if (totalCount == 0) return;
         SelectedIndex = (SelectedIndex + 1) % totalCount;
     }
@@ -421,11 +452,144 @@ public partial class QuickActionsViewModel : ViewModelBase
     [RelayCommand]
     private void ExecuteSelected()
     {
-        var allItems = TopResults.Concat(QuickActions).Concat(NavigationItems).Concat(ToolsItems).ToList();
+        var allItems = SearchResults.Concat(TopResults).Concat(QuickActions).Concat(NavigationItems).Concat(ToolsItems).ToList();
         if (SelectedIndex >= 0 && SelectedIndex < allItems.Count)
         {
             ExecuteAction(allItems[SelectedIndex]);
         }
+    }
+
+    #endregion
+
+    #region Data Search
+
+    private const int MaxResultsPerType = 3;
+    private const int MaxTotalResults = 15;
+
+    /// <summary>
+    /// Searches CompanyData collections and populates SearchResults.
+    /// </summary>
+    private void SearchCompanyData(string query)
+    {
+        var companyData = App.CompanyManager?.CompanyData;
+        if (companyData == null) return;
+
+        var results = new List<(QuickActionItem Item, double Score)>();
+
+        // Customers
+        foreach (var c in companyData.Customers)
+        {
+            var score = BestScore(query, c.Name, c.CompanyName ?? "", c.Email, c.Phone);
+            if (score > 0)
+                results.Add((new QuickActionItem(c.Name, string.IsNullOrWhiteSpace(c.CompanyName) ? c.Email : c.CompanyName, Icons.Customers, QuickActionType.SearchResult, "Customers", $"ViewSearchResult:{c.Id}"), score));
+        }
+
+        // Products
+        foreach (var p in companyData.Products)
+        {
+            var score = BestScore(query, p.Name, p.Sku, p.Description);
+            if (score > 0)
+                results.Add((new QuickActionItem(p.Name, string.IsNullOrWhiteSpace(p.Sku) ? p.Description : $"SKU: {p.Sku}", Icons.Products, QuickActionType.SearchResult, "Products", $"ViewSearchResult:{p.Id}"), score));
+        }
+
+        // Invoices
+        foreach (var inv in companyData.Invoices)
+        {
+            var customerName = companyData.Customers.FirstOrDefault(c => c.Id == inv.CustomerId)?.Name ?? "";
+            var score = BestScore(query, inv.InvoiceNumber, customerName, inv.Status.ToString());
+            if (score > 0)
+                results.Add((new QuickActionItem(inv.InvoiceNumber, $"{customerName} · {inv.Status}", Icons.Invoices, QuickActionType.SearchResult, "Invoices", $"ViewSearchResult:{inv.Id}"), score));
+        }
+
+        // Expenses
+        foreach (var e in companyData.Expenses)
+        {
+            var score = BestScore(query, e.Description, e.ReferenceNumber, e.Id);
+            if (score > 0)
+                results.Add((new QuickActionItem(e.Description, $"{CurrencyService.Format(e.Amount)} · {e.Date:MMM dd, yyyy}", Icons.Expenses, QuickActionType.SearchResult, "Expenses", $"ViewSearchResult:{e.Id}"), score));
+        }
+
+        // Revenues
+        foreach (var r in companyData.Revenues)
+        {
+            var score = BestScore(query, r.Description, r.ReferenceNumber, r.Id);
+            if (score > 0)
+                results.Add((new QuickActionItem(r.Description, $"{CurrencyService.Format(r.Amount)} · {r.Date:MMM dd, yyyy}", Icons.Revenue, QuickActionType.SearchResult, "Revenue", $"ViewSearchResult:{r.Id}"), score));
+        }
+
+        // Suppliers
+        foreach (var s in companyData.Suppliers)
+        {
+            var score = BestScore(query, s.Name, s.ContactPerson, s.Email);
+            if (score > 0)
+                results.Add((new QuickActionItem(s.Name, string.IsNullOrWhiteSpace(s.ContactPerson) ? s.Email : s.ContactPerson, Icons.Suppliers, QuickActionType.SearchResult, "Suppliers", $"ViewSearchResult:{s.Id}"), score));
+        }
+
+        // Payments
+        foreach (var p in companyData.Payments)
+        {
+            var score = BestScore(query, p.Id, p.ReferenceNumber ?? "", p.InvoiceId);
+            if (score > 0)
+                results.Add((new QuickActionItem(p.Id, $"{CurrencyService.Format(p.Amount)} · {p.PaymentMethod}", Icons.Payments, QuickActionType.SearchResult, "Payments", $"ViewSearchResult:{p.Id}"), score));
+        }
+
+        // Rental Records
+        foreach (var r in companyData.Rentals)
+        {
+            var customerName = companyData.Customers.FirstOrDefault(c => c.Id == r.CustomerId)?.Name ?? "";
+            var score = BestScore(query, r.Id, customerName, r.Status.ToString());
+            if (score > 0)
+                results.Add((new QuickActionItem(r.Id, $"{customerName} · {r.Status}", Icons.RentalRecords, QuickActionType.SearchResult, "RentalRecords", $"ViewSearchResult:{r.Id}"), score));
+        }
+
+        // Inventory Items
+        foreach (var i in companyData.Inventory)
+        {
+            var product = companyData.Products.FirstOrDefault(p => p.Id == i.ProductId);
+            var location = companyData.Locations.FirstOrDefault(l => l.Id == i.LocationId);
+            var productName = product?.Name ?? "";
+            var score = BestScore(query, productName, i.Sku, product?.Sku ?? "", location?.Name ?? "");
+            if (score > 0)
+                results.Add((new QuickActionItem($"{productName} @ {location?.Name ?? "Default"}", $"SKU: {i.Sku} · In Stock: {i.InStock}", Icons.StockLevels, QuickActionType.SearchResult, "StockLevels", $"ViewSearchResult:{i.Id}"), score));
+        }
+
+        // Purchase Orders
+        foreach (var po in companyData.PurchaseOrders)
+        {
+            var supplierName = companyData.Suppliers.FirstOrDefault(s => s.Id == po.SupplierId)?.Name ?? "";
+            var score = BestScore(query, po.PoNumber, supplierName, po.Status.ToString());
+            if (score > 0)
+                results.Add((new QuickActionItem(po.PoNumber, $"{supplierName} · {po.Status}", Icons.PurchaseOrders, QuickActionType.SearchResult, "PurchaseOrders", $"ViewSearchResult:{po.Id}"), score));
+        }
+
+        // Sort by score and take top results, max 3 per type
+        var typeCounts = new Dictionary<string, int>();
+        var added = 0;
+        foreach (var (item, _) in results.OrderByDescending(r => r.Score))
+        {
+            if (added >= MaxTotalResults) break;
+            var key = item.NavigationTarget ?? "";
+            typeCounts.TryGetValue(key, out var count);
+            if (count >= MaxResultsPerType) continue;
+            typeCounts[key] = count + 1;
+            SearchResults.Add(item);
+            added++;
+        }
+    }
+
+    /// <summary>
+    /// Returns the best fuzzy search score across multiple fields.
+    /// </summary>
+    private static double BestScore(string query, params string[] fields)
+    {
+        double best = -1;
+        foreach (var field in fields)
+        {
+            if (string.IsNullOrEmpty(field)) continue;
+            var score = LevenshteinDistance.ComputeSearchScore(query, field);
+            if (score > best) best = score;
+        }
+        return best;
     }
 
     #endregion
@@ -498,7 +662,12 @@ public enum QuickActionType
     /// <summary>
     /// Tools and settings.
     /// </summary>
-    Tools
+    Tools,
+
+    /// <summary>
+    /// Data search result from CompanyData.
+    /// </summary>
+    SearchResult
 }
 
 /// <summary>

--- a/ArgoBooks/ViewModels/StockLevelsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/StockLevelsPageViewModel.cs
@@ -487,7 +487,8 @@ public partial class StockLevelsPageViewModel : SortablePageViewModelBase
                 StatusText = GetStatusText(status),
                 StatusColor = GetStatusColor(status),
                 StatusBackground = GetStatusBackground(status),
-                LastUpdated = item.LastUpdated
+                LastUpdated = item.LastUpdated,
+                IsHighlighted = item.Id == HighlightTransactionId
             };
         }).ToList();
 
@@ -511,6 +512,9 @@ public partial class StockLevelsPageViewModel : SortablePageViewModelBase
                 },
                 i => i.ProductName);
         }
+
+        // Navigate to highlighted item if set
+        NavigateToHighlightedItem(displayItems, x => x.Id);
 
         // Calculate pagination
         var totalCount = displayItems.Count;
@@ -690,4 +694,7 @@ public partial class StockLevelDisplayItem : ObservableObject
 
     [ObservableProperty]
     private DateTime _lastUpdated;
+
+    [ObservableProperty]
+    private bool _isHighlighted;
 }

--- a/ArgoBooks/ViewModels/SuppliersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/SuppliersPageViewModel.cs
@@ -499,7 +499,8 @@ public partial class SuppliersPageViewModel : SortablePageViewModelBase
                 Country = string.IsNullOrWhiteSpace(supplier.Address.Country) ? "-" : supplier.Address.Country,
                 ProductCount = productCount,
                 IsActive = isActive,
-                Initials = GetInitials(supplier.Name)
+                Initials = GetInitials(supplier.Name),
+                IsHighlighted = supplier.Id == HighlightTransactionId
             };
         }).ToList();
 
@@ -521,6 +522,9 @@ public partial class SuppliersPageViewModel : SortablePageViewModelBase
                 },
                 s => s.Name);
         }
+
+        // Navigate to highlighted item if set
+        NavigateToHighlightedItem(displayItems, x => x.Id);
 
         // Calculate pagination
         var totalItems = displayItems.Count;
@@ -1030,4 +1034,7 @@ public partial class SupplierDisplayItem : ObservableObject
     /// Status text for display.
     /// </summary>
     public string StatusText => IsActive ? "Active" : "Inactive";
+
+    [ObservableProperty]
+    private bool _isHighlighted;
 }

--- a/ArgoBooks/Views/CustomersPage.axaml
+++ b/ArgoBooks/Views/CustomersPage.axaml
@@ -125,6 +125,7 @@
                                 <Border Padding="24,0"
                                         BorderBrush="{DynamicResource BorderBrush}"
                                         BorderThickness="0,0,0,1"
+                                        Classes.highlighted-row="{Binding IsHighlighted}"
                                         MinHeight="52">
                                     <StackPanel Orientation="Horizontal">
                                         <!-- Customer Name with Avatar - Custom content required -->

--- a/ArgoBooks/Views/InvoicesPage.axaml
+++ b/ArgoBooks/Views/InvoicesPage.axaml
@@ -211,6 +211,7 @@
                                 <Border Padding="24,0"
                                         BorderBrush="{DynamicResource BorderBrush}"
                                         BorderThickness="0,0,0,1"
+                                        Classes.highlighted-row="{Binding IsHighlighted}"
                                         MinHeight="56">
                                     <StackPanel Orientation="Horizontal">
                                         <!-- Invoice # -->

--- a/ArgoBooks/Views/PaymentsPage.axaml
+++ b/ArgoBooks/Views/PaymentsPage.axaml
@@ -298,6 +298,7 @@
                                 <Border Padding="24,0"
                                         BorderBrush="{DynamicResource BorderBrush}"
                                         BorderThickness="0,0,0,1"
+                                        Classes.highlighted-row="{Binding IsHighlighted}"
                                         MinHeight="56">
                                     <StackPanel Orientation="Horizontal">
                                         <!-- Payment ID - Simple text cell -->

--- a/ArgoBooks/Views/ProductsPage.axaml
+++ b/ArgoBooks/Views/ProductsPage.axaml
@@ -220,6 +220,7 @@
                                     <Border Padding="24,0"
                                             BorderBrush="{DynamicResource BorderBrush}"
                                             BorderThickness="0,0,0,1"
+                                            Classes.highlighted-row="{Binding IsHighlighted}"
                                             MinHeight="52">
                                         <StackPanel Orientation="Horizontal">
                                             <!-- Product Name with ID - Custom content required -->
@@ -312,6 +313,7 @@
                                     <Border Padding="24,0"
                                             BorderBrush="{DynamicResource BorderBrush}"
                                             BorderThickness="0,0,0,1"
+                                            Classes.highlighted-row="{Binding IsHighlighted}"
                                             MinHeight="52">
                                         <StackPanel Orientation="Horizontal">
                                             <!-- Product Name with ID - Custom content required -->

--- a/ArgoBooks/Views/PurchaseOrdersPage.axaml
+++ b/ArgoBooks/Views/PurchaseOrdersPage.axaml
@@ -147,6 +147,7 @@
                                     <Border Padding="24,0"
                                             BorderBrush="{DynamicResource BorderBrush}"
                                             BorderThickness="0,0,0,1"
+                                            Classes.highlighted-row="{Binding IsHighlighted}"
                                             MinHeight="52">
                                         <StackPanel Orientation="Horizontal">
                                             <!-- PO Number - Custom content for monospace font -->

--- a/ArgoBooks/Views/StockLevelsPage.axaml
+++ b/ArgoBooks/Views/StockLevelsPage.axaml
@@ -162,6 +162,7 @@
                                     <Border Padding="24,0"
                                             BorderBrush="{DynamicResource BorderBrush}"
                                             BorderThickness="0,0,0,1"
+                                            Classes.highlighted-row="{Binding IsHighlighted}"
                                             MinHeight="52">
                                         <StackPanel Orientation="Horizontal">
                                             <!-- Product Name with SKU - Custom content required -->

--- a/ArgoBooks/Views/SuppliersPage.axaml
+++ b/ArgoBooks/Views/SuppliersPage.axaml
@@ -132,6 +132,7 @@
                                 <Border Padding="24,0"
                                         BorderBrush="{DynamicResource BorderBrush}"
                                         BorderThickness="0,0,0,1"
+                                        Classes.highlighted-row="{Binding IsHighlighted}"
                                         MinHeight="52">
                                     <StackPanel Orientation="Horizontal">
                                         <!-- Supplier Name with Avatar - Custom content required -->


### PR DESCRIPTION
## Summary
- **Global search**: Header search bar now searches across 10 CompanyData types (customers, products, invoices, expenses, revenues, suppliers, payments, rental records, inventory items, purchase orders) using fuzzy matching. Results appear in a "Results" section in the QuickActions panel.
- **Click behavior**: Clicking a result navigates to the relevant page and highlights the matching row (no modal opens).
- **Row highlighting**: Added `IsHighlighted` support to 7 pages that lacked it (Customers, Products, Suppliers, Invoices, Payments, StockLevels, PurchaseOrders).
- **Cleanup**: Removed dead `Search()` command from HeaderViewModel that navigated to a non-existent Search page.

## Test plan
- [ ] Type a customer name in the header search bar — verify matching results appear under "Results"
- [ ] Click a search result — verify it navigates to the correct page and highlights the row
- [ ] Verify Quick Actions/Navigation/Tools sections still appear alongside search results
- [ ] Test keyboard navigation (up/down/enter/escape) works across all sections including results
- [ ] Test fuzzy matching with partial/misspelled queries
- [ ] Verify no modal opens when clicking a search result

🤖 Generated with [Claude Code](https://claude.com/claude-code)