### PR TITLE
Fix loading overlay timing during company initialization

### DIFF
--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -1448,7 +1448,6 @@ public class App : Application
             _appShellViewModel.SetCompanyInfo(args.CompanyName, logo);
             _appShellViewModel.CompanySwitcherPanelViewModel.SetCurrentCompany(args.CompanyName, args.FilePath, logo);
             _appShellViewModel.FileMenuPanelViewModel.SetCurrentCompany(args.FilePath);
-            _mainWindowViewModel.HideLoading();
 
             // Clear undo/redo history for fresh start with new company
             UndoRedoManager.Clear();
@@ -1548,6 +1547,10 @@ public class App : Application
 
             // Navigate to Dashboard when company is opened
             NavigationService?.NavigateTo("Dashboard");
+
+            // Hide loading overlay only after the dashboard is in place,
+            // so the user never sees the welcome screen flash during initialization.
+            _mainWindowViewModel.HideLoading();
         };
 
         CompanyManager.CompanyClosed += async (_, _) =>


### PR DESCRIPTION
## Summary
Moved the `HideLoading()` call to occur after dashboard navigation completes, rather than immediately after company info is set. This prevents the welcome screen from flashing during company initialization.

## Key Changes
- Removed `_mainWindowViewModel.HideLoading()` call from the initial company setup section
- Added `_mainWindowViewModel.HideLoading()` call after `NavigationService?.NavigateTo("Dashboard")` with explanatory comment

## Implementation Details
The loading overlay is now hidden only after the dashboard navigation is triggered, ensuring the UI is fully ready before the loading screen disappears. This prevents a visual glitch where the welcome screen would briefly appear during the company opening process.

https://claude.ai/code/session_01LE2BASmi4642PXJuu5HeTU