### PR TITLE
Add Conservative/Baseline/Optimistic forecast scenarios

### DIFF
--- a/ArgoBooks.Core/Models/Insights/InsightsData.cs
+++ b/ArgoBooks.Core/Models/Insights/InsightsData.cs
@@ -140,6 +140,16 @@ public class ForecastData
     public decimal ForecastedProfit { get; set; }
 
     /// <summary>
+    /// Lower bound of profit forecast (conservative scenario: low revenue, high expenses).
+    /// </summary>
+    public decimal ForecastedProfitLower { get; set; }
+
+    /// <summary>
+    /// Upper bound of profit forecast (optimistic scenario: high revenue, low expenses).
+    /// </summary>
+    public decimal ForecastedProfitUpper { get; set; }
+
+    /// <summary>
     /// Profit growth percentage.
     /// </summary>
     public decimal ProfitGrowthPercent { get; set; }
@@ -150,9 +160,31 @@ public class ForecastData
     public int ExpectedNewCustomers { get; set; }
 
     /// <summary>
+    /// Lower bound of new-customer forecast (conservative scenario).
+    /// </summary>
+    public int ExpectedNewCustomersLower { get; set; }
+
+    /// <summary>
+    /// Upper bound of new-customer forecast (optimistic scenario).
+    /// </summary>
+    public int ExpectedNewCustomersUpper { get; set; }
+
+    /// <summary>
     /// Customer growth percentage.
     /// </summary>
     public decimal CustomerGrowthPercent { get; set; }
+
+    /// <summary>
+    /// Growth percentages for the conservative bound, for showing "vs avg" consistent with displayed values.
+    /// </summary>
+    public decimal RevenueGrowthPercentLower { get; set; }
+    public decimal RevenueGrowthPercentUpper { get; set; }
+    public decimal ExpenseGrowthPercentLower { get; set; }
+    public decimal ExpenseGrowthPercentUpper { get; set; }
+    public decimal ProfitGrowthPercentLower { get; set; }
+    public decimal ProfitGrowthPercentUpper { get; set; }
+    public decimal CustomerGrowthPercentLower { get; set; }
+    public decimal CustomerGrowthPercentUpper { get; set; }
 
     /// <summary>
     /// Confidence score for the predictions (0-100).
@@ -266,6 +298,18 @@ public class InsightItem
     /// Whether this insight has an actionable recommendation.
     /// </summary>
     public bool HasRecommendation => !string.IsNullOrEmpty(Recommendation);
+}
+
+/// <summary>
+/// Display scenario for the forecast cards.
+/// Conservative shows the lower bound (revenue/profit/customers) and upper bound (expenses).
+/// Baseline shows the point forecast. Optimistic is the inverse of Conservative.
+/// </summary>
+public enum ForecastScenario
+{
+    Conservative = 0,
+    Baseline = 1,
+    Optimistic = 2
 }
 
 /// <summary>

--- a/ArgoBooks.Core/Models/Insights/InsightsData.cs
+++ b/ArgoBooks.Core/Models/Insights/InsightsData.cs
@@ -175,7 +175,9 @@ public class ForecastData
     public decimal CustomerGrowthPercent { get; set; }
 
     /// <summary>
-    /// Growth percentages for the conservative bound, for showing "vs avg" consistent with displayed values.
+    /// Growth percentages for the lower and upper forecast bounds, used to show "vs avg" consistent with
+    /// the displayed scenario (Conservative uses the lower bound for revenue/profit/customers and the upper
+    /// for expenses; Optimistic is the inverse).
     /// </summary>
     public decimal RevenueGrowthPercentLower { get; set; }
     public decimal RevenueGrowthPercentUpper { get; set; }

--- a/ArgoBooks.Core/Services/InsightsService.cs
+++ b/ArgoBooks.Core/Services/InsightsService.cs
@@ -662,6 +662,8 @@ public class InsightsService(
             if (historicalRevenue > 0)
             {
                 forecast.RevenueGrowthPercent = CalculatePercentChange(historicalRevenue, forecast.ForecastedRevenue);
+                forecast.RevenueGrowthPercentLower = CalculatePercentChange(historicalRevenue, forecast.ForecastedRevenueLower);
+                forecast.RevenueGrowthPercentUpper = CalculatePercentChange(historicalRevenue, forecast.ForecastedRevenueUpper);
             }
         }
 
@@ -681,11 +683,15 @@ public class InsightsService(
             if (historicalExpenses > 0)
             {
                 forecast.ExpenseGrowthPercent = CalculatePercentChange(historicalExpenses, forecast.ForecastedExpenses);
+                forecast.ExpenseGrowthPercentLower = CalculatePercentChange(historicalExpenses, forecast.ForecastedExpensesLower);
+                forecast.ExpenseGrowthPercentUpper = CalculatePercentChange(historicalExpenses, forecast.ForecastedExpensesUpper);
             }
         }
 
-        // Calculate profit forecast
+        // Calculate profit forecast (point and bounds — conservative profit pairs low revenue with high expenses)
         forecast.ForecastedProfit = forecast.ForecastedRevenue - forecast.ForecastedExpenses;
+        forecast.ForecastedProfitLower = forecast.ForecastedRevenueLower - forecast.ForecastedExpensesUpper;
+        forecast.ForecastedProfitUpper = forecast.ForecastedRevenueUpper - forecast.ForecastedExpensesLower;
 
         // Calculate profit growth
         var historicalProfit = GetScaledHistoricalValue(monthlyRevenue, periodMonths) -
@@ -693,6 +699,8 @@ public class InsightsService(
         if (historicalProfit != 0)
         {
             forecast.ProfitGrowthPercent = CalculatePercentChange(historicalProfit, forecast.ForecastedProfit);
+            forecast.ProfitGrowthPercentLower = CalculatePercentChange(historicalProfit, forecast.ForecastedProfitLower);
+            forecast.ProfitGrowthPercentUpper = CalculatePercentChange(historicalProfit, forecast.ForecastedProfitUpper);
         }
 
         // Customer growth forecast using ML
@@ -706,11 +714,15 @@ public class InsightsService(
 
             var scaleFactor = periodMonths / periodsToForecast;
             forecast.ExpectedNewCustomers = Math.Max(0, (int)Math.Round(customerForecast.ForecastedValues.Sum() * scaleFactor));
+            forecast.ExpectedNewCustomersLower = Math.Max(0, (int)Math.Round(customerForecast.LowerBounds.Sum() * scaleFactor));
+            forecast.ExpectedNewCustomersUpper = Math.Max(0, (int)Math.Round(customerForecast.UpperBounds.Sum() * scaleFactor));
 
             var historicalCustomers = GetScaledHistoricalValue(customerData, periodMonths);
             if (historicalCustomers > 0)
             {
                 forecast.CustomerGrowthPercent = CalculatePercentChange(historicalCustomers, forecast.ExpectedNewCustomers);
+                forecast.CustomerGrowthPercentLower = CalculatePercentChange(historicalCustomers, forecast.ExpectedNewCustomersLower);
+                forecast.CustomerGrowthPercentUpper = CalculatePercentChange(historicalCustomers, forecast.ExpectedNewCustomersUpper);
             }
         }
 

--- a/ArgoBooks.sln
+++ b/ArgoBooks.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArgoBooks", "ArgoBooks\Argo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArgoBooks.Desktop", "ArgoBooks.Desktop\ArgoBooks.Desktop.csproj", "{ABC31E74-02FF-46EB-B3B2-4E6AE43B456C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArgoBooks.Browser", "ArgoBooks.Browser\ArgoBooks.Browser.csproj", "{1C1A049E-235C-4CD0-B6FA-D53AC418F4DA}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArgoBooks.Core", "ArgoBooks.Core\ArgoBooks.Core.csproj", "{D4A8E2F1-5B3C-4E7D-9A1F-6C8B2E3D4F5A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArgoBooks.Tests", "ArgoBooks.Tests\ArgoBooks.Tests.csproj", "{E5B9F3A2-6C4D-5F8E-0B2G-7D9C3F4E5G6B}"
@@ -34,10 +32,6 @@ Global
 		{ABC31E74-02FF-46EB-B3B2-4E6AE43B456C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ABC31E74-02FF-46EB-B3B2-4E6AE43B456C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ABC31E74-02FF-46EB-B3B2-4E6AE43B456C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1C1A049E-235C-4CD0-B6FA-D53AC418F4DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1C1A049E-235C-4CD0-B6FA-D53AC418F4DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1C1A049E-235C-4CD0-B6FA-D53AC418F4DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1C1A049E-235C-4CD0-B6FA-D53AC418F4DA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D4A8E2F1-5B3C-4E7D-9A1F-6C8B2E3D4F5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D4A8E2F1-5B3C-4E7D-9A1F-6C8B2E3D4F5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4A8E2F1-5B3C-4E7D-9A1F-6C8B2E3D4F5A}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -964,7 +964,7 @@ public class App : Application
             // Apply saved sidebar collapsed state after settings are loaded from disk.
             // The SidebarViewModel was created before settings were loaded, so its constructor
             // read the default value. Re-apply the persisted state now.
-            var savedCollapsed = SettingsService.GlobalSettings.Ui.SidebarCollapsed;
+            var savedCollapsed = SettingsService?.GlobalSettings.Ui.SidebarCollapsed ?? false;
             if (savedCollapsed)
             {
                 _appShellViewModel.SidebarViewModel.IsCollapsed = true;

--- a/ArgoBooks/Modals/PredictionInfoModal.axaml
+++ b/ArgoBooks/Modals/PredictionInfoModal.axaml
@@ -37,7 +37,7 @@
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <TextBlock Text="Smart forecasting powered by machine learning"
                                        FontSize="13"
-                                       Foreground="{DynamicResource TextSecondaryBrush}" />
+                                       Foreground="{DynamicResource TextPrimaryBrush}" />
                         </StackPanel>
                         <Button Grid.Column="1"
                                 Classes="icon-button"
@@ -45,7 +45,7 @@
                                 Command="{Binding CloseCommand}">
                             <PathIcon Data="{x:Static icons:Icons.Close}"
                                       Width="16" Height="16"
-                                      Foreground="{DynamicResource TextSecondaryBrush}" />
+                                      Foreground="{DynamicResource TextPrimaryBrush}" />
                         </Button>
                     </Grid>
                 </Border>
@@ -62,7 +62,7 @@
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <TextBlock TextWrapping="Wrap"
                                        FontSize="13"
-                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Foreground="{DynamicResource TextPrimaryBrush}"
                                        Text="Our forecasting system uses multiple ML algorithms to predict future revenue, expenses, and customer growth. It continuously tests predictions against actual outcomes and adapts its methods based on what works best for your business. Everything runs locally - your data never leaves your computer." />
                         </StackPanel>
 
@@ -96,7 +96,7 @@
                                         <TextBlock Text="Automatically detects if your business has patterns - like higher sales in December or slower months in summer. The forecast adjusts for these cycles."
                                                    FontSize="12"
                                                    TextWrapping="Wrap"
-                                                   Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
                                     </StackPanel>
                                 </Grid>
                             </Border>
@@ -124,7 +124,7 @@
                                         <TextBlock Text="Understands whether your business is growing, stable, or declining - and factors this into predictions so they're not just based on averages."
                                                    FontSize="12"
                                                    TextWrapping="Wrap"
-                                                   Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
                                     </StackPanel>
                                 </Grid>
                             </Border>
@@ -152,7 +152,7 @@
                                         <TextBlock Text="Compares past predictions to what actually happened. Over time, you'll see how accurate the forecasts have been for your specific business."
                                                    FontSize="12"
                                                    TextWrapping="Wrap"
-                                                   Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
                                     </StackPanel>
                                 </Grid>
                             </Border>
@@ -180,7 +180,7 @@
                                         <TextBlock Text="The Historical Accuracy percentage shows how close predictions were to actual results. For example, 85% accuracy means predictions were typically within 15% of the actual values. It's calculated by comparing each past forecast to the actual outcome, then averaging the results."
                                                    FontSize="12"
                                                    TextWrapping="Wrap"
-                                                   Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
                                     </StackPanel>
                                 </Grid>
                             </Border>
@@ -208,7 +208,7 @@
                                         <TextBlock Text="The system learns which prediction method works best for your business. Methods that have been more accurate historically are weighted more heavily in future forecasts."
                                                    FontSize="12"
                                                    TextWrapping="Wrap"
-                                                   Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
                                     </StackPanel>
                                 </Grid>
                             </Border>
@@ -233,10 +233,38 @@
                                                    FontSize="13"
                                                    FontWeight="Medium"
                                                    Foreground="{DynamicResource TextPrimaryBrush}" />
-                                        <TextBlock Text="Shows a range (low to high estimate) instead of just one number. This gives you a realistic picture of what to expect."
+                                        <TextBlock Text="Shows a range (low to high estimate) instead of just one number — a band of plausible outcomes rather than a single guaranteed figure."
                                                    FontSize="12"
                                                    TextWrapping="Wrap"
-                                                   Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+
+                            <!-- Scenario Outlooks (Conservative / Baseline / Optimistic) -->
+                            <Border Background="{DynamicResource SurfaceAltBrush}"
+                                    CornerRadius="8"
+                                    Padding="16">
+                                <Grid ColumnDefinitions="Auto,*">
+                                    <Border Grid.Column="0"
+                                            Width="36" Height="36"
+                                            CornerRadius="8"
+                                            Background="{DynamicResource PrimaryLightBrush}"
+                                            Margin="0,0,12,0"
+                                            VerticalAlignment="Top">
+                                        <PathIcon Data="{x:Static icons:Icons.TrendUp}"
+                                                  Width="18" Height="18"
+                                                  Foreground="{DynamicResource PrimaryBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" Spacing="4">
+                                        <TextBlock Text="Conservative / Baseline / Optimistic"
+                                                   FontSize="13"
+                                                   FontWeight="Medium"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="Switch between three views of the same forecast. Conservative shows the low end of the range (lower revenue and customers, higher expenses); Optimistic shows the high end; Baseline is the middle. Useful for stress-testing plans against both downside and upside without picking one number to bet on."
+                                                   FontSize="12"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
                                     </StackPanel>
                                 </Grid>
                             </Border>
@@ -250,7 +278,7 @@
                                        Foreground="{DynamicResource TextPrimaryBrush}" />
                             <TextBlock TextWrapping="Wrap"
                                        FontSize="13"
-                                       Foreground="{DynamicResource TextSecondaryBrush}"
+                                       Foreground="{DynamicResource TextPrimaryBrush}"
                                        Text="The confidence score (0-100%) tells you how reliable the prediction is likely to be:" />
                             <Grid ColumnDefinitions="*,*,*" Margin="0,8,0,0">
                                 <Border Grid.Column="0" Background="{DynamicResource SuccessDarkBrush}" CornerRadius="6" Padding="12" Margin="0,0,4,0">
@@ -277,6 +305,56 @@
                             </Grid>
                         </StackPanel>
 
+                        <!-- When Forecasts May Miss -->
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="When Forecasts May Miss"
+                                       FontSize="14"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextPrimaryBrush}" />
+                            <Border Background="{DynamicResource SurfaceAltBrush}"
+                                    CornerRadius="8"
+                                    Padding="16">
+                                <Grid ColumnDefinitions="Auto,*">
+                                    <Border Grid.Column="0"
+                                            Width="36" Height="36"
+                                            CornerRadius="8"
+                                            Background="{DynamicResource WarningLightBrush}"
+                                            Margin="0,0,12,0"
+                                            VerticalAlignment="Top">
+                                        <PathIcon Data="{x:Static icons:Icons.WarningCircle}"
+                                                  Width="18" Height="18"
+                                                  Foreground="{DynamicResource WarningBrush}" />
+                                    </Border>
+                                    <StackPanel Grid.Column="1" Spacing="6">
+                                        <TextBlock Text="Forecasts learn from your past, so they can't see things that haven't happened before. Treat the numbers with extra skepticism in these situations:"
+                                                   FontSize="12"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="• Big changes the model can't predict — losing or winning a major customer, opening a new location, hiring, layoffs, or a price change."
+                                                   FontSize="12"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="• One-off events — a single large invoice or refund can skew a whole month and pull the forecast off course."
+                                                   FontSize="12"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="• New businesses with less than 12 months of data — there isn't enough history yet to tell real patterns from noise."
+                                                   FontSize="12"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="• Customer-count predictions — these are the lumpiest of the four. Use them as a rough sanity check, not a hiring plan."
+                                                   FontSize="12"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                        <TextBlock Text="• Anything used for taxes, loan applications, or formal financial reporting — forecasts here are not a substitute for an accountant."
+                                                   FontSize="12"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+                        </StackPanel>
+
                         <!-- Tips -->
                         <StackPanel Spacing="8">
                             <TextBlock Text="Tips for Better Predictions"
@@ -290,19 +368,19 @@
                                     <TextBlock Text="• More data = better predictions. 12+ months is ideal."
                                                FontSize="12"
                                                TextWrapping="Wrap"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
                                     <TextBlock Text="• The system improves over time as it learns from your data."
                                                FontSize="12"
                                                TextWrapping="Wrap"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
                                     <TextBlock Text="• Keep your records consistent and up to date."
                                                FontSize="12"
                                                TextWrapping="Wrap"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
                                     <TextBlock Text="• Use forecasts as a guide, not a guarantee."
                                                FontSize="12"
                                                TextWrapping="Wrap"
-                                               Foreground="{DynamicResource TextSecondaryBrush}" />
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
                                 </StackPanel>
                             </Border>
                         </StackPanel>
@@ -321,7 +399,7 @@
                                 <TextBlock Grid.Column="1"
                                            TextWrapping="Wrap"
                                            FontSize="12"
-                                           Foreground="{DynamicResource TextSecondaryBrush}"
+                                           Foreground="{DynamicResource TextPrimaryBrush}"
                                            Text="All calculations happen on your device. Your financial data is never sent to any external server or cloud service." />
                             </Grid>
                         </Border>

--- a/ArgoBooks/ViewModels/Dashboard/UnifiedChartWidgetViewModel.cs
+++ b/ArgoBooks/ViewModels/Dashboard/UnifiedChartWidgetViewModel.cs
@@ -259,6 +259,11 @@ public partial class UnifiedChartWidgetViewModel : WidgetViewModelBase
         var dates = dated.Select(p => p.Date!.Value).ToArray();
         var values = dated.Select(p => p.Value).ToArray();
 
+        if (ChartDataType == ChartDataType.TotalProfits)
+        {
+            ChartTitle = $"Total profits: {CurrencyService.FormatFromUSD((decimal)values.Sum(), DateTime.Now)}";
+        }
+
         var series = new ObservableCollection<ISeries>();
         series.Add(ChartLoaderService.CreateDateTimeSeries(
             dates, values, ChartDataType.GetDisplayName(), SKColor.Parse(AppColors.Palette[0])));

--- a/ArgoBooks/ViewModels/InsightsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InsightsPageViewModel.cs
@@ -124,24 +124,45 @@ public partial class InsightsPageViewModel : ViewModelBase
         AnomaliesDetected = "2";
         Opportunities = "3";
 
-        ForecastedRevenue = "$24,800";
-        RevenueGrowthValue = 12.4;
-        RevenueGrowth = "12.4%";
-        ForecastedExpenses = "$18,200";
-        ExpenseGrowthValue = -3.1;
-        ExpenseGrowth = "3.1%";
-        ForecastedProfit = "$6,600";
-        ProfitGrowthValue = 28.7;
-        ProfitGrowth = "28.7%";
-        ForecastedCustomers = "47";
-        CustomerGrowthValue = 8.2;
-        CustomerGrowth = "8.2%";
+        // Build a synthetic ForecastData for the Conservative/Baseline/Optimistic options
+        var sampleForecast = new ForecastData
+        {
+            ForecastedRevenue = 24800m,
+            ForecastedRevenueLower = 21400m,
+            ForecastedRevenueUpper = 28200m,
+            RevenueGrowthPercent = 12.4m,
+            RevenueGrowthPercentLower = -3.0m,
+            RevenueGrowthPercentUpper = 27.8m,
+
+            ForecastedExpenses = 18200m,
+            ForecastedExpensesLower = 17200m,
+            ForecastedExpensesUpper = 19000m,
+            ExpenseGrowthPercent = 3.1m,
+            ExpenseGrowthPercentLower = -2.5m,
+            ExpenseGrowthPercentUpper = 7.7m,
+
+            ForecastedProfit = 6600m,
+            ForecastedProfitLower = 2400m,
+            ForecastedProfitUpper = 11000m,
+            ProfitGrowthPercent = 28.7m,
+            ProfitGrowthPercentLower = -53.2m,
+            ProfitGrowthPercentUpper = 114.5m,
+
+            ExpectedNewCustomers = 47,
+            ExpectedNewCustomersLower = 39,
+            ExpectedNewCustomersUpper = 56,
+            CustomerGrowthPercent = 8.2m,
+            CustomerGrowthPercentLower = -10.3m,
+            CustomerGrowthPercentUpper = 28.7m
+        };
+        _latestForecast = sampleForecast;
+        ApplyForecastToCards(sampleForecast);
 
         PredictionConfidence = "82% High";
         DataMonthsNote = "Based on 14 months of data using Linear Regression";
         ForecastMethod = "Linear Regression";
         RevenueRange = "Range: $21,400 - $28,200";
-        ExpensesRange = string.Empty;
+        ExpensesRange = "Range: $17,200 - $19,000";
         HasAccuracyData = true;
         HistoricalAccuracy = "79%";
         AccuracyDescription = string.Empty;
@@ -245,6 +266,45 @@ public partial class InsightsPageViewModel : ViewModelBase
 
     [ObservableProperty]
     private DateTime _endDate;
+
+    /// <summary>
+    /// Most recent forecast result, retained so we can re-render cards when the scenario mode changes
+    /// without re-running the ML pipeline.
+    /// </summary>
+    private ForecastData? _latestForecast;
+
+    public List<string> ScenarioModeOptions { get; } = ["Conservative", "Baseline", "Optimistic"];
+
+    [ObservableProperty]
+    private int _selectedScenarioModeIndex = (int)ForecastScenario.Baseline;
+
+    [ObservableProperty]
+    private bool _scenarioToggleEnabled;
+
+    [ObservableProperty]
+    private string _scenarioOutlookHint = string.Empty;
+
+    partial void OnSelectedScenarioModeIndexChanged(int value)
+    {
+        if (_latestForecast != null)
+        {
+            ApplyForecastToCards(_latestForecast);
+        }
+        else
+        {
+            UpdateScenarioOutlookHint();
+        }
+    }
+
+    private void UpdateScenarioOutlookHint()
+    {
+        ScenarioOutlookHint = (ForecastScenario)SelectedScenarioModeIndex switch
+        {
+            ForecastScenario.Conservative => "Conservative outlook: revenue, profit, and customers at the low end of the range; expenses at the high end.",
+            ForecastScenario.Optimistic => "Optimistic outlook: revenue, profit, and customers at the high end of the range; expenses at the low end.",
+            _ => "Baseline outlook: the middle of the forecast range, between conservative and optimistic."
+        };
+    }
 
     /// <summary>
     /// Gets or sets the currently selected date range string.
@@ -779,22 +839,8 @@ public partial class InsightsPageViewModel : ViewModelBase
     /// </summary>
     private void UpdateForecastDisplay(ForecastData forecast)
     {
-        // Main forecast values
-        ForecastedRevenue = forecast.ForecastedRevenue.ToString("C0");
-        RevenueGrowthValue = (double)forecast.RevenueGrowthPercent;
-        RevenueGrowth = $"{Math.Abs(forecast.RevenueGrowthPercent):F1}%";
-
-        ForecastedExpenses = forecast.ForecastedExpenses.ToString("C0");
-        ExpenseGrowthValue = -(double)forecast.ExpenseGrowthPercent; // Negative because increased expenses is bad
-        ExpenseGrowth = $"{Math.Abs(forecast.ExpenseGrowthPercent):F1}%";
-
-        ForecastedProfit = forecast.ForecastedProfit.ToString("C0");
-        ProfitGrowthValue = (double)forecast.ProfitGrowthPercent;
-        ProfitGrowth = $"{Math.Abs(forecast.ProfitGrowthPercent):F1}%";
-
-        ForecastedCustomers = forecast.ExpectedNewCustomers.ToString();
-        CustomerGrowthValue = (double)forecast.CustomerGrowthPercent;
-        CustomerGrowth = $"{Math.Abs(forecast.CustomerGrowthPercent):F1}%";
+        _latestForecast = forecast;
+        ApplyForecastToCards(forecast);
 
         PredictionConfidence = $"{forecast.ConfidenceScore:F0}% {forecast.ConfidenceLevel}";
 
@@ -808,7 +854,7 @@ public partial class InsightsPageViewModel : ViewModelBase
 
         ForecastMethod = forecast.ForecastMethod ?? string.Empty;
 
-        // Confidence bounds/ranges
+        // Confidence bounds/ranges (always show the full envelope, independent of selected scenario)
         if (forecast.ForecastedRevenueLower > 0 || forecast.ForecastedRevenueUpper > 0)
         {
             RevenueRange = $"Range: {forecast.ForecastedRevenueLower:C0} - {forecast.ForecastedRevenueUpper:C0}";
@@ -856,6 +902,66 @@ public partial class InsightsPageViewModel : ViewModelBase
             SeasonalPatternDescription = string.Empty;
             TrendDirection = string.Empty;
         }
+    }
+
+    /// <summary>
+    /// Renders the four forecast cards (revenue, expenses, profit, customers) using the
+    /// currently selected scenario mode. Conservative shows lower bounds for revenue/profit/customers
+    /// and the upper bound for expenses (since high expenses are the conservative case); Optimistic
+    /// is the inverse; Baseline shows the point forecast.
+    /// </summary>
+    private void ApplyForecastToCards(ForecastData forecast)
+    {
+        ScenarioToggleEnabled = forecast.ForecastedRevenueUpper > forecast.ForecastedRevenueLower
+                             || forecast.ForecastedExpensesUpper > forecast.ForecastedExpensesLower;
+
+        // If bounds aren't meaningful (insufficient data), pin to Baseline regardless of selection.
+        var scenario = ScenarioToggleEnabled
+            ? (ForecastScenario)SelectedScenarioModeIndex
+            : ForecastScenario.Baseline;
+
+        var (revenue, revenueGrowth) = scenario switch
+        {
+            ForecastScenario.Conservative => (forecast.ForecastedRevenueLower, forecast.RevenueGrowthPercentLower),
+            ForecastScenario.Optimistic => (forecast.ForecastedRevenueUpper, forecast.RevenueGrowthPercentUpper),
+            _ => (forecast.ForecastedRevenue, forecast.RevenueGrowthPercent)
+        };
+        ForecastedRevenue = revenue.ToString("C0");
+        RevenueGrowthValue = (double)revenueGrowth;
+        RevenueGrowth = $"{Math.Abs(revenueGrowth):F1}%";
+
+        // Expenses flip: conservative = high expenses (upper bound), optimistic = low expenses.
+        var (expenses, expenseGrowth) = scenario switch
+        {
+            ForecastScenario.Conservative => (forecast.ForecastedExpensesUpper, forecast.ExpenseGrowthPercentUpper),
+            ForecastScenario.Optimistic => (forecast.ForecastedExpensesLower, forecast.ExpenseGrowthPercentLower),
+            _ => (forecast.ForecastedExpenses, forecast.ExpenseGrowthPercent)
+        };
+        ForecastedExpenses = expenses.ToString("C0");
+        ExpenseGrowthValue = -(double)expenseGrowth;
+        ExpenseGrowth = $"{Math.Abs(expenseGrowth):F1}%";
+
+        var (profit, profitGrowth) = scenario switch
+        {
+            ForecastScenario.Conservative => (forecast.ForecastedProfitLower, forecast.ProfitGrowthPercentLower),
+            ForecastScenario.Optimistic => (forecast.ForecastedProfitUpper, forecast.ProfitGrowthPercentUpper),
+            _ => (forecast.ForecastedProfit, forecast.ProfitGrowthPercent)
+        };
+        ForecastedProfit = profit.ToString("C0");
+        ProfitGrowthValue = (double)profitGrowth;
+        ProfitGrowth = $"{Math.Abs(profitGrowth):F1}%";
+
+        var (customers, customerGrowth) = scenario switch
+        {
+            ForecastScenario.Conservative => (forecast.ExpectedNewCustomersLower, forecast.CustomerGrowthPercentLower),
+            ForecastScenario.Optimistic => (forecast.ExpectedNewCustomersUpper, forecast.CustomerGrowthPercentUpper),
+            _ => (forecast.ExpectedNewCustomers, forecast.CustomerGrowthPercent)
+        };
+        ForecastedCustomers = customers.ToString();
+        CustomerGrowthValue = (double)customerGrowth;
+        CustomerGrowth = $"{Math.Abs(customerGrowth):F1}%";
+
+        UpdateScenarioOutlookHint();
     }
 
     /// <summary>
@@ -909,6 +1015,10 @@ public partial class InsightsPageViewModel : ViewModelBase
         TrendsDetected = "0";
         AnomaliesDetected = "0";
         Opportunities = "0";
+
+        _latestForecast = null;
+        ScenarioToggleEnabled = false;
+        ScenarioOutlookHint = string.Empty;
 
         ForecastedRevenue = "$0";
         RevenueGrowthValue = 0;

--- a/ArgoBooks/ViewModels/InsightsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InsightsPageViewModel.cs
@@ -273,8 +273,6 @@ public partial class InsightsPageViewModel : ViewModelBase
     /// </summary>
     private ForecastData? _latestForecast;
 
-    public List<string> ScenarioModeOptions { get; } = ["Conservative", "Baseline", "Optimistic"];
-
     [ObservableProperty]
     private int _selectedScenarioModeIndex = (int)ForecastScenario.Baseline;
 
@@ -913,12 +911,18 @@ public partial class InsightsPageViewModel : ViewModelBase
     private void ApplyForecastToCards(ForecastData forecast)
     {
         ScenarioToggleEnabled = forecast.ForecastedRevenueUpper > forecast.ForecastedRevenueLower
-                             || forecast.ForecastedExpensesUpper > forecast.ForecastedExpensesLower;
+                             || forecast.ForecastedExpensesUpper > forecast.ForecastedExpensesLower
+                             || forecast.ExpectedNewCustomersUpper > forecast.ExpectedNewCustomersLower;
 
-        // If bounds aren't meaningful (insufficient data), pin to Baseline regardless of selection.
-        var scenario = ScenarioToggleEnabled
-            ? (ForecastScenario)SelectedScenarioModeIndex
-            : ForecastScenario.Baseline;
+        // If bounds aren't meaningful, snap selection back to Baseline so the tab/hint match the cards.
+        // The property setter re-enters this method via OnSelectedScenarioModeIndexChanged, but the second
+        // pass is a no-op (Index already Baseline) so it terminates after one extra render.
+        if (SelectedScenarioModeIndex != (int)ForecastScenario.Baseline && !ScenarioToggleEnabled)
+        {
+            SelectedScenarioModeIndex = (int)ForecastScenario.Baseline;
+        }
+
+        var scenario = (ForecastScenario)SelectedScenarioModeIndex;
 
         var (revenue, revenueGrowth) = scenario switch
         {

--- a/ArgoBooks/Views/InsightsPage.axaml
+++ b/ArgoBooks/Views/InsightsPage.axaml
@@ -99,6 +99,25 @@
                         <controls:DateRangeSelector Grid.Column="2" VerticalAlignment="Top" />
                     </Grid>
 
+                    <!-- Scenario Mode Selector (Conservative / Baseline / Optimistic) -->
+                    <StackPanel IsVisible="{Binding !HasInsufficientData}" Spacing="6">
+                        <TabControl Classes="page-tabs"
+                                    Margin="0"
+                                    Padding="0"
+                                    HorizontalAlignment="Left"
+                                    SelectedIndex="{Binding SelectedScenarioModeIndex}"
+                                    IsEnabled="{Binding ScenarioToggleEnabled}">
+                            <TabItem Header="{loc:Loc 'Conservative'}" />
+                            <TabItem Header="{loc:Loc 'Baseline'}" />
+                            <TabItem Header="{loc:Loc 'Optimistic'}" />
+                        </TabControl>
+                        <TextBlock Text="{Binding ScenarioOutlookHint}"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                   TextWrapping="Wrap"
+                                   IsVisible="{Binding ScenarioOutlookHint, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                    </StackPanel>
+
                     <!-- Forecast Cards Row (visible when data is available) -->
                     <controls:StatCardsRow IsVisible="{Binding !HasInsufficientData}">
                         <controls:StatCard Label="{Binding RevenueLabel}"


### PR DESCRIPTION
## Summary

- **Insights page** gets a 3-mode toggle (Conservative / Baseline / Optimistic) that re-uses the ML model's existing confidence bounds for revenue, expenses, profit, and customers. Conservative pairs low revenue with high expenses; Optimistic is the inverse; Baseline is the point forecast. Date-range changes preserve the selected scenario.
- **Sample teaser** now wires up bounds so free-tier users can interact with the toggle instead of seeing it greyed out.
- **Dashboard** "Total Profits" chart title now includes the summed total (`Total profits: $X`), matching the analytics page pattern.
- **Predictions info modal** gets an explanation of the new scenarios, a new "When Forecasts May Miss" section (structural breaks, outliers, small/new businesses, lumpy customer counts, not-financial-advice caveat), softened "realistic picture" wording, and improved body-text contrast in dark theme.
- **Bundled cleanup**: fixes pre-existing CS8602 warning in `App.axaml.cs:967` and removes the orphaned `ArgoBooks.Browser` project entry from `ArgoBooks.sln` left behind by commit `5e1be27f`, which was breaking full-solution builds.

Accuracy tracking is unchanged — `ForecastAccuracyService.SaveForecast` still receives only the point forecast, so Conservative/Optimistic are display-time selections that never get retro-validated against actuals.

## Test plan

- [x] `dotnet build ArgoBooks.sln` — 0 warnings, 0 errors across all 5 projects
- [x] `dotnet test ArgoBooks.Tests` — 1961 / 1961 passing
- [ ] Open a company with 12+ months of data → toggle is enabled, defaults to Baseline matching production behaviour
- [ ] Switch to Conservative → revenue/profit/customers go down, expenses go up; "vs avg" growth percentages move correspondingly; the "Range: $A – $B" label is unchanged
- [x] Switch to Optimistic → the inverse
- [ ] Open a company with insufficient data → toggle is disabled and pinned to Baseline
- [ ] Change the date range while in Conservative → numbers refresh and stay Conservative
- [x] Free-tier teaser → toggle is fully interactive with sample bounds
- [x] Dashboard "Total Profits" chart title now shows the total
- [x] Predictions info modal text is readable in dark theme; new sections render correctly