### PR TITLE
Update telemetry upload endpoint URL format

### DIFF
--- a/ArgoBooks.Core/Services/TelemetryUploadService.cs
+++ b/ArgoBooks.Core/Services/TelemetryUploadService.cs
@@ -10,7 +10,7 @@ namespace ArgoBooks.Core.Services;
 /// </summary>
 public class TelemetryUploadService : ITelemetryUploadService
 {
-    private static readonly string UploadUrl = $"{ApiConfig.BaseUrl}/api/data/upload.php";
+    private static readonly string UploadUrl = $"{ApiConfig.BaseUrl}/api/data/upload";
     private const string UserAgentPrefix = "ArgoSalesTracker";
     private const int MaxRetries = 3;
     private const int BatchSize = 500;


### PR DESCRIPTION
## Summary
Updated the telemetry upload service to use a cleaner API endpoint URL format by removing the `.php` file extension.

## Changes
- Modified the `UploadUrl` endpoint in `TelemetryUploadService` from `/api/data/upload.php` to `/api/data/upload`
  - This change aligns with modern REST API conventions that don't expose implementation details like file extensions in the URL path

## Implementation Details
- The change is a simple string literal update to the static `UploadUrl` field
- No functional logic changes; this is purely an endpoint URL update
- The service will now target the cleaner endpoint format while maintaining all existing retry logic and batch processing behavior

https://claude.ai/code/session_01UHX4vyeuGco2FDcwMGgz9K