### PR TITLE
Add customer avatars with image upload

### DIFF
--- a/ArgoBooks.Core/Models/Common/IAvatarOwner.cs
+++ b/ArgoBooks.Core/Models/Common/IAvatarOwner.cs
@@ -1,0 +1,19 @@
+namespace ArgoBooks.Core.Models.Common;
+
+/// <summary>
+/// Marks an entity that can carry an optional avatar image stored under the
+/// company temp directory. Implemented by Customer and Supplier so CompanyManager
+/// can share a single set of avatar storage helpers.
+/// </summary>
+public interface IAvatarOwner
+{
+    string Id { get; set; }
+
+    /// <summary>
+    /// Relative path (within the company temp directory) to the avatar image,
+    /// or null if no avatar is set.
+    /// </summary>
+    string? AvatarFileName { get; set; }
+
+    DateTime UpdatedAt { get; set; }
+}

--- a/ArgoBooks.Core/Models/Entities/Customer.cs
+++ b/ArgoBooks.Core/Models/Entities/Customer.cs
@@ -6,7 +6,7 @@ namespace ArgoBooks.Core.Models.Entities;
 /// <summary>
 /// Represents a customer in the system.
 /// </summary>
-public class Customer : BaseEntity
+public class Customer : BaseEntity, IAvatarOwner
 {
     /// <summary>
     /// Customer name (person or company).

--- a/ArgoBooks.Core/Models/Entities/Customer.cs
+++ b/ArgoBooks.Core/Models/Entities/Customer.cs
@@ -49,4 +49,11 @@ public class Customer : BaseEntity
     /// </summary>
     [JsonPropertyName("lastTransactionDate")]
     public DateTime? LastTransactionDate { get; set; }
+
+    /// <summary>
+    /// Relative path (within the company temp directory) to the customer's avatar image,
+    /// or null if no custom avatar is set. When null, initials are displayed instead.
+    /// </summary>
+    [JsonPropertyName("avatarFileName")]
+    public string? AvatarFileName { get; set; }
 }

--- a/ArgoBooks.Core/Models/Entities/Supplier.cs
+++ b/ArgoBooks.Core/Models/Entities/Supplier.cs
@@ -5,7 +5,7 @@ namespace ArgoBooks.Core.Models.Entities;
 /// <summary>
 /// Represents a supplier.
 /// </summary>
-public class Supplier : BaseEntity
+public class Supplier : BaseEntity, IAvatarOwner
 {
     /// <summary>
     /// Supplier/company name.
@@ -42,4 +42,12 @@ public class Supplier : BaseEntity
     /// </summary>
     [JsonPropertyName("notes")]
     public string Notes { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Relative path (within the company temp directory) to the supplier's avatar image,
+    /// or null if no avatar is set. May be a user-uploaded file or a favicon auto-fetched
+    /// from the supplier's website. When null, initials are displayed instead.
+    /// </summary>
+    [JsonPropertyName("avatarFileName")]
+    public string? AvatarFileName { get; set; }
 }

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -132,13 +132,22 @@ public class CompanyManager : IDisposable
 
         var candidate = Path.GetFullPath(Path.Combine(_currentTempDirectory, relativeAvatarPath));
         var tempRoot = Path.GetFullPath(_currentTempDirectory);
-        var rootWithSep = tempRoot.EndsWith(Path.DirectorySeparatorChar)
-            ? tempRoot
-            : tempRoot + Path.DirectorySeparatorChar;
 
-        return candidate.StartsWith(rootWithSep, StringComparison.OrdinalIgnoreCase)
-            ? candidate
-            : null;
+        // Use Path.GetRelativePath instead of a string-prefix check: on case-sensitive
+        // filesystems (Linux/macOS) a string compare needs Ordinal, on Windows it needs
+        // OrdinalIgnoreCase, and a mismatch either rejects valid paths or admits invalid
+        // ones. GetRelativePath uses the platform's native rules, and ".."-prefixed
+        // results unambiguously mean the candidate is outside tempRoot.
+        var relativeFromRoot = Path.GetRelativePath(tempRoot, candidate);
+        if (Path.IsPathRooted(relativeFromRoot)
+            || relativeFromRoot == ".."
+            || relativeFromRoot.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+            || relativeFromRoot.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return candidate;
     }
 
     private string? GetEntityAvatarPath(IAvatarOwner? entity)

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -115,16 +115,42 @@ public class CompanyManager : IDisposable
     private const int CustomerAvatarMaxDimension = 256;
 
     /// <summary>
+    /// Resolves an avatar's relative path to an absolute path within the company temp
+    /// directory, or null if the relative path escapes that directory. Defends against
+    /// crafted .argo files that set <c>avatarFileName</c> to a traversal path
+    /// (e.g. <c>../../etc/passwd</c>) which would otherwise let a load read — or a
+    /// remove/rename operation delete or move — files outside the temp directory.
+    /// </summary>
+    private string? ResolveAvatarPathSafely(string? relativeAvatarPath)
+    {
+        if (string.IsNullOrEmpty(relativeAvatarPath) || _currentTempDirectory == null)
+            return null;
+
+        if (Path.IsPathRooted(relativeAvatarPath))
+            return null;
+
+        var candidate = Path.GetFullPath(Path.Combine(_currentTempDirectory, relativeAvatarPath));
+        var tempRoot = Path.GetFullPath(_currentTempDirectory);
+        var rootWithSep = tempRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? tempRoot
+            : tempRoot + Path.DirectorySeparatorChar;
+
+        return candidate.StartsWith(rootWithSep, StringComparison.OrdinalIgnoreCase)
+            ? candidate
+            : null;
+    }
+
+    /// <summary>
     /// Gets the absolute on-disk path to a customer's avatar image, or null when there is no
-    /// avatar set or the file is missing.
+    /// avatar set, the file is missing, or the stored path escapes the company temp directory.
     /// </summary>
     public string? GetCustomerAvatarPath(Customer customer)
     {
-        if (customer == null || string.IsNullOrEmpty(customer.AvatarFileName) || _currentTempDirectory == null)
+        if (customer == null)
             return null;
 
-        var path = Path.Combine(_currentTempDirectory, customer.AvatarFileName);
-        return File.Exists(path) ? path : null;
+        var path = ResolveAvatarPathSafely(customer.AvatarFileName);
+        return path != null && File.Exists(path) ? path : null;
     }
 
     /// <summary>
@@ -683,8 +709,10 @@ public class CompanyManager : IDisposable
         if (string.IsNullOrEmpty(existing))
             return;
 
-        var fullPath = Path.Combine(_currentTempDirectory, existing);
-        if (File.Exists(fullPath))
+        // Only delete files that resolve safely under the temp directory — guard against
+        // a crafted AvatarFileName escaping into the rest of the filesystem.
+        var fullPath = ResolveAvatarPathSafely(existing);
+        if (fullPath != null && File.Exists(fullPath))
         {
             await Task.Run(() => File.Delete(fullPath));
         }
@@ -750,19 +778,25 @@ public class CompanyManager : IDisposable
         {
             try
             {
-                var oldPath = Path.Combine(_currentTempDirectory, customer.AvatarFileName);
+                // Validate the old path stays inside the temp directory before doing any
+                // file ops — a crafted AvatarFileName must not be able to coerce a move
+                // (or implicit overwrite) of files outside the company's temp dir.
+                var oldPath = ResolveAvatarPathSafely(customer.AvatarFileName);
                 var ext = Path.GetExtension(customer.AvatarFileName);
                 var safeNewId = SanitizeForFileName(trimmed);
                 var newRelative = Path.Combine(CustomerAvatarSubdirectory, safeNewId + ext).Replace('\\', '/');
                 var newPath = Path.Combine(_currentTempDirectory, newRelative);
 
-                if (File.Exists(oldPath) && !string.Equals(oldPath, newPath, StringComparison.OrdinalIgnoreCase))
+                if (oldPath != null && File.Exists(oldPath) && !string.Equals(oldPath, newPath, StringComparison.OrdinalIgnoreCase))
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(newPath)!);
                     if (File.Exists(newPath))
                         File.Delete(newPath);
                     File.Move(oldPath, newPath);
                 }
+                // Always update AvatarFileName to the new relative path: even if the old
+                // file was missing or unsafe, the customer record should now point inside
+                // the temp dir using the new Id.
                 customer.AvatarFileName = newRelative;
             }
             catch

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -233,6 +233,84 @@ public class CompanyManager : IDisposable
     }
 
     /// <summary>
+    /// Reads the bytes of an entity's avatar file, or null if there's no avatar set or
+    /// the file can't be read. Used by the undo system to capture a snapshot before
+    /// the avatar is changed so it can be restored later.
+    /// </summary>
+    private byte[]? ReadEntityAvatarBytes(IAvatarOwner entity)
+    {
+        var path = GetEntityAvatarPath(entity);
+        if (path == null) return null;
+        try { return File.ReadAllBytes(path); }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// Restores an avatar to an exact prior state. Pass <paramref name="bytes"/> = null
+    /// to restore "no avatar" (deletes the file and clears AvatarFileName); pass bytes
+    /// to write them back as the avatar (no resize — the bytes are already a resized
+    /// PNG captured by an earlier <see cref="ReadEntityAvatarBytes"/>). Synchronous so
+    /// it can be called directly from undo/redo callbacks.
+    /// </summary>
+    private void RestoreEntityAvatarSync(IAvatarOwner entity, byte[]? bytes, string subdirectory)
+    {
+        if (CompanyData == null || _currentTempDirectory == null) return;
+
+        if (bytes == null)
+        {
+            var existing = entity.AvatarFileName;
+            if (!string.IsNullOrEmpty(existing))
+            {
+                var path = ResolveAvatarPathSafely(existing);
+                if (path != null && File.Exists(path))
+                {
+                    try { File.Delete(path); } catch { /* best effort */ }
+                }
+            }
+            entity.AvatarFileName = null;
+        }
+        else
+        {
+            var (destPath, relativePath) = PrepareAvatarDestination(entity.Id, subdirectory);
+            try
+            {
+                File.WriteAllBytes(destPath, bytes);
+                entity.AvatarFileName = relativePath;
+            }
+            catch
+            {
+                // If the write fails, leave the entity without an avatar reference rather
+                // than pointing at a partially-written file.
+                entity.AvatarFileName = null;
+            }
+        }
+
+        entity.UpdatedAt = DateTime.UtcNow;
+        CompanyData.ChangesMade = true;
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Reads the customer's avatar file as bytes, or null if none/unreadable.</summary>
+    public byte[]? ReadCustomerAvatarBytes(Customer customer) => ReadEntityAvatarBytes(customer);
+
+    /// <summary>Reads the supplier's avatar file as bytes, or null if none/unreadable.</summary>
+    public byte[]? ReadSupplierAvatarBytes(Supplier supplier) => ReadEntityAvatarBytes(supplier);
+
+    /// <summary>
+    /// Restores a customer's avatar to a prior state captured via
+    /// <see cref="ReadCustomerAvatarBytes"/>. Null restores "no avatar".
+    /// </summary>
+    public void RestoreCustomerAvatar(Customer customer, byte[]? bytes)
+        => RestoreEntityAvatarSync(customer, bytes, CustomerAvatarSubdirectory);
+
+    /// <summary>
+    /// Restores a supplier's avatar to a prior state captured via
+    /// <see cref="ReadSupplierAvatarBytes"/>. Null restores "no avatar".
+    /// </summary>
+    public void RestoreSupplierAvatar(Supplier supplier, byte[]? bytes)
+        => RestoreEntityAvatarSync(supplier, bytes, SupplierAvatarSubdirectory);
+
+    /// <summary>
     /// Move the avatar file to track a renamed entity Id. Failure is non-fatal — if the
     /// file move can't complete, AvatarFileName is left at its previous value and the
     /// avatar simply won't load until the user re-uploads.

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using ArgoBooks.Core.Data;
 using ArgoBooks.Core.Models;
+using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Core.Models.Telemetry;
 
 namespace ArgoBooks.Core.Services;
@@ -107,6 +108,22 @@ public class CompanyManager : IDisposable
             var logoPath = Path.Combine(_currentTempDirectory, CompanyData.Settings.Company.LogoFileName);
             return File.Exists(logoPath) ? logoPath : null;
         }
+    }
+
+    private const string CustomerAvatarSubdirectory = "customer_avatars";
+    private const int CustomerAvatarMaxDimension = 256;
+
+    /// <summary>
+    /// Gets the absolute on-disk path to a customer's avatar image, or null when there is no
+    /// avatar set or the file is missing.
+    /// </summary>
+    public string? GetCustomerAvatarPath(Customer customer)
+    {
+        if (customer == null || string.IsNullOrEmpty(customer.AvatarFileName) || _currentTempDirectory == null)
+            return null;
+
+        var path = Path.Combine(_currentTempDirectory, customer.AvatarFileName);
+        return File.Exists(path) ? path : null;
     }
 
     /// <summary>
@@ -614,6 +631,78 @@ public class CompanyManager : IDisposable
         CompanyData.ChangesMade = true;
 
         CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Sets a customer's avatar from a source image on disk. The image is resized down
+    /// to a small PNG inside the company temp directory, so it gets bundled into the
+    /// encrypted .argo file on next save.
+    /// </summary>
+    public async Task SetCustomerAvatarAsync(Customer customer, string sourceImagePath)
+    {
+        ArgumentNullException.ThrowIfNull(customer);
+        ArgumentException.ThrowIfNullOrEmpty(sourceImagePath);
+
+        if (CompanyData == null || _currentTempDirectory == null)
+            throw new InvalidOperationException("No company is currently open.");
+
+        if (!File.Exists(sourceImagePath))
+            throw new FileNotFoundException("Avatar source file not found.", sourceImagePath);
+
+        var avatarsDir = Path.Combine(_currentTempDirectory, CustomerAvatarSubdirectory);
+        Directory.CreateDirectory(avatarsDir);
+
+        var safeId = SanitizeForFileName(customer.Id);
+        var fileName = $"{safeId}.png";
+        var destPath = Path.Combine(avatarsDir, fileName);
+        var relativePath = Path.Combine(CustomerAvatarSubdirectory, fileName).Replace('\\', '/');
+
+        var ok = await Task.Run(() => ReceiptImageHelper.ResizeAndSaveAsPng(sourceImagePath, destPath, CustomerAvatarMaxDimension));
+        if (!ok)
+            throw new InvalidOperationException("Selected file could not be loaded as an image.");
+
+        customer.AvatarFileName = relativePath;
+        customer.UpdatedAt = DateTime.UtcNow;
+        CompanyData.ChangesMade = true;
+
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Removes a customer's avatar image. Safe to call when no avatar is set.
+    /// </summary>
+    public async Task RemoveCustomerAvatarAsync(Customer customer)
+    {
+        ArgumentNullException.ThrowIfNull(customer);
+
+        if (CompanyData == null || _currentTempDirectory == null)
+            throw new InvalidOperationException("No company is currently open.");
+
+        var existing = customer.AvatarFileName;
+        if (string.IsNullOrEmpty(existing))
+            return;
+
+        var fullPath = Path.Combine(_currentTempDirectory, existing);
+        if (File.Exists(fullPath))
+        {
+            await Task.Run(() => File.Delete(fullPath));
+        }
+
+        customer.AvatarFileName = null;
+        customer.UpdatedAt = DateTime.UtcNow;
+        CompanyData.ChangesMade = true;
+
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static string SanitizeForFileName(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return Guid.NewGuid().ToString("N");
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var cleaned = new string(raw.Where(c => !invalid.Contains(c) && c != '.').ToArray()).Trim();
+        return string.IsNullOrEmpty(cleaned) ? Guid.NewGuid().ToString("N") : cleaned;
     }
 
     /// <summary>

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -934,19 +934,21 @@ public class CompanyManager : IDisposable
 
         foreach (var item in CompanyData.Inventory)
             if (item.ProductId == oldId) item.ProductId = trimmed;
-        foreach (var po in CompanyData.PurchaseOrders)
-            if (po.ProductId == oldId) po.ProductId = trimmed;
         foreach (var ld in CompanyData.LostDamaged)
             if (ld.ProductId == oldId) ld.ProductId = trimmed;
 
-        // Line items live on the parent (Invoice / Revenue / Expense) — both Revenue
-        // and Expense derive from Transaction which exposes LineItems.
+        // Line items live on the parent (Invoice / Revenue / Expense / PurchaseOrder).
+        // Revenue and Expense derive from Transaction which exposes LineItems<LineItem>;
+        // PurchaseOrder uses its own PurchaseOrderLineItem so the loop is inlined.
         foreach (var inv in CompanyData.Invoices)
             CascadeProductIdInLineItems(inv.LineItems, oldId, trimmed);
         foreach (var rev in CompanyData.Revenues)
             CascadeProductIdInLineItems(rev.LineItems, oldId, trimmed);
         foreach (var exp in CompanyData.Expenses)
             CascadeProductIdInLineItems(exp.LineItems, oldId, trimmed);
+        foreach (var po in CompanyData.PurchaseOrders)
+            foreach (var line in po.LineItems)
+                if (line.ProductId == oldId) line.ProductId = trimmed;
 
         // Return items live nested inside Return.Items
         foreach (var ret in CompanyData.Returns)

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -4,6 +4,7 @@ using ArgoBooks.Core.Data;
 using ArgoBooks.Core.Models;
 using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Core.Models.Telemetry;
+using ArgoBooks.Core.Models.Common;
 
 namespace ArgoBooks.Core.Services;
 
@@ -703,6 +704,175 @@ public class CompanyManager : IDisposable
         var invalid = Path.GetInvalidFileNameChars();
         var cleaned = new string(raw.Where(c => !invalid.Contains(c) && c != '.').ToArray()).Trim();
         return string.IsNullOrEmpty(cleaned) ? Guid.NewGuid().ToString("N") : cleaned;
+    }
+
+    /// <summary>
+    /// Renames a customer's Id, cascading to every reference inside the open company
+    /// (invoices, revenues, payments, rentals, recurring invoices, returns) and moving
+    /// the avatar file. Throws if newId is empty, equals an existing customer's Id,
+    /// or if no company is open. A no-op when newId equals the current Id.
+    /// </summary>
+    public void ChangeCustomerId(Customer customer, string newId)
+    {
+        ArgumentNullException.ThrowIfNull(customer);
+        if (CompanyData == null || _currentTempDirectory == null)
+            throw new InvalidOperationException("No company is currently open.");
+
+        var trimmed = newId?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(trimmed))
+            throw new ArgumentException("Customer ID cannot be empty.", nameof(newId));
+
+        var oldId = customer.Id;
+        if (string.Equals(oldId, trimmed, StringComparison.Ordinal))
+            return;
+
+        if (CompanyData.Customers.Any(c => !ReferenceEquals(c, customer) && c.Id == trimmed))
+            throw new InvalidOperationException($"Another customer already uses ID '{trimmed}'.");
+
+        // Cascade FK references
+        foreach (var inv in CompanyData.Invoices)
+            if (inv.CustomerId == oldId) inv.CustomerId = trimmed;
+        foreach (var rev in CompanyData.Revenues)
+            if (rev.CustomerId == oldId) rev.CustomerId = trimmed;
+        foreach (var pay in CompanyData.Payments)
+            if (pay.CustomerId == oldId) pay.CustomerId = trimmed;
+        foreach (var rent in CompanyData.Rentals)
+            if (rent.CustomerId == oldId) rent.CustomerId = trimmed;
+        foreach (var ri in CompanyData.RecurringInvoices)
+            if (ri.CustomerId == oldId) ri.CustomerId = trimmed;
+        foreach (var ret in CompanyData.Returns)
+            if (ret.CustomerId == oldId) ret.CustomerId = trimmed;
+
+        // Move the avatar file so its name still tracks the customer Id.
+        // Failure is non-fatal: the rename still succeeds, the avatar simply
+        // won't load until the user re-uploads.
+        if (!string.IsNullOrEmpty(customer.AvatarFileName))
+        {
+            try
+            {
+                var oldPath = Path.Combine(_currentTempDirectory, customer.AvatarFileName);
+                var ext = Path.GetExtension(customer.AvatarFileName);
+                var safeNewId = SanitizeForFileName(trimmed);
+                var newRelative = Path.Combine(CustomerAvatarSubdirectory, safeNewId + ext).Replace('\\', '/');
+                var newPath = Path.Combine(_currentTempDirectory, newRelative);
+
+                if (File.Exists(oldPath) && !string.Equals(oldPath, newPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(newPath)!);
+                    if (File.Exists(newPath))
+                        File.Delete(newPath);
+                    File.Move(oldPath, newPath);
+                }
+                customer.AvatarFileName = newRelative;
+            }
+            catch
+            {
+                // Leave AvatarFileName as-is; renaming the customer Id should not block on avatar I/O.
+            }
+        }
+
+        customer.Id = trimmed;
+        customer.UpdatedAt = DateTime.UtcNow;
+        // Cached Id→Customer lookup is keyed on the old Id; invalidate so the next
+        // GetCustomer(newId) rebuilds the dictionary.
+        CompanyData.InvalidateLookupCaches();
+        CompanyData.ChangesMade = true;
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Renames a supplier's Id, cascading to every reference inside the open company
+    /// (products, purchase orders, returns, expenses).
+    /// </summary>
+    public void ChangeSupplierId(Supplier supplier, string newId)
+    {
+        ArgumentNullException.ThrowIfNull(supplier);
+        if (CompanyData == null)
+            throw new InvalidOperationException("No company is currently open.");
+
+        var trimmed = newId?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(trimmed))
+            throw new ArgumentException("Supplier ID cannot be empty.", nameof(newId));
+
+        var oldId = supplier.Id;
+        if (string.Equals(oldId, trimmed, StringComparison.Ordinal))
+            return;
+
+        if (CompanyData.Suppliers.Any(s => !ReferenceEquals(s, supplier) && s.Id == trimmed))
+            throw new InvalidOperationException($"Another supplier already uses ID '{trimmed}'.");
+
+        foreach (var prod in CompanyData.Products)
+            if (prod.SupplierId == oldId) prod.SupplierId = trimmed;
+        foreach (var po in CompanyData.PurchaseOrders)
+            if (po.SupplierId == oldId) po.SupplierId = trimmed;
+        foreach (var ret in CompanyData.Returns)
+            if (ret.SupplierId == oldId) ret.SupplierId = trimmed;
+        foreach (var exp in CompanyData.Expenses)
+            if (exp.SupplierId == oldId) exp.SupplierId = trimmed;
+
+        supplier.Id = trimmed;
+        supplier.UpdatedAt = DateTime.UtcNow;
+        CompanyData.InvalidateLookupCaches();
+        CompanyData.ChangesMade = true;
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Renames a product's Id, cascading to every reference inside the open company
+    /// (inventory items, line items on invoices/revenues/expenses, purchase orders,
+    /// lost-damaged records, return items).
+    /// </summary>
+    public void ChangeProductId(Product product, string newId)
+    {
+        ArgumentNullException.ThrowIfNull(product);
+        if (CompanyData == null)
+            throw new InvalidOperationException("No company is currently open.");
+
+        var trimmed = newId?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(trimmed))
+            throw new ArgumentException("Product ID cannot be empty.", nameof(newId));
+
+        var oldId = product.Id;
+        if (string.Equals(oldId, trimmed, StringComparison.Ordinal))
+            return;
+
+        if (CompanyData.Products.Any(p => !ReferenceEquals(p, product) && p.Id == trimmed))
+            throw new InvalidOperationException($"Another product already uses ID '{trimmed}'.");
+
+        foreach (var item in CompanyData.Inventory)
+            if (item.ProductId == oldId) item.ProductId = trimmed;
+        foreach (var po in CompanyData.PurchaseOrders)
+            if (po.ProductId == oldId) po.ProductId = trimmed;
+        foreach (var ld in CompanyData.LostDamaged)
+            if (ld.ProductId == oldId) ld.ProductId = trimmed;
+
+        // Line items live on the parent (Invoice / Revenue / Expense) — both Revenue
+        // and Expense derive from Transaction which exposes LineItems.
+        foreach (var inv in CompanyData.Invoices)
+            CascadeProductIdInLineItems(inv.LineItems, oldId, trimmed);
+        foreach (var rev in CompanyData.Revenues)
+            CascadeProductIdInLineItems(rev.LineItems, oldId, trimmed);
+        foreach (var exp in CompanyData.Expenses)
+            CascadeProductIdInLineItems(exp.LineItems, oldId, trimmed);
+
+        // Return items live nested inside Return.Items
+        foreach (var ret in CompanyData.Returns)
+        {
+            foreach (var ri in ret.Items)
+                if (ri.ProductId == oldId) ri.ProductId = trimmed;
+        }
+
+        product.Id = trimmed;
+        product.UpdatedAt = DateTime.UtcNow;
+        CompanyData.InvalidateLookupCaches();
+        CompanyData.ChangesMade = true;
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static void CascadeProductIdInLineItems(List<LineItem> lineItems, string oldId, string newId)
+    {
+        foreach (var li in lineItems)
+            if (li.ProductId == oldId) li.ProductId = newId;
     }
 
     /// <summary>

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -112,7 +112,8 @@ public class CompanyManager : IDisposable
     }
 
     private const string CustomerAvatarSubdirectory = "customer_avatars";
-    private const int CustomerAvatarMaxDimension = 256;
+    private const string SupplierAvatarSubdirectory = "supplier_avatars";
+    private const int AvatarMaxDimension = 256;
 
     /// <summary>
     /// Resolves an avatar's relative path to an absolute path within the company temp
@@ -140,18 +141,135 @@ public class CompanyManager : IDisposable
             : null;
     }
 
+    private string? GetEntityAvatarPath(IAvatarOwner? entity)
+    {
+        if (entity == null) return null;
+        var path = ResolveAvatarPathSafely(entity.AvatarFileName);
+        return path != null && File.Exists(path) ? path : null;
+    }
+
+    private async Task SetEntityAvatarFromPathAsync(IAvatarOwner entity, string sourceImagePath, string subdirectory)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        ArgumentException.ThrowIfNullOrEmpty(sourceImagePath);
+        if (CompanyData == null || _currentTempDirectory == null)
+            throw new InvalidOperationException("No company is currently open.");
+        if (!File.Exists(sourceImagePath))
+            throw new FileNotFoundException("Avatar source file not found.", sourceImagePath);
+
+        var (destPath, relativePath) = PrepareAvatarDestination(entity.Id, subdirectory);
+        var ok = await Task.Run(() => ReceiptImageHelper.ResizeAndSaveAsPng(sourceImagePath, destPath, AvatarMaxDimension));
+        if (!ok)
+            throw new InvalidOperationException("Selected file could not be loaded as an image.");
+
+        FinalizeAvatarUpdate(entity, relativePath);
+    }
+
+    private async Task SetEntityAvatarFromBytesAsync(IAvatarOwner entity, byte[] sourceBytes, string subdirectory)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        ArgumentNullException.ThrowIfNull(sourceBytes);
+        if (CompanyData == null || _currentTempDirectory == null)
+            throw new InvalidOperationException("No company is currently open.");
+
+        var (destPath, relativePath) = PrepareAvatarDestination(entity.Id, subdirectory);
+        var ok = await Task.Run(() => ReceiptImageHelper.ResizeBytesAndSaveAsPng(sourceBytes, destPath, AvatarMaxDimension));
+        if (!ok)
+            throw new InvalidOperationException("Provided bytes could not be decoded as an image.");
+
+        FinalizeAvatarUpdate(entity, relativePath);
+    }
+
+    private (string DestPath, string RelativePath) PrepareAvatarDestination(string entityId, string subdirectory)
+    {
+        var avatarsDir = Path.Combine(_currentTempDirectory!, subdirectory);
+        Directory.CreateDirectory(avatarsDir);
+        var safeId = SanitizeForFileName(entityId);
+        var fileName = $"{safeId}.png";
+        var destPath = Path.Combine(avatarsDir, fileName);
+        var relativePath = Path.Combine(subdirectory, fileName).Replace('\\', '/');
+        return (destPath, relativePath);
+    }
+
+    private void FinalizeAvatarUpdate(IAvatarOwner entity, string relativePath)
+    {
+        entity.AvatarFileName = relativePath;
+        entity.UpdatedAt = DateTime.UtcNow;
+        CompanyData!.ChangesMade = true;
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async Task RemoveEntityAvatarAsync(IAvatarOwner entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        if (CompanyData == null || _currentTempDirectory == null)
+            throw new InvalidOperationException("No company is currently open.");
+
+        var existing = entity.AvatarFileName;
+        if (string.IsNullOrEmpty(existing))
+            return;
+
+        // Only delete files that resolve safely under the temp directory — guard against
+        // a crafted AvatarFileName escaping into the rest of the filesystem.
+        var fullPath = ResolveAvatarPathSafely(existing);
+        if (fullPath != null && File.Exists(fullPath))
+        {
+            await Task.Run(() => File.Delete(fullPath));
+        }
+
+        entity.AvatarFileName = null;
+        entity.UpdatedAt = DateTime.UtcNow;
+        CompanyData.ChangesMade = true;
+        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Move the avatar file to track a renamed entity Id. Failure is non-fatal — if the
+    /// file move can't complete, AvatarFileName is left at its previous value and the
+    /// avatar simply won't load until the user re-uploads.
+    /// </summary>
+    private void TryMoveEntityAvatarOnRename(IAvatarOwner entity, string newId, string subdirectory)
+    {
+        if (string.IsNullOrEmpty(entity.AvatarFileName) || _currentTempDirectory == null)
+            return;
+
+        try
+        {
+            var oldPath = ResolveAvatarPathSafely(entity.AvatarFileName);
+            var ext = Path.GetExtension(entity.AvatarFileName);
+            var safeNewId = SanitizeForFileName(newId);
+            var newRelative = Path.Combine(subdirectory, safeNewId + ext).Replace('\\', '/');
+            var newPath = Path.Combine(_currentTempDirectory, newRelative);
+
+            if (oldPath != null && File.Exists(oldPath) && !string.Equals(oldPath, newPath, StringComparison.OrdinalIgnoreCase))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(newPath)!);
+                if (File.Exists(newPath))
+                    File.Delete(newPath);
+                File.Move(oldPath, newPath);
+            }
+            // Always update AvatarFileName to the new relative path: even if the old
+            // file was missing or unsafe, the entity record should now point inside
+            // the temp dir using the new Id.
+            entity.AvatarFileName = newRelative;
+        }
+        catch
+        {
+            // Leave AvatarFileName as-is.
+        }
+    }
+
     /// <summary>
     /// Gets the absolute on-disk path to a customer's avatar image, or null when there is no
     /// avatar set, the file is missing, or the stored path escapes the company temp directory.
     /// </summary>
-    public string? GetCustomerAvatarPath(Customer customer)
-    {
-        if (customer == null)
-            return null;
+    public string? GetCustomerAvatarPath(Customer customer) => GetEntityAvatarPath(customer);
 
-        var path = ResolveAvatarPathSafely(customer.AvatarFileName);
-        return path != null && File.Exists(path) ? path : null;
-    }
+    /// <summary>
+    /// Gets the absolute on-disk path to a supplier's avatar image, or null when there is no
+    /// avatar set, the file is missing, or the stored path escapes the company temp directory.
+    /// </summary>
+    public string? GetSupplierAvatarPath(Supplier supplier) => GetEntityAvatarPath(supplier);
 
     /// <summary>
     /// Schedules a file rename to be applied on the next save.
@@ -665,64 +783,35 @@ public class CompanyManager : IDisposable
     /// to a small PNG inside the company temp directory, so it gets bundled into the
     /// encrypted .argo file on next save.
     /// </summary>
-    public async Task SetCustomerAvatarAsync(Customer customer, string sourceImagePath)
-    {
-        ArgumentNullException.ThrowIfNull(customer);
-        ArgumentException.ThrowIfNullOrEmpty(sourceImagePath);
-
-        if (CompanyData == null || _currentTempDirectory == null)
-            throw new InvalidOperationException("No company is currently open.");
-
-        if (!File.Exists(sourceImagePath))
-            throw new FileNotFoundException("Avatar source file not found.", sourceImagePath);
-
-        var avatarsDir = Path.Combine(_currentTempDirectory, CustomerAvatarSubdirectory);
-        Directory.CreateDirectory(avatarsDir);
-
-        var safeId = SanitizeForFileName(customer.Id);
-        var fileName = $"{safeId}.png";
-        var destPath = Path.Combine(avatarsDir, fileName);
-        var relativePath = Path.Combine(CustomerAvatarSubdirectory, fileName).Replace('\\', '/');
-
-        var ok = await Task.Run(() => ReceiptImageHelper.ResizeAndSaveAsPng(sourceImagePath, destPath, CustomerAvatarMaxDimension));
-        if (!ok)
-            throw new InvalidOperationException("Selected file could not be loaded as an image.");
-
-        customer.AvatarFileName = relativePath;
-        customer.UpdatedAt = DateTime.UtcNow;
-        CompanyData.ChangesMade = true;
-
-        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
-    }
+    public Task SetCustomerAvatarAsync(Customer customer, string sourceImagePath)
+        => SetEntityAvatarFromPathAsync(customer, sourceImagePath, CustomerAvatarSubdirectory);
 
     /// <summary>
     /// Removes a customer's avatar image. Safe to call when no avatar is set.
     /// </summary>
-    public async Task RemoveCustomerAvatarAsync(Customer customer)
-    {
-        ArgumentNullException.ThrowIfNull(customer);
+    public Task RemoveCustomerAvatarAsync(Customer customer)
+        => RemoveEntityAvatarAsync(customer);
 
-        if (CompanyData == null || _currentTempDirectory == null)
-            throw new InvalidOperationException("No company is currently open.");
+    /// <summary>
+    /// Sets a supplier's avatar from a source image on disk. Same semantics as the
+    /// customer variant — image is resized to a PNG inside the company temp directory.
+    /// </summary>
+    public Task SetSupplierAvatarAsync(Supplier supplier, string sourceImagePath)
+        => SetEntityAvatarFromPathAsync(supplier, sourceImagePath, SupplierAvatarSubdirectory);
 
-        var existing = customer.AvatarFileName;
-        if (string.IsNullOrEmpty(existing))
-            return;
+    /// <summary>
+    /// Sets a supplier's avatar from already-loaded bytes (e.g. a downloaded favicon).
+    /// The bytes can be in any Skia-supported format (ICO, PNG, JPG, ...) and are
+    /// re-encoded to PNG.
+    /// </summary>
+    public Task SetSupplierAvatarFromBytesAsync(Supplier supplier, byte[] imageBytes)
+        => SetEntityAvatarFromBytesAsync(supplier, imageBytes, SupplierAvatarSubdirectory);
 
-        // Only delete files that resolve safely under the temp directory — guard against
-        // a crafted AvatarFileName escaping into the rest of the filesystem.
-        var fullPath = ResolveAvatarPathSafely(existing);
-        if (fullPath != null && File.Exists(fullPath))
-        {
-            await Task.Run(() => File.Delete(fullPath));
-        }
-
-        customer.AvatarFileName = null;
-        customer.UpdatedAt = DateTime.UtcNow;
-        CompanyData.ChangesMade = true;
-
-        CompanyDataChanged?.Invoke(this, EventArgs.Empty);
-    }
+    /// <summary>
+    /// Removes a supplier's avatar image. Safe to call when no avatar is set.
+    /// </summary>
+    public Task RemoveSupplierAvatarAsync(Supplier supplier)
+        => RemoveEntityAvatarAsync(supplier);
 
     private static string SanitizeForFileName(string raw)
     {
@@ -771,39 +860,7 @@ public class CompanyManager : IDisposable
         foreach (var ret in CompanyData.Returns)
             if (ret.CustomerId == oldId) ret.CustomerId = trimmed;
 
-        // Move the avatar file so its name still tracks the customer Id.
-        // Failure is non-fatal: the rename still succeeds, the avatar simply
-        // won't load until the user re-uploads.
-        if (!string.IsNullOrEmpty(customer.AvatarFileName))
-        {
-            try
-            {
-                // Validate the old path stays inside the temp directory before doing any
-                // file ops — a crafted AvatarFileName must not be able to coerce a move
-                // (or implicit overwrite) of files outside the company's temp dir.
-                var oldPath = ResolveAvatarPathSafely(customer.AvatarFileName);
-                var ext = Path.GetExtension(customer.AvatarFileName);
-                var safeNewId = SanitizeForFileName(trimmed);
-                var newRelative = Path.Combine(CustomerAvatarSubdirectory, safeNewId + ext).Replace('\\', '/');
-                var newPath = Path.Combine(_currentTempDirectory, newRelative);
-
-                if (oldPath != null && File.Exists(oldPath) && !string.Equals(oldPath, newPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    Directory.CreateDirectory(Path.GetDirectoryName(newPath)!);
-                    if (File.Exists(newPath))
-                        File.Delete(newPath);
-                    File.Move(oldPath, newPath);
-                }
-                // Always update AvatarFileName to the new relative path: even if the old
-                // file was missing or unsafe, the customer record should now point inside
-                // the temp dir using the new Id.
-                customer.AvatarFileName = newRelative;
-            }
-            catch
-            {
-                // Leave AvatarFileName as-is; renaming the customer Id should not block on avatar I/O.
-            }
-        }
+        TryMoveEntityAvatarOnRename(customer, trimmed, CustomerAvatarSubdirectory);
 
         customer.Id = trimmed;
         customer.UpdatedAt = DateTime.UtcNow;
@@ -843,6 +900,8 @@ public class CompanyManager : IDisposable
             if (ret.SupplierId == oldId) ret.SupplierId = trimmed;
         foreach (var exp in CompanyData.Expenses)
             if (exp.SupplierId == oldId) exp.SupplierId = trimmed;
+
+        TryMoveEntityAvatarOnRename(supplier, trimmed, SupplierAvatarSubdirectory);
 
         supplier.Id = trimmed;
         supplier.UpdatedAt = DateTime.UtcNow;

--- a/ArgoBooks.Core/Services/FaviconService.cs
+++ b/ArgoBooks.Core/Services/FaviconService.cs
@@ -49,7 +49,11 @@ public static class FaviconService
 
         try
         {
-            using var response = await _client.Value.GetAsync(faviconUrl, cancellationToken).ConfigureAwait(false);
+            // ResponseHeadersRead returns as soon as the headers arrive. We can then
+            // inspect Content-Length / Content-Type before pulling the body — important
+            // because a hostile server could otherwise force us to buffer a giant
+            // response just to discover it's over the cap.
+            using var response = await _client.Value.GetAsync(faviconUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
                 return null;
 
@@ -63,11 +67,28 @@ public static class FaviconService
                 return null;
             }
 
-            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
-            if (bytes.Length == 0 || bytes.Length > MaxFaviconBytes)
+            // Reject upfront when the server is honest about an oversized payload.
+            var declaredLength = response.Content.Headers.ContentLength;
+            if (declaredLength.HasValue && declaredLength.Value > MaxFaviconBytes)
                 return null;
 
-            return bytes;
+            // Stream into a bounded buffer; abort the moment we cross the cap so a
+            // server lying about / omitting Content-Length can't force a huge alloc.
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            using var buffer = new MemoryStream(capacity: declaredLength.HasValue ? (int)Math.Min(declaredLength.Value, MaxFaviconBytes) : 16 * 1024);
+            var chunk = new byte[8192];
+            while (true)
+            {
+                var read = await contentStream.ReadAsync(chunk.AsMemory(), cancellationToken).ConfigureAwait(false);
+                if (read <= 0) break;
+                if (buffer.Length + read > MaxFaviconBytes)
+                    return null; // Server overran the cap mid-stream.
+                buffer.Write(chunk, 0, read);
+            }
+
+            if (buffer.Length == 0)
+                return null;
+            return buffer.ToArray();
         }
         catch
         {

--- a/ArgoBooks.Core/Services/FaviconService.cs
+++ b/ArgoBooks.Core/Services/FaviconService.cs
@@ -1,0 +1,77 @@
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Best-effort favicon downloader. Used to give a supplier a default avatar derived
+/// from its website when the user has not picked one. Direct GET against
+/// <c>{scheme}://{host}/favicon.ico</c> on the supplier's own domain — no third-party
+/// service is involved, which keeps the supplier list private and matches what the
+/// user's browser already does for that site.
+/// </summary>
+public static class FaviconService
+{
+    private const int MaxFaviconBytes = 2 * 1024 * 1024; // 2 MB hard cap
+    private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(5);
+
+    private static readonly Lazy<HttpClient> _client = new(() =>
+    {
+        var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 5
+        };
+        var client = new HttpClient(handler) { Timeout = FetchTimeout };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("ArgoBooks/1.0 (favicon fetcher)");
+        return client;
+    });
+
+    /// <summary>
+    /// Tries to download <c>/favicon.ico</c> for the host implied by <paramref name="websiteUrl"/>.
+    /// Returns the raw bytes (which may be ICO/PNG/etc) or null on any failure.
+    /// Always swallows exceptions — the caller treats null as "no favicon available".
+    /// </summary>
+    public static async Task<byte[]?> TryFetchFaviconAsync(string? websiteUrl, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(websiteUrl))
+            return null;
+
+        var input = websiteUrl.Trim();
+        if (!input.Contains("://", StringComparison.Ordinal))
+            input = "https://" + input;
+
+        if (!Uri.TryCreate(input, UriKind.Absolute, out var uri))
+            return null;
+        if (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp)
+            return null;
+        if (string.IsNullOrEmpty(uri.Host))
+            return null;
+
+        var faviconUrl = $"{uri.Scheme}://{uri.Host}/favicon.ico";
+
+        try
+        {
+            using var response = await _client.Value.GetAsync(faviconUrl, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            // Reject obviously-non-image responses (e.g. an HTML 200 page when the
+            // server doesn't have a real favicon and serves the index instead).
+            var contentType = response.Content.Headers.ContentType?.MediaType;
+            if (contentType != null
+                && !contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+                && !contentType.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            if (bytes.Length == 0 || bytes.Length > MaxFaviconBytes)
+                return null;
+
+            return bytes;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/ArgoBooks.Core/Services/ReceiptImageHelper.cs
+++ b/ArgoBooks.Core/Services/ReceiptImageHelper.cs
@@ -245,6 +245,33 @@ public static class ReceiptImageHelper
         }
 
         using var bitmap = SKBitmap.Decode(sourcePath);
+        return WriteResizedPng(bitmap, origin, destPath, maxDimension);
+    }
+
+    /// <summary>
+    /// Bytes-based variant of <see cref="ResizeAndSaveAsPng(string,string,int)"/> for callers
+    /// that already have the source image in memory (e.g. a downloaded favicon). Handles
+    /// .ico, .png, .jpg, and other Skia-supported formats.
+    /// </summary>
+    public static bool ResizeBytesAndSaveAsPng(byte[] sourceBytes, string destPath, int maxDimension)
+    {
+        if (sourceBytes == null || sourceBytes.Length == 0)
+            return false;
+
+        SKEncodedOrigin origin = SKEncodedOrigin.TopLeft;
+        using (var stream = new MemoryStream(sourceBytes, writable: false))
+        using (var codec = SKCodec.Create(stream))
+        {
+            if (codec != null)
+                origin = codec.EncodedOrigin;
+        }
+
+        using var bitmap = SKBitmap.Decode(sourceBytes);
+        return WriteResizedPng(bitmap, origin, destPath, maxDimension);
+    }
+
+    private static bool WriteResizedPng(SKBitmap? bitmap, SKEncodedOrigin origin, string destPath, int maxDimension)
+    {
         if (bitmap == null)
             return false;
 

--- a/ArgoBooks.Core/Services/ReceiptImageHelper.cs
+++ b/ArgoBooks.Core/Services/ReceiptImageHelper.cs
@@ -224,6 +224,50 @@ public static class ReceiptImageHelper
         return encoded.ToArray();
     }
 
+    /// <summary>
+    /// Loads an image from disk, downscales it to fit within <paramref name="maxDimension"/>
+    /// preserving aspect ratio, and writes it as PNG to <paramref name="destPath"/>.
+    /// PNG is used (lossless) so logos with text and small icons stay crisp at avatar sizes.
+    /// Returns false if the source could not be decoded.
+    /// </summary>
+    public static bool ResizeAndSaveAsPng(string sourcePath, string destPath, int maxDimension)
+    {
+        using var bitmap = SKBitmap.Decode(sourcePath);
+        if (bitmap == null)
+            return false;
+
+        var scale = Math.Min(
+            (float)maxDimension / bitmap.Width,
+            (float)maxDimension / bitmap.Height);
+
+        SKBitmap target;
+        if (scale >= 1f)
+        {
+            target = bitmap;
+        }
+        else
+        {
+            var newWidth = Math.Max(1, (int)(bitmap.Width * scale));
+            var newHeight = Math.Max(1, (int)(bitmap.Height * scale));
+            target = ResizeBitmap(bitmap, newWidth, newHeight);
+        }
+
+        try
+        {
+            using var image = SKImage.FromBitmap(target);
+            using var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var stream = File.Create(destPath);
+            encoded.SaveTo(stream);
+        }
+        finally
+        {
+            if (!ReferenceEquals(target, bitmap))
+                target.Dispose();
+        }
+
+        return true;
+    }
+
     internal static byte[] EncodeAsJpeg(SKBitmap bitmap, int quality)
     {
         using var image = SKImage.FromBitmap(bitmap);

--- a/ArgoBooks.Core/Services/ReceiptImageHelper.cs
+++ b/ArgoBooks.Core/Services/ReceiptImageHelper.cs
@@ -232,38 +232,46 @@ public static class ReceiptImageHelper
     /// </summary>
     public static bool ResizeAndSaveAsPng(string sourcePath, string destPath, int maxDimension)
     {
+        // Read the EXIF origin via SKCodec, then decode pixels separately from the path.
+        // Phone JPEGs encode rotation in EXIF rather than re-encoding the pixels, so
+        // portrait photos would otherwise end up sideways at the avatar size.
+        SKEncodedOrigin origin;
+        using (var orientationStream = File.OpenRead(sourcePath))
+        using (var codec = SKCodec.Create(orientationStream))
+        {
+            if (codec == null)
+                return false;
+            origin = codec.EncodedOrigin;
+        }
+
         using var bitmap = SKBitmap.Decode(sourcePath);
         if (bitmap == null)
             return false;
 
+        var swapDims = origin is SKEncodedOrigin.LeftBottom or SKEncodedOrigin.RightTop
+            or SKEncodedOrigin.LeftTop or SKEncodedOrigin.RightBottom;
+        var orientedWidth = swapDims ? bitmap.Height : bitmap.Width;
+        var orientedHeight = swapDims ? bitmap.Width : bitmap.Height;
+
         var scale = Math.Min(
-            (float)maxDimension / bitmap.Width,
-            (float)maxDimension / bitmap.Height);
+            (float)maxDimension / orientedWidth,
+            (float)maxDimension / orientedHeight);
+        if (scale > 1f)
+            scale = 1f;
 
-        SKBitmap target;
-        if (scale >= 1f)
-        {
-            target = bitmap;
-        }
-        else
-        {
-            var newWidth = Math.Max(1, (int)(bitmap.Width * scale));
-            var newHeight = Math.Max(1, (int)(bitmap.Height * scale));
-            target = ResizeBitmap(bitmap, newWidth, newHeight);
-        }
+        var targetWidth = Math.Max(1, (int)(orientedWidth * scale));
+        var targetHeight = Math.Max(1, (int)(orientedHeight * scale));
 
-        try
-        {
-            using var image = SKImage.FromBitmap(target);
-            using var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
-            using var stream = File.Create(destPath);
-            encoded.SaveTo(stream);
-        }
-        finally
-        {
-            if (!ReferenceEquals(target, bitmap))
-                target.Dispose();
-        }
+        using var surface = SKSurface.Create(new SKImageInfo(targetWidth, targetHeight));
+        var canvas = surface.Canvas;
+        canvas.Scale(scale, scale);
+        ApplyExifTransform(canvas, origin, bitmap.Width, bitmap.Height, orientedWidth, orientedHeight);
+        canvas.DrawBitmap(bitmap, 0, 0);
+
+        using var image = surface.Snapshot();
+        using var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Create(destPath);
+        encoded.SaveTo(stream);
 
         return true;
     }

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -1758,36 +1758,57 @@ public class App : Application
         // temp directory only when the modal is saved.
         _appShellViewModel.CustomerModalsViewModel.BrowseAvatarRequested += async (_, _) =>
         {
-            if (Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
-                return;
-
-            var files = await desktop.MainWindow!.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = "Select Customer Avatar".Translate(),
-                AllowMultiple = false,
-                FileTypeFilter =
-                [
-                    new FilePickerFileType("Images")
-                    {
-                        Patterns = ["*.png", "*.jpg", "*.jpeg"]
-                    }
-                ]
-            });
-
-            if (files.Count > 0)
-            {
-                var path = files[0].Path.LocalPath;
-                try
-                {
-                    var bitmap = new Bitmap(path);
-                    _appShellViewModel.CustomerModalsViewModel.SetPendingAvatar(path, bitmap);
-                }
-                catch (Exception ex)
-                {
-                    ErrorLogger?.LogWarning($"Failed to load avatar image: {ex.Message}", "CustomerAvatar");
-                }
-            }
+            await PickAvatarAsync(
+                "Select Customer Avatar".Translate(),
+                (path, bmp) => _appShellViewModel.CustomerModalsViewModel.SetPendingAvatar(path, bmp),
+                "CustomerAvatar");
         };
+
+        // Supplier modals — same pattern as customer.
+        _appShellViewModel.SupplierModalsViewModel.BrowseAvatarRequested += async (_, _) =>
+        {
+            await PickAvatarAsync(
+                "Select Supplier Avatar".Translate(),
+                (path, bmp) => _appShellViewModel.SupplierModalsViewModel.SetPendingAvatar(path, bmp),
+                "SupplierAvatar");
+        };
+    }
+
+    /// <summary>
+    /// Shows the OS image-picker, decodes the result into a Bitmap, and hands the
+    /// pair off to the caller. Centralized so customer and supplier avatar pickers
+    /// share the file-type filter and error handling.
+    /// </summary>
+    private static async Task PickAvatarAsync(string title, Action<string, Bitmap> onPicked, string errorTag)
+    {
+        if (Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+            return;
+
+        var files = await desktop.MainWindow!.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = title,
+            AllowMultiple = false,
+            FileTypeFilter =
+            [
+                new FilePickerFileType("Images")
+                {
+                    Patterns = ["*.png", "*.jpg", "*.jpeg"]
+                }
+            ]
+        });
+
+        if (files.Count == 0) return;
+
+        var path = files[0].Path.LocalPath;
+        try
+        {
+            var bitmap = new Bitmap(path);
+            onPicked(path, bitmap);
+        }
+        catch (Exception ex)
+        {
+            ErrorLogger?.LogWarning($"Failed to load avatar image: {ex.Message}", errorTag);
+        }
     }
 
     /// <summary>

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -1752,6 +1752,42 @@ public class App : Application
                 _appShellViewModel.InvoiceTemplateDesignerViewModel.SetLogoFromFile(files[0].Path.LocalPath);
             }
         };
+
+        // Customer modals — let the user pick an avatar image. The bitmap is loaded for
+        // an immediate preview; the file is staged and copied/resized into the company
+        // temp directory only when the modal is saved.
+        _appShellViewModel.CustomerModalsViewModel.BrowseAvatarRequested += async (_, _) =>
+        {
+            if (Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+                return;
+
+            var files = await desktop.MainWindow!.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = "Select Customer Avatar".Translate(),
+                AllowMultiple = false,
+                FileTypeFilter =
+                [
+                    new FilePickerFileType("Images")
+                    {
+                        Patterns = ["*.png", "*.jpg", "*.jpeg"]
+                    }
+                ]
+            });
+
+            if (files.Count > 0)
+            {
+                var path = files[0].Path.LocalPath;
+                try
+                {
+                    var bitmap = new Bitmap(path);
+                    _appShellViewModel.CustomerModalsViewModel.SetPendingAvatar(path, bitmap);
+                }
+                catch (Exception ex)
+                {
+                    ErrorLogger?.LogWarning($"Failed to load avatar image: {ex.Message}", "CustomerAvatar");
+                }
+            }
+        };
     }
 
     /// <summary>

--- a/ArgoBooks/Helpers/AvatarBitmapLoader.cs
+++ b/ArgoBooks/Helpers/AvatarBitmapLoader.cs
@@ -1,0 +1,38 @@
+using ArgoBooks.Core.Models.Entities;
+using Avalonia.Media.Imaging;
+
+namespace ArgoBooks.Helpers;
+
+/// <summary>
+/// Loads a customer's or supplier's avatar bitmap from the company temp directory,
+/// returning null if there's no avatar or the file fails to decode. Centralizes the
+/// path resolution + Bitmap construction that was otherwise duplicated across the
+/// list view models (Customers / Invoices / Revenue / Suppliers).
+/// </summary>
+public static class AvatarBitmapLoader
+{
+    public static Bitmap? LoadCustomer(Customer? customer)
+    {
+        if (customer == null) return null;
+        return LoadFromPath(App.CompanyManager?.GetCustomerAvatarPath(customer));
+    }
+
+    public static Bitmap? LoadSupplier(Supplier? supplier)
+    {
+        if (supplier == null) return null;
+        return LoadFromPath(App.CompanyManager?.GetSupplierAvatarPath(supplier));
+    }
+
+    private static Bitmap? LoadFromPath(string? path)
+    {
+        if (path == null) return null;
+        try
+        {
+            return new Bitmap(path);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/ArgoBooks/Modals/CustomerModals.axaml
+++ b/ArgoBooks/Modals/CustomerModals.axaml
@@ -55,6 +55,41 @@
                     <!-- Form Content -->
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Margin="24" Spacing="16">
+                            <!-- Avatar -->
+                            <Grid HorizontalAlignment="Center" Width="96" Height="96">
+                                <Button Classes="link"
+                                        Padding="0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        Cursor="Hand"
+                                        ToolTip.Tip="{loc:Loc 'Click to upload photo'}"
+                                        Command="{Binding BrowseAvatarCommand}">
+                                    <Border Width="80" Height="80" CornerRadius="40"
+                                            Background="{DynamicResource PrimaryBrush}"
+                                            ClipToBounds="True">
+                                        <Panel>
+                                            <TextBlock Text="{Binding ModalInitialsPreview}"
+                                                       FontSize="28" FontWeight="SemiBold"
+                                                       Foreground="White"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                       IsVisible="{Binding !HasModalAvatar}" />
+                                            <Image Source="{Binding ModalAvatarSource}"
+                                                   Stretch="UniformToFill"
+                                                   IsVisible="{Binding HasModalAvatar}" />
+                                        </Panel>
+                                    </Border>
+                                </Button>
+                                <Button Classes="icon-button"
+                                        Width="24" Height="24"
+                                        Padding="0"
+                                        HorizontalAlignment="Right" VerticalAlignment="Top"
+                                        ToolTip.Tip="{loc:Loc 'Remove photo'}"
+                                        Command="{Binding RemoveAvatarCommand}"
+                                        IsVisible="{Binding HasModalAvatar}">
+                                    <PathIcon Data="{x:Static icons:Icons.Close}" Width="12" Height="12" />
+                                </Button>
+                            </Grid>
+
                             <!-- ID, First Name and Last Name Row -->
                             <Grid ColumnDefinitions="Auto,16,*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6" Width="100">
@@ -200,6 +235,41 @@
                     <!-- Form Content (Same as Add + Status) -->
                     <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <StackPanel Margin="24" Spacing="16">
+                            <!-- Avatar -->
+                            <Grid HorizontalAlignment="Center" Width="96" Height="96">
+                                <Button Classes="link"
+                                        Padding="0"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        Cursor="Hand"
+                                        ToolTip.Tip="{loc:Loc 'Click to upload photo'}"
+                                        Command="{Binding BrowseAvatarCommand}">
+                                    <Border Width="80" Height="80" CornerRadius="40"
+                                            Background="{DynamicResource PrimaryBrush}"
+                                            ClipToBounds="True">
+                                        <Panel>
+                                            <TextBlock Text="{Binding ModalInitialsPreview}"
+                                                       FontSize="28" FontWeight="SemiBold"
+                                                       Foreground="White"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                       IsVisible="{Binding !HasModalAvatar}" />
+                                            <Image Source="{Binding ModalAvatarSource}"
+                                                   Stretch="UniformToFill"
+                                                   IsVisible="{Binding HasModalAvatar}" />
+                                        </Panel>
+                                    </Border>
+                                </Button>
+                                <Button Classes="icon-button"
+                                        Width="24" Height="24"
+                                        Padding="0"
+                                        HorizontalAlignment="Right" VerticalAlignment="Top"
+                                        ToolTip.Tip="{loc:Loc 'Remove photo'}"
+                                        Command="{Binding RemoveAvatarCommand}"
+                                        IsVisible="{Binding HasModalAvatar}">
+                                    <PathIcon Data="{x:Static icons:Icons.Close}" Width="12" Height="12" />
+                                </Button>
+                            </Grid>
+
                             <!-- ID, First Name and Last Name Row -->
                             <Grid ColumnDefinitions="Auto,16,*,16,*">
                                 <StackPanel Grid.Column="0" Spacing="6" Width="100">

--- a/ArgoBooks/Modals/CustomerModals.axaml
+++ b/ArgoBooks/Modals/CustomerModals.axaml
@@ -95,6 +95,11 @@
                                 <StackPanel Grid.Column="0" Spacing="6" Width="100">
                                     <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" PlaceholderText="{loc:Loc 'CUS-xxx'}" MaxLength="20" />
+                                    <TextBlock Text="{Binding ModalIdError}"
+                                               FontSize="12"
+                                               Foreground="{DynamicResource ErrorBrush}"
+                                               TextWrapping="Wrap"
+                                               IsVisible="{Binding ModalIdError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
@@ -275,6 +280,11 @@
                                 <StackPanel Grid.Column="0" Spacing="6" Width="100">
                                     <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" MaxLength="20" />
+                                    <TextBlock Text="{Binding ModalIdError}"
+                                               FontSize="12"
+                                               Foreground="{DynamicResource ErrorBrush}"
+                                               TextWrapping="Wrap"
+                                               IsVisible="{Binding ModalIdError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">

--- a/ArgoBooks/Modals/ProductModals.axaml
+++ b/ArgoBooks/Modals/ProductModals.axaml
@@ -49,6 +49,8 @@
                                 <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                     <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" PlaceholderText="{loc:Loc 'PRD-xxx'}" MaxLength="20" />
+                                    <TextBlock Text="{Binding ModalIdError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" TextWrapping="Wrap"
+                                               IsVisible="{Binding ModalIdError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
@@ -183,6 +185,8 @@
                                 <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                     <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                     <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" MaxLength="20" />
+                                    <TextBlock Text="{Binding ModalIdError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" TextWrapping="Wrap"
+                                               IsVisible="{Binding ModalIdError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                 </StackPanel>
                                 <StackPanel Grid.Column="2" Spacing="6">
                                     <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">

--- a/ArgoBooks/Modals/SupplierModals.axaml
+++ b/ArgoBooks/Modals/SupplierModals.axaml
@@ -26,6 +26,41 @@
                    </Border>
                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                        <StackPanel Margin="24" Spacing="16">
+                           <!-- Avatar — auto-fills from website favicon when the user has not picked an image -->
+                           <Grid HorizontalAlignment="Center" Width="96" Height="96">
+                               <Button Classes="link"
+                                       Padding="0"
+                                       Background="Transparent"
+                                       BorderThickness="0"
+                                       Cursor="Hand"
+                                       ToolTip.Tip="{loc:Loc 'Click to upload photo'}"
+                                       Command="{Binding BrowseAvatarCommand}">
+                                   <Border Width="80" Height="80" CornerRadius="8"
+                                           Background="{DynamicResource PrimaryBrush}"
+                                           ClipToBounds="True">
+                                       <Panel>
+                                           <TextBlock Text="{Binding ModalInitialsPreview}"
+                                                      FontSize="28" FontWeight="SemiBold"
+                                                      Foreground="White"
+                                                      HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                      IsVisible="{Binding !HasModalAvatar}" />
+                                           <Image Source="{Binding ModalAvatarSource}"
+                                                  Stretch="UniformToFill"
+                                                  IsVisible="{Binding HasModalAvatar}" />
+                                       </Panel>
+                                   </Border>
+                               </Button>
+                               <Button Classes="icon-button"
+                                       Width="24" Height="24"
+                                       Padding="0"
+                                       HorizontalAlignment="Right" VerticalAlignment="Top"
+                                       ToolTip.Tip="{loc:Loc 'Remove photo'}"
+                                       Command="{Binding RemoveAvatarCommand}"
+                                       IsVisible="{Binding HasModalAvatar}">
+                                   <PathIcon Data="{x:Static local:Icons.Close}" Width="12" Height="12" />
+                               </Button>
+                           </Grid>
+
                            <Grid ColumnDefinitions="Auto,16,*">
                                <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                    <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
@@ -125,6 +160,41 @@
                    </Border>
                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                        <StackPanel Margin="24" Spacing="16">
+                           <!-- Avatar — auto-fills from website favicon when the user has not picked an image -->
+                           <Grid HorizontalAlignment="Center" Width="96" Height="96">
+                               <Button Classes="link"
+                                       Padding="0"
+                                       Background="Transparent"
+                                       BorderThickness="0"
+                                       Cursor="Hand"
+                                       ToolTip.Tip="{loc:Loc 'Click to upload photo'}"
+                                       Command="{Binding BrowseAvatarCommand}">
+                                   <Border Width="80" Height="80" CornerRadius="8"
+                                           Background="{DynamicResource PrimaryBrush}"
+                                           ClipToBounds="True">
+                                       <Panel>
+                                           <TextBlock Text="{Binding ModalInitialsPreview}"
+                                                      FontSize="28" FontWeight="SemiBold"
+                                                      Foreground="White"
+                                                      HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                      IsVisible="{Binding !HasModalAvatar}" />
+                                           <Image Source="{Binding ModalAvatarSource}"
+                                                  Stretch="UniformToFill"
+                                                  IsVisible="{Binding HasModalAvatar}" />
+                                       </Panel>
+                                   </Border>
+                               </Button>
+                               <Button Classes="icon-button"
+                                       Width="24" Height="24"
+                                       Padding="0"
+                                       HorizontalAlignment="Right" VerticalAlignment="Top"
+                                       ToolTip.Tip="{loc:Loc 'Remove photo'}"
+                                       Command="{Binding RemoveAvatarCommand}"
+                                       IsVisible="{Binding HasModalAvatar}">
+                                   <PathIcon Data="{x:Static local:Icons.Close}" Width="12" Height="12" />
+                               </Button>
+                           </Grid>
+
                            <Grid ColumnDefinitions="Auto,16,*">
                                <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                    <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />

--- a/ArgoBooks/Modals/SupplierModals.axaml
+++ b/ArgoBooks/Modals/SupplierModals.axaml
@@ -30,6 +30,7 @@
                                <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                    <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" PlaceholderText="{loc:Loc 'SUP-xxx'}" MaxLength="20" />
+                                   <TextBlock Text="{Binding ModalIdError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" TextWrapping="Wrap" IsVisible="{Binding ModalIdError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
                                    <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">
@@ -128,6 +129,7 @@
                                <StackPanel Grid.Column="0" Spacing="6" Width="120">
                                    <TextBlock Text="{loc:Loc 'ID'}" FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}" />
                                    <TextBox Text="{Binding ModalId, Mode=TwoWay}" Classes="form-input" MaxLength="20" />
+                                   <TextBlock Text="{Binding ModalIdError}" FontSize="12" Foreground="{DynamicResource ErrorBrush}" TextWrapping="Wrap" IsVisible="{Binding ModalIdError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                </StackPanel>
                                <StackPanel Grid.Column="2" Spacing="6">
                                    <TextBlock FontSize="13" FontWeight="Medium" Foreground="{DynamicResource TextSecondaryBrush}">

--- a/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
@@ -559,13 +559,14 @@ public partial class CustomerModalsViewModel : ViewModelBase
         _originalNotes = ModalNotes;
 
         // Load existing avatar (if any) into the modal preview.
-        // Track _originalHasAvatar based on the customer's stored AvatarFileName, not
-        // on whether the bitmap actually decoded — that way if the file is missing or
-        // corrupted, the user can still hit Remove to clear the dangling reference.
+        // _originalHasAvatar tracks the persisted state (used for change detection so
+        // a missing/corrupt file can still be cleared on save). HasModalAvatar drives
+        // the *visual* — only set it when the bitmap actually decoded, otherwise the
+        // UI would show a blank Image control instead of falling back to initials.
         _pendingAvatarSourcePath = null;
         _shouldRemoveAvatarOnSave = false;
         _originalHasAvatar = !string.IsNullOrEmpty(customer.AvatarFileName);
-        HasModalAvatar = _originalHasAvatar;
+        HasModalAvatar = false;
         ModalAvatarSource = null;
 
         var avatarPath = App.CompanyManager?.GetCustomerAvatarPath(customer);
@@ -574,6 +575,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
             try
             {
                 ModalAvatarSource = new Bitmap(avatarPath);
+                HasModalAvatar = true;
             }
             catch
             {
@@ -710,17 +712,10 @@ public partial class CustomerModalsViewModel : ViewModelBase
         if (oldNotes != newNotes) changes["Notes"] = new FieldChange { OldValue = oldNotes, NewValue = newNotes };
         if (oldStatus != newStatus) changes["Status"] = new FieldChange { OldValue = oldStatus.ToString(), NewValue = newStatus.ToString() };
         if (changes.Count > 0) App.EventLogService?.SetPendingChanges(changes);
-        customerToEdit.Name = newName;
-        customerToEdit.CompanyName = newCompanyName;
-        customerToEdit.Email = newEmail;
-        customerToEdit.Phone = newPhone;
-        customerToEdit.Address = newAddress;
-        customerToEdit.Notes = newNotes;
-        customerToEdit.Status = newStatus;
-        customerToEdit.UpdatedAt = DateTime.UtcNow;
 
-        // Renaming the Id cascades to every reference (invoices, revenues, etc.)
-        // and moves the avatar file. Validation has already ensured uniqueness.
+        // Apply the Id rename FIRST so a failure (e.g. unique-constraint race) doesn't
+        // leave the entity with new field values but the old Id. Validation already
+        // prevents conflicts; this ordering is defense-in-depth.
         if (hasIdChange)
         {
             try
@@ -735,6 +730,15 @@ public partial class CustomerModalsViewModel : ViewModelBase
                 return;
             }
         }
+
+        customerToEdit.Name = newName;
+        customerToEdit.CompanyName = newCompanyName;
+        customerToEdit.Email = newEmail;
+        customerToEdit.Phone = newPhone;
+        customerToEdit.Address = newAddress;
+        customerToEdit.Notes = newNotes;
+        customerToEdit.Status = newStatus;
+        customerToEdit.UpdatedAt = DateTime.UtcNow;
 
         companyData.MarkAsModified();
 

--- a/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
@@ -559,29 +559,26 @@ public partial class CustomerModalsViewModel : ViewModelBase
         _originalNotes = ModalNotes;
 
         // Load existing avatar (if any) into the modal preview.
+        // Track _originalHasAvatar based on the customer's stored AvatarFileName, not
+        // on whether the bitmap actually decoded — that way if the file is missing or
+        // corrupted, the user can still hit Remove to clear the dangling reference.
         _pendingAvatarSourcePath = null;
         _shouldRemoveAvatarOnSave = false;
+        _originalHasAvatar = !string.IsNullOrEmpty(customer.AvatarFileName);
+        HasModalAvatar = _originalHasAvatar;
+        ModalAvatarSource = null;
+
         var avatarPath = App.CompanyManager?.GetCustomerAvatarPath(customer);
         if (avatarPath != null)
         {
             try
             {
                 ModalAvatarSource = new Bitmap(avatarPath);
-                HasModalAvatar = true;
-                _originalHasAvatar = true;
             }
             catch
             {
                 ModalAvatarSource = null;
-                HasModalAvatar = false;
-                _originalHasAvatar = false;
             }
-        }
-        else
-        {
-            ModalAvatarSource = null;
-            HasModalAvatar = false;
-            _originalHasAvatar = false;
         }
         OnPropertyChanged(nameof(ModalInitialsPreview));
 
@@ -838,6 +835,18 @@ public partial class CustomerModalsViewModel : ViewModelBase
             {
                 var deletedCustomer = customer;
                 App.EventLogService?.CapturePreDeletionSnapshot("Customer", deletedCustomer.Id);
+
+                // Clean up the avatar file before removing the customer. This avoids
+                // bloat (and retention of deleted-customer images) inside the .argo
+                // archive on next save. Undo of delete restores the customer record
+                // but the avatar is gone — acceptable degradation for a file the user
+                // explicitly chose to delete.
+                if (App.CompanyManager != null && !string.IsNullOrEmpty(deletedCustomer.AvatarFileName))
+                {
+                    try { await App.CompanyManager.RemoveCustomerAvatarAsync(deletedCustomer); }
+                    catch (Exception ex) { App.ErrorLogger?.LogWarning($"Failed to remove customer avatar on delete: {ex.Message}", "Customer.Delete"); }
+                }
+
                 companyData.Customers.Remove(customer);
                 companyData.MarkAsModified();
 

--- a/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
@@ -84,6 +84,9 @@ public partial class CustomerModalsViewModel : ViewModelBase
     private string _modalStatus = "Active";
 
     [ObservableProperty]
+    private string? _modalIdError;
+
+    [ObservableProperty]
     private string? _modalFirstNameError;
 
     [ObservableProperty]
@@ -94,6 +97,11 @@ public partial class CustomerModalsViewModel : ViewModelBase
 
     [ObservableProperty]
     private string? _modalPhoneError;
+
+    partial void OnModalIdChanged(string value)
+    {
+        ModalIdError = null;
+    }
 
     [ObservableProperty]
     private Bitmap? _modalAvatarSource;
@@ -184,6 +192,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
     private CustomerDisplayItem? _historyCustomer;
 
     // Original values for change detection in edit mode
+    private string _originalId = string.Empty;
     private string _originalFirstName = string.Empty;
     private string _originalLastName = string.Empty;
     private string _originalCompanyName = string.Empty;
@@ -217,6 +226,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
     /// Returns true if any changes have been made in the Edit modal.
     /// </summary>
     public bool HasEditModalChanges =>
+        ModalId.Trim() != _originalId ||
         ModalFirstName != _originalFirstName ||
         ModalLastName != _originalLastName ||
         ModalCompanyName != _originalCompanyName ||
@@ -535,6 +545,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
         };
 
         // Store original values for change detection
+        _originalId = ModalId;
         _originalFirstName = ModalFirstName;
         _originalLastName = ModalLastName;
         _originalCompanyName = ModalCompanyName;
@@ -611,6 +622,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
         if (companyData == null)
             return;
 
+        var oldId = _editingCustomer.Id;
         var oldName = _editingCustomer.Name;
         var oldCompanyName = _editingCustomer.CompanyName;
         var oldEmail = _editingCustomer.Email;
@@ -626,6 +638,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
         var oldNotes = _editingCustomer.Notes;
         var oldStatus = _editingCustomer.Status;
 
+        var newId = ModalId.Trim();
         var newName = $"{ModalFirstName.Trim()} {ModalLastName.Trim()}".Trim();
         var newCompanyName = string.IsNullOrWhiteSpace(ModalCompanyName) ? null : ModalCompanyName.Trim();
         var newEmail = ModalEmail.Trim();
@@ -648,7 +661,9 @@ public partial class CustomerModalsViewModel : ViewModelBase
         };
 
         // Check if anything actually changed
-        var hasFieldChanges = oldName != newName ||
+        var hasIdChange = oldId != newId;
+        var hasFieldChanges = hasIdChange ||
+                         oldName != newName ||
                          oldCompanyName != newCompanyName ||
                          oldEmail != newEmail ||
                          oldPhone != newPhone ||
@@ -687,6 +702,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
         var customerToEdit = _editingCustomer;
         App.EventLogService?.CapturePreModificationSnapshot("Customer", customerToEdit.Id);
         var changes = new Dictionary<string, FieldChange>();
+        if (hasIdChange) changes["ID"] = new FieldChange { OldValue = oldId, NewValue = newId };
         if (oldName != newName) changes["Name"] = new FieldChange { OldValue = oldName, NewValue = newName };
         if (oldCompanyName != newCompanyName) changes["Company"] = new FieldChange { OldValue = oldCompanyName ?? "", NewValue = newCompanyName ?? "" };
         if (oldEmail != newEmail) changes["Email"] = new FieldChange { OldValue = oldEmail, NewValue = newEmail };
@@ -706,12 +722,31 @@ public partial class CustomerModalsViewModel : ViewModelBase
         customerToEdit.Status = newStatus;
         customerToEdit.UpdatedAt = DateTime.UtcNow;
 
+        // Renaming the Id cascades to every reference (invoices, revenues, etc.)
+        // and moves the avatar file. Validation has already ensured uniqueness.
+        if (hasIdChange)
+        {
+            try
+            {
+                App.CompanyManager?.ChangeCustomerId(customerToEdit, newId);
+            }
+            catch (Exception ex)
+            {
+                App.ErrorLogger?.LogError(ex, Core.Models.Telemetry.ErrorCategory.Validation, "Customer.ChangeId");
+                ModalIdError = ex.Message;
+                HasValidationMessage = true;
+                return;
+            }
+        }
+
         companyData.MarkAsModified();
 
         App.UndoRedoManager.RecordAction(new DelegateAction(
             $"Edit customer '{newName}'",
             () =>
             {
+                if (hasIdChange)
+                    App.CompanyManager?.ChangeCustomerId(customerToEdit, oldId);
                 customerToEdit.Name = oldName;
                 customerToEdit.CompanyName = oldCompanyName;
                 customerToEdit.Email = oldEmail;
@@ -724,6 +759,8 @@ public partial class CustomerModalsViewModel : ViewModelBase
             },
             () =>
             {
+                if (hasIdChange)
+                    App.CompanyManager?.ChangeCustomerId(customerToEdit, newId);
                 customerToEdit.Name = newName;
                 customerToEdit.CompanyName = newCompanyName;
                 customerToEdit.Email = newEmail;
@@ -1163,6 +1200,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
     private void ClearModalFields()
     {
         ModalId = string.Empty;
+        _originalId = string.Empty;
         ModalFirstName = string.Empty;
         ModalLastName = string.Empty;
         ModalCompanyName = string.Empty;
@@ -1186,6 +1224,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
 
     private void ClearModalErrors()
     {
+        ModalIdError = null;
         ModalFirstNameError = null;
         ModalLastNameError = null;
         ModalEmailError = null;
@@ -1223,6 +1262,24 @@ public partial class CustomerModalsViewModel : ViewModelBase
         var companyData = App.CompanyManager?.CompanyData;
         if (companyData != null)
         {
+            var trimmedId = ModalId.Trim();
+            if (_editingCustomer != null && string.IsNullOrEmpty(trimmedId))
+            {
+                ModalIdError = "ID cannot be empty.".Translate();
+                isValid = false;
+            }
+            else if (!string.IsNullOrEmpty(trimmedId))
+            {
+                var existingWithSameId = companyData.Customers.Any(c =>
+                    c.Id == trimmedId &&
+                    (_editingCustomer == null || !ReferenceEquals(c, _editingCustomer)));
+                if (existingWithSameId)
+                {
+                    ModalIdError = "A customer with this ID already exists.".Translate();
+                    isValid = false;
+                }
+            }
+
             var fullName = $"{ModalFirstName.Trim()} {ModalLastName.Trim()}";
             var existingWithSameName = companyData.Customers.Any(c =>
                 c.Name.Equals(fullName, StringComparison.OrdinalIgnoreCase) &&

--- a/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
@@ -459,11 +459,16 @@ public partial class CustomerModalsViewModel : ViewModelBase
         // *after* the customer is in the collection so its Id is stable.
         await ApplyPendingAvatarChangeAsync(newCustomer);
 
+        // Snapshot the saved avatar bytes so undo can delete the file and redo can
+        // recreate it. Tiny PNG so the closure capture is cheap.
+        var newAvatarBytes = App.CompanyManager?.ReadCustomerAvatarBytes(newCustomer);
         var customerToUndo = newCustomer;
         App.UndoRedoManager.RecordAction(new DelegateAction(
             $"Add customer '{newCustomer.Name}'",
             () =>
             {
+                if (newAvatarBytes != null)
+                    App.CompanyManager?.RestoreCustomerAvatar(customerToUndo, null);
                 companyData.Customers.Remove(customerToUndo);
                 companyData.MarkAsModified();
                 CustomerSaved?.Invoke(this, EventArgs.Empty);
@@ -471,6 +476,8 @@ public partial class CustomerModalsViewModel : ViewModelBase
             () =>
             {
                 companyData.Customers.Add(customerToUndo);
+                if (newAvatarBytes != null)
+                    App.CompanyManager?.RestoreCustomerAvatar(customerToUndo, newAvatarBytes);
                 companyData.MarkAsModified();
                 CustomerSaved?.Invoke(this, EventArgs.Empty);
             }));
@@ -481,8 +488,8 @@ public partial class CustomerModalsViewModel : ViewModelBase
 
     /// <summary>
     /// Applies any pending avatar add/remove from the modal to the customer record.
-    /// Avatar changes are not part of the undo stack — they are intentionally one-way
-    /// to keep the implementation simple and avoid juggling files in undo callbacks.
+    /// Callers capture the resulting bytes via ReadCustomerAvatarBytes if they need
+    /// to include the change in an undo action.
     /// </summary>
     private async Task ApplyPendingAvatarChangeAsync(Customer customer)
     {
@@ -683,15 +690,38 @@ public partial class CustomerModalsViewModel : ViewModelBase
             return;
         }
 
-        // Apply avatar changes (not undoable — see ApplyPendingAvatarChangeAsync).
+        // Snapshot the avatar bytes BEFORE applying the change so the undo callback
+        // can write them back; capture again AFTER so redo restores the new state.
+        // Tiny resized PNG, so closure capture is cheap.
+        byte[]? oldAvatarBytes = null;
+        byte[]? newAvatarBytes = null;
         if (hasAvatarChanges)
         {
+            oldAvatarBytes = App.CompanyManager?.ReadCustomerAvatarBytes(_editingCustomer);
             await ApplyPendingAvatarChangeAsync(_editingCustomer);
+            newAvatarBytes = App.CompanyManager?.ReadCustomerAvatarBytes(_editingCustomer);
         }
 
         if (!hasFieldChanges)
         {
-            // Only the avatar changed — still notify so list views refresh, then close.
+            // Only the avatar changed — record a dedicated undo entry so the user
+            // can revert just the image change.
+            var customerForAvatarUndo = _editingCustomer;
+            App.UndoRedoManager.RecordAction(new DelegateAction(
+                $"Change customer '{customerForAvatarUndo.Name}' photo",
+                () =>
+                {
+                    App.CompanyManager?.RestoreCustomerAvatar(customerForAvatarUndo, oldAvatarBytes);
+                    companyData.MarkAsModified();
+                    CustomerSaved?.Invoke(this, EventArgs.Empty);
+                },
+                () =>
+                {
+                    App.CompanyManager?.RestoreCustomerAvatar(customerForAvatarUndo, newAvatarBytes);
+                    companyData.MarkAsModified();
+                    CustomerSaved?.Invoke(this, EventArgs.Empty);
+                }));
+
             companyData.MarkAsModified();
             CustomerSaved?.Invoke(this, EventArgs.Empty);
             CloseEditModal();
@@ -755,6 +785,8 @@ public partial class CustomerModalsViewModel : ViewModelBase
                 customerToEdit.Address = oldAddress;
                 customerToEdit.Notes = oldNotes;
                 customerToEdit.Status = oldStatus;
+                if (hasAvatarChanges)
+                    App.CompanyManager?.RestoreCustomerAvatar(customerToEdit, oldAvatarBytes);
                 companyData.MarkAsModified();
                 CustomerSaved?.Invoke(this, EventArgs.Empty);
             },
@@ -769,6 +801,8 @@ public partial class CustomerModalsViewModel : ViewModelBase
                 customerToEdit.Address = newAddress;
                 customerToEdit.Notes = newNotes;
                 customerToEdit.Status = newStatus;
+                if (hasAvatarChanges)
+                    App.CompanyManager?.RestoreCustomerAvatar(customerToEdit, newAvatarBytes);
                 companyData.MarkAsModified();
                 CustomerSaved?.Invoke(this, EventArgs.Empty);
             }));
@@ -840,12 +874,17 @@ public partial class CustomerModalsViewModel : ViewModelBase
                 var deletedCustomer = customer;
                 App.EventLogService?.CapturePreDeletionSnapshot("Customer", deletedCustomer.Id);
 
+                // Snapshot the avatar bytes BEFORE deleting so undo can restore the
+                // file alongside the customer record. The customer's AvatarFileName is
+                // also captured implicitly — the customer object stays alive in the
+                // closure and is mutated in place by RestoreCustomerAvatar.
+                var deletedAvatarBytes = App.CompanyManager?.ReadCustomerAvatarBytes(deletedCustomer);
+                var savedAvatarFileName = deletedCustomer.AvatarFileName;
+
                 // Clean up the avatar file before removing the customer. This avoids
                 // bloat (and retention of deleted-customer images) inside the .argo
-                // archive on next save. Undo of delete restores the customer record
-                // but the avatar is gone — acceptable degradation for a file the user
-                // explicitly chose to delete.
-                if (App.CompanyManager != null && !string.IsNullOrEmpty(deletedCustomer.AvatarFileName))
+                // archive on next save.
+                if (App.CompanyManager != null && !string.IsNullOrEmpty(savedAvatarFileName))
                 {
                     try { await App.CompanyManager.RemoveCustomerAvatarAsync(deletedCustomer); }
                     catch (Exception ex) { App.ErrorLogger?.LogWarning($"Failed to remove customer avatar on delete: {ex.Message}", "Customer.Delete"); }
@@ -859,11 +898,15 @@ public partial class CustomerModalsViewModel : ViewModelBase
                     () =>
                     {
                         companyData.Customers.Add(deletedCustomer);
+                        if (deletedAvatarBytes != null)
+                            App.CompanyManager?.RestoreCustomerAvatar(deletedCustomer, deletedAvatarBytes);
                         companyData.MarkAsModified();
                         CustomerDeleted?.Invoke(this, EventArgs.Empty);
                     },
                     () =>
                     {
+                        if (deletedAvatarBytes != null)
+                            App.CompanyManager?.RestoreCustomerAvatar(deletedCustomer, null);
                         companyData.Customers.Remove(deletedCustomer);
                         companyData.MarkAsModified();
                         CustomerDeleted?.Invoke(this, EventArgs.Empty);

--- a/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomerModalsViewModel.cs
@@ -6,6 +6,7 @@ using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models;
 using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Entities;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -94,12 +95,62 @@ public partial class CustomerModalsViewModel : ViewModelBase
     [ObservableProperty]
     private string? _modalPhoneError;
 
+    [ObservableProperty]
+    private Bitmap? _modalAvatarSource;
+
+    [ObservableProperty]
+    private bool _hasModalAvatar;
+
+    /// <summary>
+    /// Path of an avatar image picked in the modal that should be applied on save.
+    /// Null if the user did not pick a new image during this session.
+    /// </summary>
+    private string? _pendingAvatarSourcePath;
+
+    /// <summary>
+    /// True when the user clicked Remove on an existing avatar; on save the customer's
+    /// avatar file should be deleted.
+    /// </summary>
+    private bool _shouldRemoveAvatarOnSave;
+
+    /// <summary>
+    /// Snapshot of whether the customer had an avatar when the edit modal was opened —
+    /// used for change detection.
+    /// </summary>
+    private bool _originalHasAvatar;
+
+    /// <summary>
+    /// Live preview of the initials that would be shown if no avatar is set,
+    /// driven from ModalFirstName + ModalLastName so the avatar circle in the
+    /// modal updates as the user types.
+    /// </summary>
+    public string ModalInitialsPreview
+    {
+        get
+        {
+            var first = ModalFirstName?.Trim() ?? string.Empty;
+            var last = ModalLastName?.Trim() ?? string.Empty;
+            if (first.Length > 0 && last.Length > 0)
+                return $"{char.ToUpperInvariant(first[0])}{char.ToUpperInvariant(last[0])}";
+            if (first.Length >= 2)
+                return first[..2].ToUpperInvariant();
+            if (first.Length == 1)
+                return first.ToUpperInvariant();
+            if (last.Length >= 2)
+                return last[..2].ToUpperInvariant();
+            if (last.Length == 1)
+                return last.ToUpperInvariant();
+            return "?";
+        }
+    }
+
     partial void OnModalFirstNameChanged(string value)
     {
         if (!string.IsNullOrWhiteSpace(value))
         {
             ModalFirstNameError = null;
         }
+        OnPropertyChanged(nameof(ModalInitialsPreview));
     }
 
     partial void OnModalLastNameChanged(string value)
@@ -108,6 +159,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
         {
             ModalLastNameError = null;
         }
+        OnPropertyChanged(nameof(ModalInitialsPreview));
     }
 
     partial void OnModalPhoneChanged(string value)
@@ -158,7 +210,8 @@ public partial class CustomerModalsViewModel : ViewModelBase
         !string.IsNullOrWhiteSpace(ModalStateProvince) ||
         !string.IsNullOrWhiteSpace(ModalZipCode) ||
         !string.IsNullOrWhiteSpace(ModalCountry) ||
-        !string.IsNullOrWhiteSpace(ModalNotes);
+        !string.IsNullOrWhiteSpace(ModalNotes) ||
+        HasModalAvatar;
 
     /// <summary>
     /// Returns true if any changes have been made in the Edit modal.
@@ -174,7 +227,9 @@ public partial class CustomerModalsViewModel : ViewModelBase
         ModalStateProvince != _originalStateProvince ||
         ModalZipCode != _originalZipCode ||
         ModalCountry != _originalCountry ||
-        ModalNotes != _originalNotes;
+        ModalNotes != _originalNotes ||
+        _pendingAvatarSourcePath != null ||
+        _shouldRemoveAvatarOnSave;
 
     #endregion
 
@@ -273,6 +328,44 @@ public partial class CustomerModalsViewModel : ViewModelBase
     /// </summary>
     public event EventHandler? FiltersCleared;
 
+    /// <summary>
+    /// Fired when the user clicks the avatar in the modal to pick a new image.
+    /// App.axaml.cs subscribes and shows the OS file picker.
+    /// </summary>
+    public event EventHandler? BrowseAvatarRequested;
+
+    #endregion
+
+    #region Avatar Commands
+
+    [RelayCommand]
+    private void BrowseAvatar()
+    {
+        BrowseAvatarRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void RemoveAvatar()
+    {
+        ModalAvatarSource = null;
+        HasModalAvatar = false;
+        _pendingAvatarSourcePath = null;
+        _shouldRemoveAvatarOnSave = _originalHasAvatar;
+        OnPropertyChanged(nameof(ModalInitialsPreview));
+    }
+
+    /// <summary>
+    /// Called by App.axaml.cs after the user picks an avatar image. Updates the
+    /// preview bitmap and stages the source path to be applied on save.
+    /// </summary>
+    public void SetPendingAvatar(string path, Bitmap bitmap)
+    {
+        _pendingAvatarSourcePath = path;
+        _shouldRemoveAvatarOnSave = false;
+        ModalAvatarSource = bitmap;
+        HasModalAvatar = true;
+    }
+
     #endregion
 
     #region Add Customer
@@ -308,7 +401,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    public void SaveNewCustomer()
+    public async Task SaveNewCustomerAsync()
     {
         if (!ValidateModal())
             return;
@@ -352,6 +445,10 @@ public partial class CustomerModalsViewModel : ViewModelBase
         companyData.Customers.Add(newCustomer);
         companyData.MarkAsModified();
 
+        // Persist the avatar image (if one was picked) into the company temp directory
+        // *after* the customer is in the collection so its Id is stable.
+        await ApplyPendingAvatarChangeAsync(newCustomer);
+
         var customerToUndo = newCustomer;
         App.UndoRedoManager.RecordAction(new DelegateAction(
             $"Add customer '{newCustomer.Name}'",
@@ -370,6 +467,34 @@ public partial class CustomerModalsViewModel : ViewModelBase
 
         CustomerSaved?.Invoke(this, EventArgs.Empty);
         CloseAddModal();
+    }
+
+    /// <summary>
+    /// Applies any pending avatar add/remove from the modal to the customer record.
+    /// Avatar changes are not part of the undo stack — they are intentionally one-way
+    /// to keep the implementation simple and avoid juggling files in undo callbacks.
+    /// </summary>
+    private async Task ApplyPendingAvatarChangeAsync(Customer customer)
+    {
+        var manager = App.CompanyManager;
+        if (manager == null)
+            return;
+
+        try
+        {
+            if (_pendingAvatarSourcePath != null)
+            {
+                await manager.SetCustomerAvatarAsync(customer, _pendingAvatarSourcePath);
+            }
+            else if (_shouldRemoveAvatarOnSave)
+            {
+                await manager.RemoveCustomerAvatarAsync(customer);
+            }
+        }
+        catch (Exception ex)
+        {
+            App.ErrorLogger?.LogError(ex, Core.Models.Telemetry.ErrorCategory.Validation, "Customer.ApplyAvatarChange");
+        }
     }
 
     #endregion
@@ -422,6 +547,33 @@ public partial class CustomerModalsViewModel : ViewModelBase
         _originalCountry = ModalCountry;
         _originalNotes = ModalNotes;
 
+        // Load existing avatar (if any) into the modal preview.
+        _pendingAvatarSourcePath = null;
+        _shouldRemoveAvatarOnSave = false;
+        var avatarPath = App.CompanyManager?.GetCustomerAvatarPath(customer);
+        if (avatarPath != null)
+        {
+            try
+            {
+                ModalAvatarSource = new Bitmap(avatarPath);
+                HasModalAvatar = true;
+                _originalHasAvatar = true;
+            }
+            catch
+            {
+                ModalAvatarSource = null;
+                HasModalAvatar = false;
+                _originalHasAvatar = false;
+            }
+        }
+        else
+        {
+            ModalAvatarSource = null;
+            HasModalAvatar = false;
+            _originalHasAvatar = false;
+        }
+        OnPropertyChanged(nameof(ModalInitialsPreview));
+
         ClearModalErrors();
         IsEditModalOpen = true;
     }
@@ -450,7 +602,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    public void SaveEditedCustomer()
+    public async Task SaveEditedCustomerAsync()
     {
         if (!ValidateModal() || _editingCustomer == null)
             return;
@@ -496,7 +648,7 @@ public partial class CustomerModalsViewModel : ViewModelBase
         };
 
         // Check if anything actually changed
-        var hasChanges = oldName != newName ||
+        var hasFieldChanges = oldName != newName ||
                          oldCompanyName != newCompanyName ||
                          oldEmail != newEmail ||
                          oldPhone != newPhone ||
@@ -508,9 +660,26 @@ public partial class CustomerModalsViewModel : ViewModelBase
                          oldNotes != newNotes ||
                          oldStatus != newStatus;
 
+        var hasAvatarChanges = _pendingAvatarSourcePath != null || _shouldRemoveAvatarOnSave;
+
         // If nothing changed, just close the modal without recording an action
-        if (!hasChanges)
+        if (!hasFieldChanges && !hasAvatarChanges)
         {
+            CloseEditModal();
+            return;
+        }
+
+        // Apply avatar changes (not undoable — see ApplyPendingAvatarChangeAsync).
+        if (hasAvatarChanges)
+        {
+            await ApplyPendingAvatarChangeAsync(_editingCustomer);
+        }
+
+        if (!hasFieldChanges)
+        {
+            // Only the avatar changed — still notify so list views refresh, then close.
+            companyData.MarkAsModified();
+            CustomerSaved?.Invoke(this, EventArgs.Empty);
             CloseEditModal();
             return;
         }
@@ -1006,6 +1175,12 @@ public partial class CustomerModalsViewModel : ViewModelBase
         ModalCountry = string.Empty;
         ModalNotes = string.Empty;
         ModalStatus = "Active";
+        ModalAvatarSource = null;
+        HasModalAvatar = false;
+        _pendingAvatarSourcePath = null;
+        _shouldRemoveAvatarOnSave = false;
+        _originalHasAvatar = false;
+        OnPropertyChanged(nameof(ModalInitialsPreview));
         ClearModalErrors();
     }
 

--- a/ArgoBooks/ViewModels/CustomersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomersPageViewModel.cs
@@ -446,7 +446,7 @@ public partial class CustomersPageViewModel : SortablePageViewModelBase
                 addressParts.Add(customer.Address.State);
             var addressString = addressParts.Count > 0 ? string.Join(", ", addressParts) : "-";
 
-            var avatarBitmap = LoadCustomerAvatarBitmap(customer);
+            var avatarBitmap = AvatarBitmapLoader.LoadCustomer(customer);
 
             return new CustomerDisplayItem
             {
@@ -499,22 +499,6 @@ public partial class CustomersPageViewModel : SortablePageViewModelBase
             .Take(PageSize);
 
         Customers.ReplaceAll(pagedCustomers);
-    }
-
-    private static Bitmap? LoadCustomerAvatarBitmap(Customer customer)
-    {
-        var path = App.CompanyManager?.GetCustomerAvatarPath(customer);
-        if (path == null)
-            return null;
-
-        try
-        {
-            return new Bitmap(path);
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     protected override void UpdatePageNumbers()

--- a/ArgoBooks/ViewModels/CustomersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/CustomersPageViewModel.cs
@@ -9,6 +9,7 @@ using ArgoBooks.Core.Services;
 using ArgoBooks.Localization;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -445,6 +446,8 @@ public partial class CustomersPageViewModel : SortablePageViewModelBase
                 addressParts.Add(customer.Address.State);
             var addressString = addressParts.Count > 0 ? string.Join(", ", addressParts) : "-";
 
+            var avatarBitmap = LoadCustomerAvatarBitmap(customer);
+
             return new CustomerDisplayItem
             {
                 Id = customer.Id,
@@ -455,7 +458,9 @@ public partial class CustomersPageViewModel : SortablePageViewModelBase
                 Country = string.IsNullOrWhiteSpace(customer.Address.Country) ? "-" : customer.Address.Country,
                 LastRental = customer.LastTransactionDate,
                 Status = customer.Status,
-                IsHighlighted = customer.Id == HighlightTransactionId
+                IsHighlighted = customer.Id == HighlightTransactionId,
+                AvatarBitmap = avatarBitmap,
+                HasAvatar = avatarBitmap != null
             };
         }).ToList();
 
@@ -494,6 +499,22 @@ public partial class CustomersPageViewModel : SortablePageViewModelBase
             .Take(PageSize);
 
         Customers.ReplaceAll(pagedCustomers);
+    }
+
+    private static Bitmap? LoadCustomerAvatarBitmap(Customer customer)
+    {
+        var path = App.CompanyManager?.GetCustomerAvatarPath(customer);
+        if (path == null)
+            return null;
+
+        try
+        {
+            return new Bitmap(path);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     protected override void UpdatePageNumbers()
@@ -937,6 +958,12 @@ public partial class CustomerDisplayItem : ObservableObject
 
     [ObservableProperty]
     private EntityStatus _status = EntityStatus.Active;
+
+    [ObservableProperty]
+    private Bitmap? _avatarBitmap;
+
+    [ObservableProperty]
+    private bool _hasAvatar;
 
     /// <summary>
     /// Gets the initials from the customer name for avatar display.

--- a/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
@@ -2,11 +2,13 @@ using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
+using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Core.Models.Portal;
 using ArgoBooks.Core.Models.Transactions;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ArgoBooks.Helpers;
@@ -662,6 +664,8 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
                 : null;
             var statusDisplay = GetStatusDisplay(invoice);
 
+            var avatarBitmap = LoadCustomerAvatar(customer);
+
             return new InvoiceDisplayItem
             {
                 Id = invoice.Id,
@@ -670,6 +674,8 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
                 CustomerId = invoice.CustomerId,
                 CustomerName = customer?.Name ?? "Unknown Customer",
                 CustomerInitials = GetInitials(customer?.Name ?? "?"),
+                CustomerAvatarBitmap = avatarBitmap,
+                HasCustomerAvatar = avatarBitmap != null,
                 IssueDate = invoice.IssueDate,
                 DueDate = invoice.DueDate,
                 Subtotal = invoice.Subtotal,
@@ -743,6 +749,25 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
             InvoiceStatus.Cancelled => "Cancelled",
             _ => "Unknown"
         };
+    }
+
+    private static Bitmap? LoadCustomerAvatar(Customer? customer)
+    {
+        if (customer == null)
+            return null;
+
+        var path = App.CompanyManager?.GetCustomerAvatarPath(customer);
+        if (path == null)
+            return null;
+
+        try
+        {
+            return new Bitmap(path);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static string GetInitials(string name)
@@ -875,6 +900,12 @@ public partial class InvoiceDisplayItem : ObservableObject
 
     [ObservableProperty]
     private string _customerInitials = string.Empty;
+
+    [ObservableProperty]
+    private Bitmap? _customerAvatarBitmap;
+
+    [ObservableProperty]
+    private bool _hasCustomerAvatar;
 
     [ObservableProperty]
     private DateTime _issueDate;

--- a/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoicesPageViewModel.cs
@@ -2,7 +2,6 @@ using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
-using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Core.Models.Portal;
 using ArgoBooks.Core.Models.Transactions;
 using ArgoBooks.Core.Services;
@@ -664,7 +663,7 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
                 : null;
             var statusDisplay = GetStatusDisplay(invoice);
 
-            var avatarBitmap = LoadCustomerAvatar(customer);
+            var avatarBitmap = AvatarBitmapLoader.LoadCustomer(customer);
 
             return new InvoiceDisplayItem
             {
@@ -749,25 +748,6 @@ public partial class InvoicesPageViewModel : SortablePageViewModelBase
             InvoiceStatus.Cancelled => "Cancelled",
             _ => "Unknown"
         };
-    }
-
-    private static Bitmap? LoadCustomerAvatar(Customer? customer)
-    {
-        if (customer == null)
-            return null;
-
-        var path = App.CompanyManager?.GetCustomerAvatarPath(customer);
-        if (path == null)
-            return null;
-
-        try
-        {
-            return new Bitmap(path);
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     private static string GetInitials(string name)

--- a/ArgoBooks/ViewModels/ProductModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ProductModalsViewModel.cs
@@ -93,10 +93,18 @@ public partial class ProductModalsViewModel : ViewModelBase
     private string? _modalError;
 
     [ObservableProperty]
+    private string? _modalIdError;
+
+    [ObservableProperty]
     private string? _modalProductNameError;
 
     [ObservableProperty]
     private string? _modalCategoryError;
+
+    partial void OnModalIdChanged(string value)
+    {
+        ModalIdError = null;
+    }
 
     partial void OnModalProductNameChanged(string value)
     {
@@ -127,6 +135,7 @@ public partial class ProductModalsViewModel : ViewModelBase
     private bool _isExpensesTab = true;
 
     // Original values for change detection in edit mode
+    private string _originalId = string.Empty;
     private string _originalProductName = string.Empty;
     private string _originalDescription = string.Empty;
     private string _originalItemType = "Product";
@@ -157,6 +166,7 @@ public partial class ProductModalsViewModel : ViewModelBase
     /// Returns true if any changes have been made in the Edit modal.
     /// </summary>
     public bool HasEditModalChanges =>
+        ModalId.Trim() != _originalId ||
         ModalProductName != _originalProductName ||
         ModalDescription != _originalDescription ||
         ModalItemType != _originalItemType ||
@@ -386,6 +396,7 @@ public partial class ProductModalsViewModel : ViewModelBase
         UpdateDropdownOptions();
 
         ModalId = product.Id;
+        _originalId = product.Id;
         ModalProductName = product.Name;
         ModalDescription = product.Description;
         ModalSku = product.Sku;
@@ -465,6 +476,7 @@ public partial class ProductModalsViewModel : ViewModelBase
         if (companyData == null)
             return;
 
+        var oldId = _editingProduct.Id;
         var oldName = _editingProduct.Name;
         var oldDescription = _editingProduct.Description;
         var oldSku = _editingProduct.Sku;
@@ -476,9 +488,11 @@ public partial class ProductModalsViewModel : ViewModelBase
         var oldReorderPoint = _editingProduct.ReorderPoint;
         var oldOverstockThreshold = _editingProduct.OverstockThreshold;
 
+        var newId = ModalId.Trim();
         var newName = ModalProductName.Trim();
         var newDescription = string.IsNullOrWhiteSpace(ModalDescription) ? string.Empty : ModalDescription.Trim();
-        var newSku = string.IsNullOrWhiteSpace(ModalSku) ? _editingProduct.Id : ModalSku.Trim();
+        // SKU defaults to the product's *new* Id when blank, so the fallback follows a rename.
+        var newSku = string.IsNullOrWhiteSpace(ModalSku) ? newId : ModalSku.Trim();
         var newCategoryId = ModalCategory?.Id;
         var newSupplierId = ModalSupplier?.Id;
         var newUnitPrice = decimal.TryParse(ModalUnitPrice, out var unitPrice) ? unitPrice : 0;
@@ -488,7 +502,9 @@ public partial class ProductModalsViewModel : ViewModelBase
         var newTrackInventory = ModalTrackInventory;
 
         // Check if anything actually changed
-        var hasChanges = oldName != newName ||
+        var hasIdChange = oldId != newId;
+        var hasChanges = hasIdChange ||
+                         oldName != newName ||
                          oldDescription != newDescription ||
                          oldSku != newSku ||
                          oldCategoryId != newCategoryId ||
@@ -509,6 +525,7 @@ public partial class ProductModalsViewModel : ViewModelBase
         var productToEdit = _editingProduct;
         App.EventLogService?.CapturePreModificationSnapshot("Product", productToEdit.Id);
         var changes = new Dictionary<string, FieldChange>();
+        if (hasIdChange) changes["ID"] = new FieldChange { OldValue = oldId, NewValue = newId };
         if (oldName != newName) changes["Name"] = new FieldChange { OldValue = oldName, NewValue = newName };
         if (oldDescription != newDescription) changes["Description"] = new FieldChange { OldValue = oldDescription, NewValue = newDescription };
         if (oldSku != newSku) changes["SKU"] = new FieldChange { OldValue = oldSku, NewValue = newSku };
@@ -530,12 +547,27 @@ public partial class ProductModalsViewModel : ViewModelBase
         productToEdit.OverstockThreshold = newOverstockThreshold;
         productToEdit.UpdatedAt = DateTime.UtcNow;
 
+        if (hasIdChange)
+        {
+            try
+            {
+                App.CompanyManager?.ChangeProductId(productToEdit, newId);
+            }
+            catch (Exception ex)
+            {
+                App.ErrorLogger?.LogError(ex, Core.Models.Telemetry.ErrorCategory.Validation, "Product.ChangeId");
+                ModalIdError = ex.Message;
+                return;
+            }
+        }
+
         companyData.MarkAsModified();
 
         App.UndoRedoManager.RecordAction(new DelegateAction(
             $"Edit product '{newName}'",
             () =>
             {
+                if (hasIdChange) App.CompanyManager?.ChangeProductId(productToEdit, oldId);
                 productToEdit.Name = oldName;
                 productToEdit.Description = oldDescription;
                 productToEdit.Sku = oldSku;
@@ -551,6 +583,7 @@ public partial class ProductModalsViewModel : ViewModelBase
             },
             () =>
             {
+                if (hasIdChange) App.CompanyManager?.ChangeProductId(productToEdit, newId);
                 productToEdit.Name = newName;
                 productToEdit.Description = newDescription;
                 productToEdit.Sku = newSku;
@@ -764,6 +797,8 @@ public partial class ProductModalsViewModel : ViewModelBase
     private void ClearModalFields()
     {
         ModalId = string.Empty;
+        _originalId = string.Empty;
+        ModalIdError = null;
         ModalProductName = string.Empty;
         ModalDescription = string.Empty;
         ModalItemType = "Product";
@@ -784,10 +819,33 @@ public partial class ProductModalsViewModel : ViewModelBase
     private bool ValidateModal()
     {
         ModalError = null;
+        ModalIdError = null;
         ModalProductNameError = null;
         ModalCategoryError = null;
 
         var isValid = true;
+
+        var companyDataForId = App.CompanyManager?.CompanyData;
+        if (companyDataForId != null)
+        {
+            var trimmedId = ModalId.Trim();
+            if (_editingProduct != null && string.IsNullOrEmpty(trimmedId))
+            {
+                ModalIdError = "ID cannot be empty.".Translate();
+                isValid = false;
+            }
+            else if (!string.IsNullOrEmpty(trimmedId))
+            {
+                var existingWithSameId = companyDataForId.Products.Any(p =>
+                    p.Id == trimmedId &&
+                    (_editingProduct == null || !ReferenceEquals(p, _editingProduct)));
+                if (existingWithSameId)
+                {
+                    ModalIdError = "A product with this ID already exists.".Translate();
+                    isValid = false;
+                }
+            }
+        }
 
         if (string.IsNullOrWhiteSpace(ModalProductName))
         {

--- a/ArgoBooks/ViewModels/ProductModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/ProductModalsViewModel.cs
@@ -535,18 +535,10 @@ public partial class ProductModalsViewModel : ViewModelBase
         if (oldReorderPoint != newReorderPoint) changes["Reorder Point"] = new FieldChange { OldValue = oldReorderPoint.ToString(), NewValue = newReorderPoint.ToString() };
         if (oldOverstockThreshold != newOverstockThreshold) changes["Overstock Threshold"] = new FieldChange { OldValue = oldOverstockThreshold.ToString(), NewValue = newOverstockThreshold.ToString() };
         if (changes.Count > 0) App.EventLogService?.SetPendingChanges(changes);
-        productToEdit.Name = newName;
-        productToEdit.Description = newDescription;
-        productToEdit.Sku = newSku;
-        productToEdit.CategoryId = newCategoryId;
-        productToEdit.SupplierId = newSupplierId;
-        productToEdit.UnitPrice = newUnitPrice;
-        productToEdit.CostPrice = newCostPrice;
-        productToEdit.TrackInventory = newTrackInventory;
-        productToEdit.ReorderPoint = newReorderPoint;
-        productToEdit.OverstockThreshold = newOverstockThreshold;
-        productToEdit.UpdatedAt = DateTime.UtcNow;
 
+        // Apply the Id rename FIRST so a failure doesn't leave the product with new
+        // field values but the old Id. Validation already prevents conflicts; this
+        // ordering is defense-in-depth.
         if (hasIdChange)
         {
             try
@@ -560,6 +552,18 @@ public partial class ProductModalsViewModel : ViewModelBase
                 return;
             }
         }
+
+        productToEdit.Name = newName;
+        productToEdit.Description = newDescription;
+        productToEdit.Sku = newSku;
+        productToEdit.CategoryId = newCategoryId;
+        productToEdit.SupplierId = newSupplierId;
+        productToEdit.UnitPrice = newUnitPrice;
+        productToEdit.CostPrice = newCostPrice;
+        productToEdit.TrackInventory = newTrackInventory;
+        productToEdit.ReorderPoint = newReorderPoint;
+        productToEdit.OverstockThreshold = newOverstockThreshold;
+        productToEdit.UpdatedAt = DateTime.UtcNow;
 
         companyData.MarkAsModified();
 

--- a/ArgoBooks/ViewModels/RevenuePageViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenuePageViewModel.cs
@@ -1,7 +1,6 @@
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
-using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Core.Models.Transactions;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Services;
@@ -490,7 +489,7 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
             var hasReceipt = !string.IsNullOrEmpty(revenue.ReceiptId);
             var receipt = hasReceipt ? companyData?.Receipts.FirstOrDefault(r => r.Id == revenue.ReceiptId) : null;
             var receiptFilePath = receipt?.OriginalFilePath ?? string.Empty;
-            var customerAvatar = LoadCustomerAvatar(customer);
+            var customerAvatar = AvatarBitmapLoader.LoadCustomer(customer);
 
             return new RevenueDisplayItem
             {
@@ -696,25 +695,6 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
 
         // Use the shared receipt viewer modal
         App.ReceiptViewerModal?.Show(receiptPath, item.Id);
-    }
-
-    private static Bitmap? LoadCustomerAvatar(Customer? customer)
-    {
-        if (customer == null)
-            return null;
-
-        var path = App.CompanyManager?.GetCustomerAvatarPath(customer);
-        if (path == null)
-            return null;
-
-        try
-        {
-            return new Bitmap(path);
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     private static string? GetReceiptImagePath(string revenueId)

--- a/ArgoBooks/ViewModels/RevenuePageViewModel.cs
+++ b/ArgoBooks/ViewModels/RevenuePageViewModel.cs
@@ -1,11 +1,13 @@
 using ArgoBooks.Controls;
 using ArgoBooks.Controls.ColumnWidths;
 using ArgoBooks.Core.Enums;
+using ArgoBooks.Core.Models.Entities;
 using ArgoBooks.Core.Models.Transactions;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
 using ArgoBooks.Helpers;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -488,6 +490,7 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
             var hasReceipt = !string.IsNullOrEmpty(revenue.ReceiptId);
             var receipt = hasReceipt ? companyData?.Receipts.FirstOrDefault(r => r.Id == revenue.ReceiptId) : null;
             var receiptFilePath = receipt?.OriginalFilePath ?? string.Empty;
+            var customerAvatar = LoadCustomerAvatar(customer);
 
             return new RevenueDisplayItem
             {
@@ -523,7 +526,9 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
                 IsHighlighted = revenue.Id == HighlightTransactionId,
                 InvoiceId = revenue.InvoiceId ?? string.Empty,
                 IsPendingConversion = revenue.IsPendingConversion,
-                OriginalCurrency = revenue.OriginalCurrency
+                OriginalCurrency = revenue.OriginalCurrency,
+                CustomerAvatarBitmap = customerAvatar,
+                HasCustomerAvatar = customerAvatar != null
             };
         }).ToList();
 
@@ -693,6 +698,25 @@ public partial class RevenuePageViewModel : SortablePageViewModelBase
         App.ReceiptViewerModal?.Show(receiptPath, item.Id);
     }
 
+    private static Bitmap? LoadCustomerAvatar(Customer? customer)
+    {
+        if (customer == null)
+            return null;
+
+        var path = App.CompanyManager?.GetCustomerAvatarPath(customer);
+        if (path == null)
+            return null;
+
+        try
+        {
+            return new Bitmap(path);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static string? GetReceiptImagePath(string revenueId)
     {
         // Always load from company file to ensure consistency
@@ -816,6 +840,12 @@ public partial class RevenueDisplayItem : ObservableObject
 
     [ObservableProperty]
     private string _originalCurrency = "USD";
+
+    [ObservableProperty]
+    private Bitmap? _customerAvatarBitmap;
+
+    [ObservableProperty]
+    private bool _hasCustomerAvatar;
 
     public string DateFormatted => DateFormatService.Format(Date);
     public string TotalFormatted => IsPendingConversion

--- a/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
@@ -452,11 +452,28 @@ public partial class SupplierModalsViewModel : ViewModelBase
         // temp directory after the supplier is in the collection so its Id is stable.
         await ApplyPendingAvatarChangeAsync(newSupplier);
 
+        // Snapshot the saved avatar bytes so undo can delete the file and redo can
+        // recreate it.
+        var newAvatarBytes = App.CompanyManager?.ReadSupplierAvatarBytes(newSupplier);
         var supplierToUndo = newSupplier;
         App.UndoRedoManager.RecordAction(new DelegateAction(
             $"Add supplier '{newSupplier.Name}'",
-            () => { companyData.Suppliers.Remove(supplierToUndo); companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty); },
-            () => { companyData.Suppliers.Add(supplierToUndo); companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty); }));
+            () =>
+            {
+                if (newAvatarBytes != null)
+                    App.CompanyManager?.RestoreSupplierAvatar(supplierToUndo, null);
+                companyData.Suppliers.Remove(supplierToUndo);
+                companyData.MarkAsModified();
+                SupplierSaved?.Invoke(this, EventArgs.Empty);
+            },
+            () =>
+            {
+                companyData.Suppliers.Add(supplierToUndo);
+                if (newAvatarBytes != null)
+                    App.CompanyManager?.RestoreSupplierAvatar(supplierToUndo, newAvatarBytes);
+                companyData.MarkAsModified();
+                SupplierSaved?.Invoke(this, EventArgs.Empty);
+            }));
 
         SupplierSaved?.Invoke(this, EventArgs.Empty);
         CloseAddModal();
@@ -464,8 +481,8 @@ public partial class SupplierModalsViewModel : ViewModelBase
 
     /// <summary>
     /// Applies any pending avatar change (manual upload, fetched favicon, or removal)
-    /// to the supplier record. Avatar changes are not part of the undo stack — keeps
-    /// the implementation simple and avoids juggling files in undo callbacks.
+    /// to the supplier record. Callers capture the resulting bytes via
+    /// ReadSupplierAvatarBytes if they need to include the change in an undo action.
     /// Manual upload wins over a pending favicon if both somehow exist.
     /// </summary>
     private async Task ApplyPendingAvatarChangeAsync(Supplier supplier)
@@ -643,14 +660,37 @@ public partial class SupplierModalsViewModel : ViewModelBase
             return;
         }
 
-        // Apply avatar changes (not undoable — see ApplyPendingAvatarChangeAsync).
+        // Snapshot the avatar bytes BEFORE applying the change so undo can write them
+        // back; capture again AFTER so redo restores the new state.
+        byte[]? oldAvatarBytes = null;
+        byte[]? newAvatarBytes = null;
         if (hasAvatarChanges)
         {
+            oldAvatarBytes = App.CompanyManager?.ReadSupplierAvatarBytes(_editingSupplier);
             await ApplyPendingAvatarChangeAsync(_editingSupplier);
+            newAvatarBytes = App.CompanyManager?.ReadSupplierAvatarBytes(_editingSupplier);
         }
 
         if (!hasFieldChanges)
         {
+            // Only the avatar changed — record a dedicated undo entry so the user
+            // can revert just the image change.
+            var supplierForAvatarUndo = _editingSupplier;
+            App.UndoRedoManager.RecordAction(new DelegateAction(
+                $"Change supplier '{supplierForAvatarUndo.Name}' photo",
+                () =>
+                {
+                    App.CompanyManager?.RestoreSupplierAvatar(supplierForAvatarUndo, oldAvatarBytes);
+                    companyData.MarkAsModified();
+                    SupplierSaved?.Invoke(this, EventArgs.Empty);
+                },
+                () =>
+                {
+                    App.CompanyManager?.RestoreSupplierAvatar(supplierForAvatarUndo, newAvatarBytes);
+                    companyData.MarkAsModified();
+                    SupplierSaved?.Invoke(this, EventArgs.Empty);
+                }));
+
             companyData.MarkAsModified();
             SupplierSaved?.Invoke(this, EventArgs.Empty);
             CloseEditModal();
@@ -703,11 +743,15 @@ public partial class SupplierModalsViewModel : ViewModelBase
             $"Edit supplier '{newName}'",
             () => {
                 if (hasIdChange) App.CompanyManager?.ChangeSupplierId(supplierToEdit, oldId);
-                supplierToEdit.Name = oldName; supplierToEdit.Email = oldEmail; supplierToEdit.Phone = oldPhone; supplierToEdit.Website = oldWebsite; supplierToEdit.Address = oldAddress; supplierToEdit.Notes = oldNotes; companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty);
+                supplierToEdit.Name = oldName; supplierToEdit.Email = oldEmail; supplierToEdit.Phone = oldPhone; supplierToEdit.Website = oldWebsite; supplierToEdit.Address = oldAddress; supplierToEdit.Notes = oldNotes;
+                if (hasAvatarChanges) App.CompanyManager?.RestoreSupplierAvatar(supplierToEdit, oldAvatarBytes);
+                companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty);
             },
             () => {
                 if (hasIdChange) App.CompanyManager?.ChangeSupplierId(supplierToEdit, newId);
-                supplierToEdit.Name = newName; supplierToEdit.Email = newEmail; supplierToEdit.Phone = newPhone; supplierToEdit.Website = newWebsite; supplierToEdit.Address = newAddress; supplierToEdit.Notes = newNotes; companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty);
+                supplierToEdit.Name = newName; supplierToEdit.Email = newEmail; supplierToEdit.Phone = newPhone; supplierToEdit.Website = newWebsite; supplierToEdit.Address = newAddress; supplierToEdit.Notes = newNotes;
+                if (hasAvatarChanges) App.CompanyManager?.RestoreSupplierAvatar(supplierToEdit, newAvatarBytes);
+                companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty);
             }));
 
         SupplierSaved?.Invoke(this, EventArgs.Empty);
@@ -768,10 +812,12 @@ public partial class SupplierModalsViewModel : ViewModelBase
             var deletedSupplier = supplier;
             App.EventLogService?.CapturePreDeletionSnapshot("Supplier", deletedSupplier.Id);
 
+            // Snapshot the avatar bytes BEFORE deleting so undo can restore the
+            // file alongside the supplier record.
+            var deletedAvatarBytes = App.CompanyManager?.ReadSupplierAvatarBytes(deletedSupplier);
+
             // Clean up the avatar file before removing the supplier — avoids bloat and
             // retention of deleted-supplier images in the .argo archive on next save.
-            // Mirrors the customer-delete behavior. Undo of delete restores the supplier
-            // record but not the avatar.
             if (App.CompanyManager != null && !string.IsNullOrEmpty(deletedSupplier.AvatarFileName))
             {
                 try { await App.CompanyManager.RemoveSupplierAvatarAsync(deletedSupplier); }
@@ -783,8 +829,20 @@ public partial class SupplierModalsViewModel : ViewModelBase
 
             App.UndoRedoManager.RecordAction(new DelegateAction(
                 $"Delete supplier '{supplier.Name}'",
-                () => { companyData?.Suppliers.Add(deletedSupplier); companyData?.MarkAsModified(); SupplierDeleted?.Invoke(this, EventArgs.Empty); },
-                () => { companyData?.Suppliers.Remove(deletedSupplier); companyData?.MarkAsModified(); SupplierDeleted?.Invoke(this, EventArgs.Empty); }));
+                () => {
+                    companyData?.Suppliers.Add(deletedSupplier);
+                    if (deletedAvatarBytes != null)
+                        App.CompanyManager?.RestoreSupplierAvatar(deletedSupplier, deletedAvatarBytes);
+                    companyData?.MarkAsModified();
+                    SupplierDeleted?.Invoke(this, EventArgs.Empty);
+                },
+                () => {
+                    if (deletedAvatarBytes != null)
+                        App.CompanyManager?.RestoreSupplierAvatar(deletedSupplier, null);
+                    companyData?.Suppliers.Remove(deletedSupplier);
+                    companyData?.MarkAsModified();
+                    SupplierDeleted?.Invoke(this, EventArgs.Empty);
+                }));
 
             SupplierDeleted?.Invoke(this, EventArgs.Empty);
         }

--- a/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
@@ -150,11 +150,6 @@ public partial class SupplierModalsViewModel : ViewModelBase
         ModalIdError = null;
     }
 
-    partial void OnModalSupplierNameChanged(string value)
-    {
-        OnPropertyChanged(nameof(ModalInitialsPreview));
-    }
-
     partial void OnModalWebsiteChanged(string value)
     {
         // Auto-fetch the supplier's /favicon.ico — but only when the user has not
@@ -306,7 +301,16 @@ public partial class SupplierModalsViewModel : ViewModelBase
     /// </summary>
     private void TriggerFaviconFetch(string? websiteUrl)
     {
-        _faviconCts?.Cancel();
+        // Cancel and dispose the previous CTS — keystroke-driven calls would otherwise
+        // leak a CancellationTokenSource (and its underlying timer) per keystroke.
+        var previous = _faviconCts;
+        if (previous != null)
+        {
+            previous.Cancel();
+            previous.Dispose();
+        }
+        _faviconCts = null;
+
         if (string.IsNullOrWhiteSpace(websiteUrl))
             return;
 
@@ -356,6 +360,14 @@ public partial class SupplierModalsViewModel : ViewModelBase
             catch (Exception ex)
             {
                 App.ErrorLogger?.LogWarning($"Favicon fetch failed: {ex.Message}", "Supplier.Favicon");
+            }
+            finally
+            {
+                // Drop our reference if the field still points at this CTS (i.e. no newer
+                // keystroke has replaced it). The CTS is disposable; release it.
+                if (ReferenceEquals(_faviconCts, cts))
+                    _faviconCts = null;
+                cts.Dispose();
             }
         });
     }
@@ -498,16 +510,25 @@ public partial class SupplierModalsViewModel : ViewModelBase
         // Load the existing avatar BEFORE setting ModalWebsite — that way the
         // OnModalWebsiteChanged hook sees HasModalAvatar=true and skips the favicon
         // fetch instead of racing to overwrite the existing avatar.
+        // _originalHasAvatar tracks the persisted state for change detection;
+        // HasModalAvatar drives the *visual* and is only set when the bitmap actually
+        // decoded — otherwise the UI would show a blank Image instead of falling back
+        // to initials. (If decode fails and the supplier has a website, the favicon
+        // hook will then auto-fetch a replacement, which is graceful recovery.)
         _pendingAvatarSourcePath = null;
         _pendingFaviconBytes = null;
         _shouldRemoveAvatarOnSave = false;
         _originalHasAvatar = !string.IsNullOrEmpty(supplier.AvatarFileName);
-        HasModalAvatar = _originalHasAvatar;
+        HasModalAvatar = false;
         ModalAvatarSource = null;
         var existingAvatarPath = App.CompanyManager?.GetSupplierAvatarPath(supplier);
         if (existingAvatarPath != null)
         {
-            try { ModalAvatarSource = new Bitmap(existingAvatarPath); }
+            try
+            {
+                ModalAvatarSource = new Bitmap(existingAvatarPath);
+                HasModalAvatar = true;
+            }
             catch { ModalAvatarSource = null; }
         }
         OnPropertyChanged(nameof(ModalInitialsPreview));
@@ -649,14 +670,10 @@ public partial class SupplierModalsViewModel : ViewModelBase
         if (oldAddr != newAddr) changes["Address"] = new FieldChange { OldValue = oldAddr, NewValue = newAddr };
         if (oldNotes != newNotes) changes["Notes"] = new FieldChange { OldValue = oldNotes, NewValue = newNotes };
         if (changes.Count > 0) App.EventLogService?.SetPendingChanges(changes);
-        supplierToEdit.Name = newName;
-        supplierToEdit.Email = newEmail;
-        supplierToEdit.Phone = newPhone;
-        supplierToEdit.Website = newWebsite;
-        supplierToEdit.Address = newAddress;
-        supplierToEdit.Notes = newNotes;
-        supplierToEdit.UpdatedAt = DateTime.UtcNow;
 
+        // Apply the Id rename FIRST so a failure doesn't leave the entity with new
+        // field values but the old Id. Validation already prevents conflicts; this
+        // ordering is defense-in-depth.
         if (hasIdChange)
         {
             try
@@ -671,6 +688,14 @@ public partial class SupplierModalsViewModel : ViewModelBase
                 return;
             }
         }
+
+        supplierToEdit.Name = newName;
+        supplierToEdit.Email = newEmail;
+        supplierToEdit.Phone = newPhone;
+        supplierToEdit.Website = newWebsite;
+        supplierToEdit.Address = newAddress;
+        supplierToEdit.Notes = newNotes;
+        supplierToEdit.UpdatedAt = DateTime.UtcNow;
 
         companyData.MarkAsModified();
 
@@ -849,6 +874,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
         {
             ModalSupplierNameError = null;
         }
+        OnPropertyChanged(nameof(ModalInitialsPreview));
     }
 
     partial void OnModalEmailChanged(string value)
@@ -875,8 +901,13 @@ public partial class SupplierModalsViewModel : ViewModelBase
 
     private void ClearModalFields()
     {
-        // Cancel any in-flight favicon fetch from a previous open of the modal.
-        _faviconCts?.Cancel();
+        // Cancel and dispose any in-flight favicon fetch from a previous open of the modal.
+        var fetchInFlight = _faviconCts;
+        if (fetchInFlight != null)
+        {
+            fetchInFlight.Cancel();
+            fetchInFlight.Dispose();
+        }
         _faviconCts = null;
 
         ModalId = string.Empty;

--- a/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
@@ -77,6 +77,9 @@ public partial class SupplierModalsViewModel : ViewModelBase
     private string? _modalError;
 
     [ObservableProperty]
+    private string? _modalIdError;
+
+    [ObservableProperty]
     private string? _modalSupplierNameError;
 
     [ObservableProperty]
@@ -85,9 +88,15 @@ public partial class SupplierModalsViewModel : ViewModelBase
     [ObservableProperty]
     private string? _modalPhoneError;
 
+    partial void OnModalIdChanged(string value)
+    {
+        ModalIdError = null;
+    }
+
     private Supplier? _editingSupplier;
 
     // Original values for change detection in edit mode
+    private string _originalId = string.Empty;
     private string _originalSupplierName = string.Empty;
     private string _originalEmail = string.Empty;
     private string _originalPhone = string.Empty;
@@ -118,6 +127,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
     /// Returns true if any changes have been made in the Edit modal.
     /// </summary>
     public bool HasEditModalChanges =>
+        ModalId.Trim() != _originalId ||
         ModalSupplierName != _originalSupplierName ||
         ModalEmail != _originalEmail ||
         ModalPhone != _originalPhone ||
@@ -271,6 +281,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
 
         _editingSupplier = supplier;
         ModalId = supplier.Id;
+        _originalId = supplier.Id;
         ModalSupplierName = supplier.Name;
         ModalEmail = supplier.Email;
         ModalPhone = supplier.Phone;
@@ -329,6 +340,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
         var companyData = App.CompanyManager?.CompanyData;
         if (companyData == null) return;
 
+        var oldId = _editingSupplier.Id;
         var oldName = _editingSupplier.Name;
         var oldEmail = _editingSupplier.Email;
         var oldPhone = _editingSupplier.Phone;
@@ -343,6 +355,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
         };
         var oldNotes = _editingSupplier.Notes;
 
+        var newId = ModalId.Trim();
         var newName = ModalSupplierName.Trim();
         var newEmail = string.IsNullOrWhiteSpace(ModalEmail) ? string.Empty : ModalEmail.Trim();
         var newPhone = string.IsNullOrWhiteSpace(ModalPhone) ? string.Empty : ModalPhone.Trim();
@@ -358,7 +371,9 @@ public partial class SupplierModalsViewModel : ViewModelBase
         var newNotes = string.IsNullOrWhiteSpace(ModalNotes) ? string.Empty : ModalNotes.Trim();
 
         // Check if anything actually changed
-        var hasChanges = oldName != newName ||
+        var hasIdChange = oldId != newId;
+        var hasChanges = hasIdChange ||
+                         oldName != newName ||
                          oldEmail != newEmail ||
                          oldPhone != newPhone ||
                          oldWebsite != newWebsite ||
@@ -379,6 +394,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
         var supplierToEdit = _editingSupplier;
         App.EventLogService?.CapturePreModificationSnapshot("Supplier", supplierToEdit.Id);
         var changes = new Dictionary<string, FieldChange>();
+        if (hasIdChange) changes["ID"] = new FieldChange { OldValue = oldId, NewValue = newId };
         if (oldName != newName) changes["Name"] = new FieldChange { OldValue = oldName, NewValue = newName };
         if (oldEmail != newEmail) changes["Email"] = new FieldChange { OldValue = oldEmail, NewValue = newEmail };
         if (oldPhone != newPhone) changes["Phone"] = new FieldChange { OldValue = oldPhone, NewValue = newPhone };
@@ -395,12 +411,34 @@ public partial class SupplierModalsViewModel : ViewModelBase
         supplierToEdit.Address = newAddress;
         supplierToEdit.Notes = newNotes;
         supplierToEdit.UpdatedAt = DateTime.UtcNow;
+
+        if (hasIdChange)
+        {
+            try
+            {
+                App.CompanyManager?.ChangeSupplierId(supplierToEdit, newId);
+            }
+            catch (Exception ex)
+            {
+                App.ErrorLogger?.LogError(ex, Core.Models.Telemetry.ErrorCategory.Validation, "Supplier.ChangeId");
+                ModalIdError = ex.Message;
+                HasValidationMessage = true;
+                return;
+            }
+        }
+
         companyData.MarkAsModified();
 
         App.UndoRedoManager.RecordAction(new DelegateAction(
             $"Edit supplier '{newName}'",
-            () => { supplierToEdit.Name = oldName; supplierToEdit.Email = oldEmail; supplierToEdit.Phone = oldPhone; supplierToEdit.Website = oldWebsite; supplierToEdit.Address = oldAddress; supplierToEdit.Notes = oldNotes; companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty); },
-            () => { supplierToEdit.Name = newName; supplierToEdit.Email = newEmail; supplierToEdit.Phone = newPhone; supplierToEdit.Website = newWebsite; supplierToEdit.Address = newAddress; supplierToEdit.Notes = newNotes; companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty); }));
+            () => {
+                if (hasIdChange) App.CompanyManager?.ChangeSupplierId(supplierToEdit, oldId);
+                supplierToEdit.Name = oldName; supplierToEdit.Email = oldEmail; supplierToEdit.Phone = oldPhone; supplierToEdit.Website = oldWebsite; supplierToEdit.Address = oldAddress; supplierToEdit.Notes = oldNotes; companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty);
+            },
+            () => {
+                if (hasIdChange) App.CompanyManager?.ChangeSupplierId(supplierToEdit, newId);
+                supplierToEdit.Name = newName; supplierToEdit.Email = newEmail; supplierToEdit.Phone = newPhone; supplierToEdit.Website = newWebsite; supplierToEdit.Address = newAddress; supplierToEdit.Notes = newNotes; companyData.MarkAsModified(); SupplierSaved?.Invoke(this, EventArgs.Empty);
+            }));
 
         SupplierSaved?.Invoke(this, EventArgs.Empty);
         CloseEditModal();
@@ -582,6 +620,8 @@ public partial class SupplierModalsViewModel : ViewModelBase
     private void ClearModalFields()
     {
         ModalId = string.Empty;
+        _originalId = string.Empty;
+        ModalIdError = null;
         ModalSupplierName = string.Empty;
         ModalEmail = string.Empty;
         ModalPhone = string.Empty;
@@ -602,10 +642,33 @@ public partial class SupplierModalsViewModel : ViewModelBase
     private bool ValidateModal()
     {
         ModalError = null;
+        ModalIdError = null;
         ModalSupplierNameError = null;
         ModalEmailError = null;
         ModalPhoneError = null;
         var isValid = true;
+
+        var companyDataForId = App.CompanyManager?.CompanyData;
+        if (companyDataForId != null)
+        {
+            var trimmedId = ModalId.Trim();
+            if (_editingSupplier != null && string.IsNullOrEmpty(trimmedId))
+            {
+                ModalIdError = "ID cannot be empty.".Translate();
+                isValid = false;
+            }
+            else if (!string.IsNullOrEmpty(trimmedId))
+            {
+                var existingWithSameId = companyDataForId.Suppliers.Any(s =>
+                    s.Id == trimmedId &&
+                    (_editingSupplier == null || !ReferenceEquals(s, _editingSupplier)));
+                if (existingWithSameId)
+                {
+                    ModalIdError = "A supplier with this ID already exists.".Translate();
+                    isValid = false;
+                }
+            }
+        }
 
         if (string.IsNullOrWhiteSpace(ModalSupplierName))
         {

--- a/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/SupplierModalsViewModel.cs
@@ -4,8 +4,11 @@ using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models;
 using ArgoBooks.Core.Models.Common;
 using ArgoBooks.Core.Models.Entities;
+using ArgoBooks.Core.Services;
 using ArgoBooks.Localization;
 using ArgoBooks.Services;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -88,9 +91,80 @@ public partial class SupplierModalsViewModel : ViewModelBase
     [ObservableProperty]
     private string? _modalPhoneError;
 
+    [ObservableProperty]
+    private Bitmap? _modalAvatarSource;
+
+    [ObservableProperty]
+    private bool _hasModalAvatar;
+
+    /// <summary>
+    /// Local file path picked via the file picker. Applied on save.
+    /// </summary>
+    private string? _pendingAvatarSourcePath;
+
+    /// <summary>
+    /// Bytes downloaded from the supplier's website /favicon.ico. Applied on save
+    /// only when the user has not picked their own image.
+    /// </summary>
+    private byte[]? _pendingFaviconBytes;
+
+    /// <summary>
+    /// True when the user clicked Remove on an existing avatar; on save the supplier's
+    /// avatar file should be deleted.
+    /// </summary>
+    private bool _shouldRemoveAvatarOnSave;
+
+    /// <summary>
+    /// Snapshot of whether the supplier had an avatar when the edit modal was opened —
+    /// used for change detection.
+    /// </summary>
+    private bool _originalHasAvatar;
+
+    /// <summary>
+    /// Cancels an in-flight favicon download when the user keeps typing or closes the modal.
+    /// </summary>
+    private CancellationTokenSource? _faviconCts;
+
+    /// <summary>
+    /// Live preview of the initials shown when no avatar is set.
+    /// Driven from ModalSupplierName so the avatar circle updates as the user types.
+    /// </summary>
+    public string ModalInitialsPreview
+    {
+        get
+        {
+            var name = ModalSupplierName?.Trim() ?? string.Empty;
+            if (name.Length == 0) return "?";
+
+            var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 2)
+                return $"{char.ToUpperInvariant(parts[0][0])}{char.ToUpperInvariant(parts[1][0])}";
+            if (parts[0].Length >= 2)
+                return parts[0][..2].ToUpperInvariant();
+            return parts[0].ToUpperInvariant();
+        }
+    }
+
     partial void OnModalIdChanged(string value)
     {
         ModalIdError = null;
+    }
+
+    partial void OnModalSupplierNameChanged(string value)
+    {
+        OnPropertyChanged(nameof(ModalInitialsPreview));
+    }
+
+    partial void OnModalWebsiteChanged(string value)
+    {
+        // Auto-fetch the supplier's /favicon.ico — but only when the user has not
+        // already picked or kept their own image. The check on HasModalAvatar handles
+        // every "image already there" case (existing avatar in edit mode, prior favicon
+        // fetch in this session, manual file pick).
+        if (HasModalAvatar || _pendingAvatarSourcePath != null)
+            return;
+
+        TriggerFaviconFetch(value);
     }
 
     private Supplier? _editingSupplier;
@@ -137,7 +211,10 @@ public partial class SupplierModalsViewModel : ViewModelBase
         ModalStateProvince != _originalStateProvince ||
         ModalZipCode != _originalZipCode ||
         ModalCountry != _originalCountry ||
-        ModalNotes != _originalNotes;
+        ModalNotes != _originalNotes ||
+        _pendingAvatarSourcePath != null ||
+        _pendingFaviconBytes != null ||
+        _shouldRemoveAvatarOnSave;
 
     #endregion
 
@@ -181,6 +258,108 @@ public partial class SupplierModalsViewModel : ViewModelBase
     public event EventHandler? FiltersApplied;
     public event EventHandler? FiltersCleared;
 
+    /// <summary>
+    /// Fired when the user clicks the avatar in the modal to pick a new image.
+    /// App.axaml.cs subscribes and shows the OS file picker.
+    /// </summary>
+    public event EventHandler? BrowseAvatarRequested;
+
+    #endregion
+
+    #region Avatar Commands
+
+    [RelayCommand]
+    private void BrowseAvatar() => BrowseAvatarRequested?.Invoke(this, EventArgs.Empty);
+
+    [RelayCommand]
+    private void RemoveAvatar()
+    {
+        ModalAvatarSource = null;
+        HasModalAvatar = false;
+        _pendingAvatarSourcePath = null;
+        _pendingFaviconBytes = null;
+        _shouldRemoveAvatarOnSave = _originalHasAvatar;
+
+        // Re-evaluate the website: with no avatar showing, the favicon fetch becomes
+        // applicable again. Mirrors the rule "if the user did not select an image,
+        // pull the website's favicon".
+        TriggerFaviconFetch(ModalWebsite);
+    }
+
+    /// <summary>
+    /// Called by App.axaml.cs after the user picks an avatar image. Updates the preview
+    /// bitmap and stages the source path to be applied on save. Manual pick wins over
+    /// any pending favicon.
+    /// </summary>
+    public void SetPendingAvatar(string path, Bitmap bitmap)
+    {
+        _pendingAvatarSourcePath = path;
+        _pendingFaviconBytes = null;
+        _shouldRemoveAvatarOnSave = false;
+        ModalAvatarSource = bitmap;
+        HasModalAvatar = true;
+    }
+
+    /// <summary>
+    /// Cancels any in-flight favicon download and kicks off a new one (debounced)
+    /// for the given URL. Silently does nothing on bad URLs / network failures.
+    /// </summary>
+    private void TriggerFaviconFetch(string? websiteUrl)
+    {
+        _faviconCts?.Cancel();
+        if (string.IsNullOrWhiteSpace(websiteUrl))
+            return;
+
+        var cts = new CancellationTokenSource();
+        _faviconCts = cts;
+        var urlSnapshot = websiteUrl;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                // Debounce — give the user time to keep typing before we hit the network.
+                await Task.Delay(500, cts.Token).ConfigureAwait(false);
+                if (cts.IsCancellationRequested) return;
+
+                var bytes = await FaviconService.TryFetchFaviconAsync(urlSnapshot, cts.Token).ConfigureAwait(false);
+                if (bytes == null || cts.IsCancellationRequested) return;
+
+                Bitmap? bitmap;
+                try
+                {
+                    using var ms = new MemoryStream(bytes);
+                    bitmap = new Bitmap(ms);
+                }
+                catch
+                {
+                    return; // Format Avalonia can't decode; ignore.
+                }
+
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    if (cts.IsCancellationRequested) return;
+                    // Re-check the gating conditions on the UI thread — the user may
+                    // have picked a file or removed-with-empty-website while we were
+                    // waiting on the network.
+                    if (HasModalAvatar || _pendingAvatarSourcePath != null)
+                    {
+                        bitmap.Dispose();
+                        return;
+                    }
+                    ModalAvatarSource = bitmap;
+                    HasModalAvatar = true;
+                    _pendingFaviconBytes = bytes;
+                });
+            }
+            catch (TaskCanceledException) { /* user kept typing */ }
+            catch (Exception ex)
+            {
+                App.ErrorLogger?.LogWarning($"Favicon fetch failed: {ex.Message}", "Supplier.Favicon");
+            }
+        });
+    }
+
     #endregion
 
     #region Add Supplier
@@ -216,7 +395,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    public void SaveNewSupplier()
+    public async Task SaveNewSupplierAsync()
     {
         if (!ValidateModal()) return;
 
@@ -257,6 +436,10 @@ public partial class SupplierModalsViewModel : ViewModelBase
         companyData.Suppliers.Add(newSupplier);
         companyData.MarkAsModified();
 
+        // Persist the avatar (manual pick or auto-fetched favicon) into the company
+        // temp directory after the supplier is in the collection so its Id is stable.
+        await ApplyPendingAvatarChangeAsync(newSupplier);
+
         var supplierToUndo = newSupplier;
         App.UndoRedoManager.RecordAction(new DelegateAction(
             $"Add supplier '{newSupplier.Name}'",
@@ -265,6 +448,32 @@ public partial class SupplierModalsViewModel : ViewModelBase
 
         SupplierSaved?.Invoke(this, EventArgs.Empty);
         CloseAddModal();
+    }
+
+    /// <summary>
+    /// Applies any pending avatar change (manual upload, fetched favicon, or removal)
+    /// to the supplier record. Avatar changes are not part of the undo stack — keeps
+    /// the implementation simple and avoids juggling files in undo callbacks.
+    /// Manual upload wins over a pending favicon if both somehow exist.
+    /// </summary>
+    private async Task ApplyPendingAvatarChangeAsync(Supplier supplier)
+    {
+        var manager = App.CompanyManager;
+        if (manager == null) return;
+
+        try
+        {
+            if (_pendingAvatarSourcePath != null)
+                await manager.SetSupplierAvatarAsync(supplier, _pendingAvatarSourcePath);
+            else if (_pendingFaviconBytes != null)
+                await manager.SetSupplierAvatarFromBytesAsync(supplier, _pendingFaviconBytes);
+            else if (_shouldRemoveAvatarOnSave)
+                await manager.RemoveSupplierAvatarAsync(supplier);
+        }
+        catch (Exception ex)
+        {
+            App.ErrorLogger?.LogError(ex, Core.Models.Telemetry.ErrorCategory.Validation, "Supplier.ApplyAvatarChange");
+        }
     }
 
     #endregion
@@ -285,6 +494,24 @@ public partial class SupplierModalsViewModel : ViewModelBase
         ModalSupplierName = supplier.Name;
         ModalEmail = supplier.Email;
         ModalPhone = supplier.Phone;
+
+        // Load the existing avatar BEFORE setting ModalWebsite — that way the
+        // OnModalWebsiteChanged hook sees HasModalAvatar=true and skips the favicon
+        // fetch instead of racing to overwrite the existing avatar.
+        _pendingAvatarSourcePath = null;
+        _pendingFaviconBytes = null;
+        _shouldRemoveAvatarOnSave = false;
+        _originalHasAvatar = !string.IsNullOrEmpty(supplier.AvatarFileName);
+        HasModalAvatar = _originalHasAvatar;
+        ModalAvatarSource = null;
+        var existingAvatarPath = App.CompanyManager?.GetSupplierAvatarPath(supplier);
+        if (existingAvatarPath != null)
+        {
+            try { ModalAvatarSource = new Bitmap(existingAvatarPath); }
+            catch { ModalAvatarSource = null; }
+        }
+        OnPropertyChanged(nameof(ModalInitialsPreview));
+
         ModalWebsite = supplier.Website;
         ModalStreetAddress = supplier.Address.Street;
         ModalCity = supplier.Address.City;
@@ -333,7 +560,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    public void SaveEditedSupplier()
+    public async Task SaveEditedSupplierAsync()
     {
         if (!ValidateModal() || _editingSupplier == null) return;
 
@@ -372,7 +599,7 @@ public partial class SupplierModalsViewModel : ViewModelBase
 
         // Check if anything actually changed
         var hasIdChange = oldId != newId;
-        var hasChanges = hasIdChange ||
+        var hasFieldChanges = hasIdChange ||
                          oldName != newName ||
                          oldEmail != newEmail ||
                          oldPhone != newPhone ||
@@ -384,9 +611,27 @@ public partial class SupplierModalsViewModel : ViewModelBase
                          oldAddress.Country != newAddress.Country ||
                          oldNotes != newNotes;
 
+        var hasAvatarChanges = _pendingAvatarSourcePath != null
+                            || _pendingFaviconBytes != null
+                            || _shouldRemoveAvatarOnSave;
+
         // If nothing changed, just close the modal without recording an action
-        if (!hasChanges)
+        if (!hasFieldChanges && !hasAvatarChanges)
         {
+            CloseEditModal();
+            return;
+        }
+
+        // Apply avatar changes (not undoable — see ApplyPendingAvatarChangeAsync).
+        if (hasAvatarChanges)
+        {
+            await ApplyPendingAvatarChangeAsync(_editingSupplier);
+        }
+
+        if (!hasFieldChanges)
+        {
+            companyData.MarkAsModified();
+            SupplierSaved?.Invoke(this, EventArgs.Empty);
             CloseEditModal();
             return;
         }
@@ -497,6 +742,17 @@ public partial class SupplierModalsViewModel : ViewModelBase
 
             var deletedSupplier = supplier;
             App.EventLogService?.CapturePreDeletionSnapshot("Supplier", deletedSupplier.Id);
+
+            // Clean up the avatar file before removing the supplier — avoids bloat and
+            // retention of deleted-supplier images in the .argo archive on next save.
+            // Mirrors the customer-delete behavior. Undo of delete restores the supplier
+            // record but not the avatar.
+            if (App.CompanyManager != null && !string.IsNullOrEmpty(deletedSupplier.AvatarFileName))
+            {
+                try { await App.CompanyManager.RemoveSupplierAvatarAsync(deletedSupplier); }
+                catch (Exception ex) { App.ErrorLogger?.LogWarning($"Failed to remove supplier avatar on delete: {ex.Message}", "Supplier.Delete"); }
+            }
+
             companyData?.Suppliers.Remove(supplier);
             companyData?.MarkAsModified();
 
@@ -619,6 +875,10 @@ public partial class SupplierModalsViewModel : ViewModelBase
 
     private void ClearModalFields()
     {
+        // Cancel any in-flight favicon fetch from a previous open of the modal.
+        _faviconCts?.Cancel();
+        _faviconCts = null;
+
         ModalId = string.Empty;
         _originalId = string.Empty;
         ModalIdError = null;
@@ -637,6 +897,14 @@ public partial class SupplierModalsViewModel : ViewModelBase
         ModalEmailError = null;
         ModalPhoneError = null;
         HasValidationMessage = false;
+
+        ModalAvatarSource = null;
+        HasModalAvatar = false;
+        _pendingAvatarSourcePath = null;
+        _pendingFaviconBytes = null;
+        _shouldRemoveAvatarOnSave = false;
+        _originalHasAvatar = false;
+        OnPropertyChanged(nameof(ModalInitialsPreview));
     }
 
     private bool ValidateModal()

--- a/ArgoBooks/ViewModels/SuppliersPageViewModel.cs
+++ b/ArgoBooks/ViewModels/SuppliersPageViewModel.cs
@@ -9,6 +9,7 @@ using ArgoBooks.Data;
 using ArgoBooks.Localization;
 using ArgoBooks.Services;
 using ArgoBooks.Utilities;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -513,6 +514,8 @@ public partial class SuppliersPageViewModel : SortablePageViewModelBase
                 addressParts.Add(supplier.Address.State);
             var addressString = addressParts.Count > 0 ? string.Join(", ", addressParts) : "-";
 
+            var avatarBitmap = AvatarBitmapLoader.LoadSupplier(supplier);
+
             return new SupplierDisplayItem
             {
                 Id = supplier.Id,
@@ -525,6 +528,8 @@ public partial class SuppliersPageViewModel : SortablePageViewModelBase
                 ProductCount = productCount,
                 IsActive = isActive,
                 Initials = GetInitials(supplier.Name),
+                AvatarBitmap = avatarBitmap,
+                HasAvatar = avatarBitmap != null,
                 IsHighlighted = supplier.Id == HighlightTransactionId
             };
         }).ToList();
@@ -1054,6 +1059,12 @@ public partial class SupplierDisplayItem : ObservableObject
 
     [ObservableProperty]
     private string _initials = string.Empty;
+
+    [ObservableProperty]
+    private Bitmap? _avatarBitmap;
+
+    [ObservableProperty]
+    private bool _hasAvatar;
 
     /// <summary>
     /// Status text for display.

--- a/ArgoBooks/Views/CustomersPage.axaml
+++ b/ArgoBooks/Views/CustomersPage.axaml
@@ -134,9 +134,16 @@
                                             <table:ArgoTableCell.CellContent>
                                                 <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                                     <Border Grid.Column="0" Width="40" Height="40" CornerRadius="20"
-                                                            Background="{DynamicResource PrimaryBrush}" Margin="0,0,12,0">
-                                                        <TextBlock Text="{Binding Initials}" FontSize="14" FontWeight="SemiBold"
-                                                                   Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                                            Background="{DynamicResource PrimaryBrush}" Margin="0,0,12,0"
+                                                            ClipToBounds="True">
+                                                        <Panel>
+                                                            <TextBlock Text="{Binding Initials}" FontSize="14" FontWeight="SemiBold"
+                                                                       Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                                       IsVisible="{Binding !HasAvatar}" />
+                                                            <Image Source="{Binding AvatarBitmap}"
+                                                                   Stretch="UniformToFill"
+                                                                   IsVisible="{Binding HasAvatar}" />
+                                                        </Panel>
                                                     </Border>
                                                     <StackPanel Grid.Column="1" VerticalAlignment="Center">
                                                         <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="Medium"

--- a/ArgoBooks/Views/InvoicesPage.axaml
+++ b/ArgoBooks/Views/InvoicesPage.axaml
@@ -226,13 +226,20 @@
                                             <table:ArgoTableCell.CellContent>
                                                 <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="16"
-                                                            Background="{DynamicResource PrimaryBrush}" Margin="0,0,10,0">
-                                                        <TextBlock Text="{Binding CustomerInitials}"
-                                                                   FontSize="12"
-                                                                   FontWeight="SemiBold"
-                                                                   Foreground="White"
-                                                                   HorizontalAlignment="Center"
-                                                                   VerticalAlignment="Center" />
+                                                            Background="{DynamicResource PrimaryBrush}" Margin="0,0,10,0"
+                                                            ClipToBounds="True">
+                                                        <Panel>
+                                                            <TextBlock Text="{Binding CustomerInitials}"
+                                                                       FontSize="12"
+                                                                       FontWeight="SemiBold"
+                                                                       Foreground="White"
+                                                                       HorizontalAlignment="Center"
+                                                                       VerticalAlignment="Center"
+                                                                       IsVisible="{Binding !HasCustomerAvatar}" />
+                                                            <Image Source="{Binding CustomerAvatarBitmap}"
+                                                                   Stretch="UniformToFill"
+                                                                   IsVisible="{Binding HasCustomerAvatar}" />
+                                                        </Panel>
                                                     </Border>
                                                     <TextBlock Grid.Column="1" Text="{Binding CustomerName}"
                                                                FontSize="14"

--- a/ArgoBooks/Views/RevenuePage.axaml
+++ b/ArgoBooks/Views/RevenuePage.axaml
@@ -200,13 +200,20 @@
                                             <table:ArgoTableCell.CellContent>
                                                 <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                                     <Border Grid.Column="0" Width="32" Height="32" CornerRadius="16"
-                                                            Background="{DynamicResource PrimaryBrush}" Margin="0,0,10,0">
-                                                        <TextBlock Text="{Binding CustomerInitials}"
-                                                                   FontSize="12"
-                                                                   FontWeight="SemiBold"
-                                                                   Foreground="White"
-                                                                   HorizontalAlignment="Center"
-                                                                   VerticalAlignment="Center" />
+                                                            Background="{DynamicResource PrimaryBrush}" Margin="0,0,10,0"
+                                                            ClipToBounds="True">
+                                                        <Panel>
+                                                            <TextBlock Text="{Binding CustomerInitials}"
+                                                                       FontSize="12"
+                                                                       FontWeight="SemiBold"
+                                                                       Foreground="White"
+                                                                       HorizontalAlignment="Center"
+                                                                       VerticalAlignment="Center"
+                                                                       IsVisible="{Binding !HasCustomerAvatar}" />
+                                                            <Image Source="{Binding CustomerAvatarBitmap}"
+                                                                   Stretch="UniformToFill"
+                                                                   IsVisible="{Binding HasCustomerAvatar}" />
+                                                        </Panel>
                                                     </Border>
                                                     <TextBlock Grid.Column="1" Text="{Binding CustomerName}"
                                                                FontSize="14"

--- a/ArgoBooks/Views/SuppliersPage.axaml
+++ b/ArgoBooks/Views/SuppliersPage.axaml
@@ -141,9 +141,16 @@
                                             <table:ArgoTableCell.CellContent>
                                                 <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center">
                                                     <Border Grid.Column="0" Width="40" Height="40" CornerRadius="8"
-                                                            Background="{DynamicResource PrimaryBrush}" Margin="0,0,12,0">
-                                                        <TextBlock Text="{Binding Initials}" FontSize="14" FontWeight="SemiBold"
-                                                                   Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                                            Background="{DynamicResource PrimaryBrush}" Margin="0,0,12,0"
+                                                            ClipToBounds="True">
+                                                        <Panel>
+                                                            <TextBlock Text="{Binding Initials}" FontSize="14" FontWeight="SemiBold"
+                                                                       Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                                       IsVisible="{Binding !HasAvatar}" />
+                                                            <Image Source="{Binding AvatarBitmap}"
+                                                                   Stretch="UniformToFill"
+                                                                   IsVisible="{Binding HasAvatar}" />
+                                                        </Panel>
                                                     </Border>
                                                     <StackPanel Grid.Column="1" VerticalAlignment="Center">
                                                         <TextBlock Text="{Binding Name}" FontSize="14" FontWeight="Medium"


### PR DESCRIPTION
## Summary
- Customers can now have a custom avatar image (photo, logo, or anything they want); the existing initials remain the default when no image is set.
- Image picker is the circular avatar at the top of the Add/Edit Customer modal — click to upload, X to remove. Initials in the modal preview update live as the user types the first/last name.
- Avatars are downscaled to fit within 256x256 (aspect-preserving) and re-encoded as lossless PNG via SkiaSharp, then stored in `customer_avatars/{customerId}.png` inside the encrypted `.argo` archive (mirrors the existing company-logo pattern), so they travel with the company file. EXIF orientation is applied during the resize so phone JPEGs don't end up sideways.
- Shown wherever the customer was previously rendered as initials: Customers page (40x40), Invoices rows (32x32), Revenue rows (32x32). Old `.argo` files load fine — `AvatarFileName` is nullable.
- Bonus fix in this branch: editing the **ID** of a Customer / Supplier / Product now actually persists. The Edit modal silently dropped ID changes; this PR cascades the new ID to every FK reference (invoices, revenues, payments, etc.), invalidates the cached lookup dictionaries, moves the avatar file to track the new ID, and includes the rename inside undo/redo.
- Add customer avatars so you can find customers visually faster. Also added avatars to suppliers so you can add their logo.
- Fix inconsistent toast notifications and polish toast/insights UI.

## Test plan
- [ ] Add a new customer, click the avatar circle, pick a PNG/JPG, save → customer appears in list with the image.
- [ ] Edit an existing customer → modal shows current avatar; click X to remove → list reverts to initials after save.
- [ ] Edit an existing customer with no avatar → upload one → save → list shows new avatar.
- [ ] Open the same customer's invoice on the Invoices page and a revenue entry on the Revenue page → avatar appears in those rows too.
- [ ] Save and reopen the company file → avatars persist.
- [ ] Open an `.argo` file created before this change → all customers fall back to initials, no errors.
- [ ] Pick a portrait phone JPEG → confirm orientation is correct in the avatar (not rotated 90°).
- [ ] Pick a large (10MB+) photo → confirm it's resized (file in `customer_avatars/` is small and ≤256px on its longest edge).
- [ ] Edit a customer's ID → save → confirm invoices and revenues for that customer still show them correctly (new ID), and the avatar follows the rename.
- [ ] Try to edit a customer's ID to one already in use → save → inline ID error appears, save is blocked.
- [ ] Delete a customer with an avatar → save → confirm the avatar file is gone from the archive (no orphan in `customer_avatars/`).