### PR TITLE
Add rental availability calendar + fix unknown sample rentals

### DIFF
--- a/ArgoBooks.Core/Services/SpreadsheetImportService.cs
+++ b/ArgoBooks.Core/Services/SpreadsheetImportService.cs
@@ -168,7 +168,7 @@ public class SpreadsheetImportService
                 foreach (var worksheet in workbook.Worksheets)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    ImportWorksheet(worksheet, companyData);
+                    ImportWorksheet(worksheet, companyData, options);
                 }
 
                 // Update ID counters based on imported data
@@ -1969,7 +1969,7 @@ public class SpreadsheetImportService
 
     #region Worksheet Import
 
-    private void ImportWorksheet(IXLWorksheet worksheet, CompanyData data)
+    private void ImportWorksheet(IXLWorksheet worksheet, CompanyData data, ImportOptions? options = null)
     {
         var sheetName = worksheet.Name;
 
@@ -1985,64 +1985,64 @@ public class SpreadsheetImportService
         switch (SpreadsheetSheetTypeExtensions.ParseSheetName(sheetName))
         {
             case SpreadsheetSheetType.Customers:
-                ImportCustomers(data, headers, rows);
+                ImportCustomers(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Invoices:
-                ImportInvoices(data, headers, rows);
+                ImportInvoices(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Expenses:
-                ImportPurchases(data, headers, rows);
+                ImportPurchases(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Products:
-                ImportProducts(data, headers, rows);
+                ImportProducts(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Inventory:
-                ImportInventory(data, headers, rows);
+                ImportInventory(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Payments:
-                ImportPayments(data, headers, rows);
+                ImportPayments(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Suppliers:
-                ImportSuppliers(data, headers, rows);
+                ImportSuppliers(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Revenue:
-                ImportSales(data, headers, rows);
+                ImportSales(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.RentalInventory:
-                ImportRentalInventory(data, headers, rows);
+                ImportRentalInventory(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.RentalRecords:
-                ImportRentalRecords(data, headers, rows);
+                ImportRentalRecords(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Categories:
-                ImportCategories(data, headers, rows);
+                ImportCategories(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Departments:
-                ImportDepartments(data, headers, rows);
+                ImportDepartments(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Employees:
-                ImportEmployees(data, headers, rows);
+                ImportEmployees(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Locations:
-                ImportLocations(data, headers, rows);
+                ImportLocations(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.RecurringInvoices:
-                ImportRecurringInvoices(data, headers, rows);
+                ImportRecurringInvoices(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.StockAdjustments:
-                ImportStockAdjustments(data, headers, rows);
+                ImportStockAdjustments(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.PurchaseOrders:
-                ImportPurchaseOrders(data, headers, rows);
+                ImportPurchaseOrders(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.PurchaseOrderLineItems:
-                ImportPurchaseOrderLineItems(data, headers, rows);
+                ImportPurchaseOrderLineItems(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.Returns:
-                ImportReturns(data, headers, rows);
+                ImportReturns(data, headers, rows, options);
                 break;
             case SpreadsheetSheetType.LostDamaged:
-                ImportLostDamaged(data, headers, rows);
+                ImportLostDamaged(data, headers, rows, options);
                 break;
         }
     }
@@ -3029,8 +3029,38 @@ Respond with ONLY a JSON array, one entry per product in the same order:
 
             var item = existing ?? new RentalItem();
             item.Id = id;
+
+            // Prefer explicit "Inventory Item ID"; otherwise resolve from "Product ID" so
+            // sheets that link rental items to products directly still chain through to a name.
             var inventoryItemId = GetString(row, headers, "Inventory Item ID");
-            item.InventoryItemId = string.IsNullOrEmpty(inventoryItemId) ? string.Empty : inventoryItemId;
+            if (string.IsNullOrEmpty(inventoryItemId))
+            {
+                var productId = GetString(row, headers, "Product ID");
+                if (!string.IsNullOrEmpty(productId))
+                {
+                    var existingInv = data.Inventory.FirstOrDefault(inv => inv.ProductId == productId);
+                    if (existingInv != null)
+                    {
+                        inventoryItemId = existingInv.Id;
+                    }
+                    else if (options?.AutoCreateMissingReferences == true)
+                    {
+                        // UpdateIdCounters runs after all sheets, so derive the next ID from
+                        // the current inventory state to avoid colliding with existing IDs.
+                        var nextNum = GetMaxIdNumber(data.Inventory.Select(i => i.Id), "INV-ITM-") + 1;
+                        var newInv = new InventoryItem
+                        {
+                            Id = $"INV-ITM-{nextNum:D3}",
+                            ProductId = productId,
+                            InStock = GetInt(row, headers, "Total Qty")
+                        };
+                        data.Inventory.Add(newInv);
+                        inventoryItemId = newInv.Id;
+                    }
+                }
+            }
+            item.InventoryItemId = inventoryItemId;
+
             item.DailyRate = GetDecimal(row, headers, "Daily Rate");
             item.WeeklyRate = GetDecimal(row, headers, "Weekly Rate");
             item.MonthlyRate = GetDecimal(row, headers, "Monthly Rate");

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -110,6 +110,11 @@ public class App : Application
     public static RentalInventoryModalsViewModel? RentalInventoryModalsViewModel => _appShellViewModel?.RentalInventoryModalsViewModel;
 
     /// <summary>
+    /// Gets the rental availability modal view model for shared access (per-item calendar).
+    /// </summary>
+    public static RentalAvailabilityModalViewModel? RentalAvailabilityModalViewModel => _appShellViewModel?.RentalAvailabilityModalViewModel;
+
+    /// <summary>
     /// Gets the rental records modals view model for shared access.
     /// </summary>
     public static RentalRecordsModalsViewModel? RentalRecordsModalsViewModel => _appShellViewModel?.RentalRecordsModalsViewModel;

--- a/ArgoBooks/Controls/ColumnWidths/RentalInventoryTableColumnWidths.cs
+++ b/ArgoBooks/Controls/ColumnWidths/RentalInventoryTableColumnWidths.cs
@@ -26,7 +26,7 @@ public partial class RentalInventoryTableColumnWidths : TableColumnWidthsBase
     private double _depositColumnWidth = 90;
 
     [ObservableProperty]
-    private double _actionsColumnWidth = 120;
+    private double _actionsColumnWidth = 160;
 
     public RentalInventoryTableColumnWidths()
     {
@@ -38,7 +38,7 @@ public partial class RentalInventoryTableColumnWidths : TableColumnWidthsBase
         RegisterColumn("DailyRate", new ColumnDef { StarValue = 0.7, MinWidth = 70, PreferredWidth = 90 }, w => DailyRateColumnWidth = w);
         RegisterColumn("WeeklyRate", new ColumnDef { StarValue = 0.7, MinWidth = 70, PreferredWidth = 90 }, w => WeeklyRateColumnWidth = w);
         RegisterColumn("Deposit", new ColumnDef { StarValue = 0.7, MinWidth = 70, PreferredWidth = 90 }, w => DepositColumnWidth = w);
-        RegisterColumn("Actions", new ColumnDef { IsFixed = true, FixedWidth = ActionsWidth(3), MinWidth = ActionsWidth(3) }, w => ActionsColumnWidth = w);
+        RegisterColumn("Actions", new ColumnDef { IsFixed = true, FixedWidth = ActionsWidth(4), MinWidth = ActionsWidth(4) }, w => ActionsColumnWidth = w);
 
         InitializeColumnWidths();
     }

--- a/ArgoBooks/Converters/BoolConverters.cs
+++ b/ArgoBooks/Converters/BoolConverters.cs
@@ -202,6 +202,30 @@ public static class BoolConverters
     public static readonly IValueConverter ToCircleBorderThickness =
         new FuncValueConverter<bool, Thickness>(value => value ? new Thickness(0) : new Thickness(2));
 
+    /// <summary>
+    /// Converts bool (isOutsideMonth) to opacity for calendar day cells.
+    /// Outside month = 0.35 (dim), inside month = 1.0 (full).
+    /// </summary>
+    public static readonly IValueConverter OutsideMonthOpacity =
+        new FuncValueConverter<bool, double>(value => value ? 0.35 : 1.0);
+
+    /// <summary>
+    /// Converts bool (exceedsLimit) to ErrorBrush when true, TextTertiaryBrush when false.
+    /// Used to highlight hint labels that should turn red when their associated value is invalid.
+    /// </summary>
+    public static readonly IValueConverter ToErrorOrTertiaryBrush =
+        new FuncValueConverter<bool, IBrush>(value =>
+        {
+            var key = value ? "ErrorBrush" : "TextTertiaryBrush";
+            if (Application.Current?.Resources != null &&
+                Application.Current.Resources.TryGetResource(key, Application.Current.ActualThemeVariant, out var resource) &&
+                resource is IBrush brush)
+            {
+                return brush;
+            }
+            return new SolidColorBrush(Color.Parse(value ? AppColors.Error : AppColors.GrayText));
+        });
+
 }
 
 /// <summary>

--- a/ArgoBooks/Converters/StatusToBrushConverter.cs
+++ b/ArgoBooks/Converters/StatusToBrushConverter.cs
@@ -187,6 +187,40 @@ public static class StatusConverters
 
     #endregion
 
+    #region Availability Day (rental availability calendar)
+
+    public static readonly IValueConverter AvailabilityDayBackground = new StatusToBrushConverter(
+        new Dictionary<string, string>
+        {
+            ["Met"] = GreenBg,
+            ["Partial"] = YellowBg,
+            ["Full"] = AppColors.ErrorLightest,
+            ["Outside"] = "Transparent",
+            ["Empty"] = "Transparent"
+        }, "Transparent");
+
+    public static readonly IValueConverter AvailabilityDayBorder = new StatusToBrushConverter(
+        new Dictionary<string, string>
+        {
+            ["Met"] = AppColors.Success,
+            ["Partial"] = AppColors.Warning,
+            ["Full"] = AppColors.ErrorLight,
+            ["Outside"] = "Transparent",
+            ["Empty"] = AppColors.GrayLightest
+        }, AppColors.GrayLightest);
+
+    public static readonly IValueConverter AvailabilityDayForeground = new StatusToBrushConverter(
+        new Dictionary<string, string>
+        {
+            ["Met"] = GreenFg,
+            ["Partial"] = YellowFg,
+            ["Full"] = RedFg,
+            ["Outside"] = GrayFg,
+            ["Empty"] = GrayFg
+        }, GrayFg);
+
+    #endregion
+
     #region Payment Transaction Status
 
     public static readonly IValueConverter PaymentTransactionStatusBackground = new StatusToBrushConverter(

--- a/ArgoBooks/Converters/StringConverters.cs
+++ b/ArgoBooks/Converters/StringConverters.cs
@@ -96,4 +96,19 @@ public static class StringConverters
     /// Converts revenue status to badge foreground color.
     /// </summary>
     public static readonly IValueConverter ToRevenueStatusForeground = StatusConverters.TransactionStatusForeground;
+
+    /// <summary>
+    /// Converts rental availability day state ("Met"/"Partial"/"Full"/"Outside"/"Empty") to background brush.
+    /// </summary>
+    public static readonly IValueConverter ToAvailabilityDayBackground = StatusConverters.AvailabilityDayBackground;
+
+    /// <summary>
+    /// Converts rental availability day state to border brush.
+    /// </summary>
+    public static readonly IValueConverter ToAvailabilityDayBorder = StatusConverters.AvailabilityDayBorder;
+
+    /// <summary>
+    /// Converts rental availability day state to free-count text color.
+    /// </summary>
+    public static readonly IValueConverter ToAvailabilityDayForeground = StatusConverters.AvailabilityDayForeground;
 }

--- a/ArgoBooks/Modals/RentalAvailabilityModal.axaml
+++ b/ArgoBooks/Modals/RentalAvailabilityModal.axaml
@@ -1,0 +1,395 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:ArgoBooks.ViewModels"
+             xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:converters="using:ArgoBooks.Converters"
+             xmlns:behaviors="using:ArgoBooks.Behaviors"
+             xmlns:loc="using:ArgoBooks.Localization"
+             xmlns:icons="using:ArgoBooks"
+             mc:Ignorable="d" d:DesignWidth="940" d:DesignHeight="640"
+             x:Class="ArgoBooks.Modals.RentalAvailabilityModal"
+             x:DataType="vm:RentalAvailabilityModalViewModel">
+
+    <Design.DataContext>
+        <vm:RentalAvailabilityModalViewModel />
+    </Design.DataContext>
+
+    <controls:ModalOverlay IsOpen="{Binding IsOpen}"
+                           ClosingCommand="{Binding CloseCommand}">
+        <controls:ModalOverlay.ModalContent>
+            <Border Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource BorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Width="1140"
+                    MaxHeight="780"
+                    Margin="40"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    BoxShadow="0 8 32 0 #40000000">
+                <Grid RowDefinitions="Auto,*,Auto">
+
+                    <!-- Header -->
+                    <Border Grid.Row="0" Padding="24,18"
+                            BorderBrush="{DynamicResource BorderBrush}"
+                            BorderThickness="0,0,0,1">
+                        <Grid ColumnDefinitions="Auto,*,Auto">
+                            <Border Grid.Column="0"
+                                    Width="40" Height="40"
+                                    CornerRadius="6"
+                                    Background="{DynamicResource PrimaryLightBrush}"
+                                    Margin="0,0,14,0">
+                                <PathIcon Data="{x:Static icons:Icons.Calendar}"
+                                          Width="20" Height="20"
+                                          Foreground="{DynamicResource PrimaryBrush}" />
+                            </Border>
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+                                <TextBlock FontSize="16">
+                                    <Run Text="{Binding ItemName}"
+                                         FontWeight="SemiBold"
+                                         Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    <Run Text=" — "
+                                         Foreground="{DynamicResource TextSecondaryBrush}" />
+                                    <Run Text="{loc:Loc 'Availability'}"
+                                         Foreground="{DynamicResource TextSecondaryBrush}" />
+                                </TextBlock>
+                                <TextBlock Text="{Binding ItemSubtitle}"
+                                           FontSize="11"
+                                           Foreground="{DynamicResource TextTertiaryBrush}" />
+                            </StackPanel>
+                            <Button Grid.Column="2"
+                                    Classes="icon-button"
+                                    Width="32" Height="32"
+                                    VerticalAlignment="Center"
+                                    Command="{Binding CloseCommand}">
+                                <PathIcon Data="{x:Static icons:Icons.Close}"
+                                          Width="16" Height="16"
+                                          Foreground="{DynamicResource TextSecondaryBrush}" />
+                            </Button>
+                        </Grid>
+                    </Border>
+
+                    <!-- Body: side panel + calendar -->
+                    <Grid Grid.Row="1" ColumnDefinitions="280,*">
+
+                        <!-- Side Panel -->
+                        <Border Grid.Column="0"
+                                BorderBrush="{DynamicResource BorderBrush}"
+                                BorderThickness="0,0,1,0">
+                            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <StackPanel Margin="22" Spacing="22">
+
+                                    <!-- Quantity input -->
+                                    <StackPanel Spacing="8">
+                                        <TextBlock Text="{loc:Loc 'How many do you need?'}"
+                                                   FontSize="10"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                                   />
+                                        <Grid ColumnDefinitions="36,*,36" Height="40" ColumnSpacing="8">
+                                            <Button Grid.Column="0"
+                                                    Classes="icon-button"
+                                                    Command="{Binding DecrementQuantityCommand}"
+                                                    Content="−"
+                                                    FontSize="18"
+                                                    HorizontalContentAlignment="Center" />
+                                            <TextBox Grid.Column="1"
+                                                     Text="{Binding QuantityNeededText, Mode=TwoWay}"
+                                                     behaviors:NumericInputBehavior.IsIntegerOnly="True"
+                                                     MaxLength="7"
+                                                     HorizontalContentAlignment="Center"
+                                                     VerticalContentAlignment="Center"
+                                                     FontSize="18"
+                                                     FontWeight="SemiBold"
+                                                     MinHeight="40"
+                                                     Padding="0"
+                                                     Foreground="{DynamicResource TextPrimaryBrush}" />
+                                            <Button Grid.Column="2"
+                                                    Classes="icon-button"
+                                                    Command="{Binding IncrementQuantityCommand}"
+                                                    Content="+"
+                                                    FontSize="18"
+                                                    HorizontalContentAlignment="Center" />
+                                        </Grid>
+                                        <TextBlock FontSize="10"
+                                                   Foreground="{Binding QuantityExceedsTotal, Converter={x:Static converters:BoolConverters.ToErrorOrTertiaryBrush}}"
+                                                   HorizontalAlignment="Center">
+                                            <Run Text="{loc:Loc 'Total fleet:'}" />
+                                            <Run Text=" " />
+                                            <Run Text="{Binding TotalQty}" />
+                                        </TextBlock>
+                                    </StackPanel>
+
+                                    <!-- Next available answer -->
+                                    <Border Padding="16"
+                                            CornerRadius="8"
+                                            Background="{DynamicResource SuccessLightBrush}"
+                                            BorderBrush="{DynamicResource SuccessBrush}"
+                                            BorderThickness="1"
+                                            IsVisible="{Binding HasNextAvailable}">
+                                        <StackPanel Spacing="4">
+                                            <TextBlock Text="{loc:Loc 'NEXT AVAILABLE'}"
+                                                       FontSize="9"
+                                                       FontWeight="Bold"
+                                                       Foreground="{DynamicResource SuccessTextBrush}"
+                                                       />
+                                            <TextBlock Text="{Binding NextAvailableDate}"
+                                                       FontSize="22"
+                                                       FontWeight="Bold"
+                                                       Foreground="{DynamicResource SuccessTextBrush}"
+                                                       LineHeight="26" />
+                                            <TextBlock Text="{Binding NextAvailableDetail}"
+                                                       FontSize="12"
+                                                       FontWeight="Medium"
+                                                       Foreground="{DynamicResource SuccessTextBrush}"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Padding="16"
+                                            CornerRadius="8"
+                                            Background="{DynamicResource ErrorLightBrush}"
+                                            BorderBrush="{DynamicResource ErrorBrush}"
+                                            BorderThickness="1"
+                                            IsVisible="{Binding !HasNextAvailable}">
+                                        <StackPanel Spacing="4">
+                                            <TextBlock Text="{loc:Loc 'NOT AVAILABLE'}"
+                                                       FontSize="9"
+                                                       FontWeight="Bold"
+                                                       Foreground="{DynamicResource ErrorBrush}"
+                                                       />
+                                            <TextBlock Text="{Binding NextAvailableDate}"
+                                                       FontSize="22"
+                                                       FontWeight="Bold"
+                                                       Foreground="{DynamicResource ErrorBrush}"
+                                                       LineHeight="26" />
+                                            <TextBlock Text="{Binding NextAvailableDetail}"
+                                                       FontSize="12"
+                                                       FontWeight="Medium"
+                                                       Foreground="{DynamicResource ErrorBrush}"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
+                                    </Border>
+
+                                    <!-- Right now -->
+                                    <StackPanel Spacing="8">
+                                        <TextBlock Text="{loc:Loc 'RIGHT NOW'}"
+                                                   FontSize="10"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                                   />
+                                        <Border Padding="14,12"
+                                                CornerRadius="8"
+                                                Background="{DynamicResource SurfaceAltBrush}"
+                                                BorderBrush="{DynamicResource BorderBrush}"
+                                                BorderThickness="1">
+                                            <Grid ColumnDefinitions="*,*">
+                                                <StackPanel Grid.Column="0" Spacing="2">
+                                                    <TextBlock Text="{Binding FreeNow}"
+                                                               FontSize="20"
+                                                               FontWeight="Bold"
+                                                               Foreground="{DynamicResource SuccessBrush}" />
+                                                    <TextBlock Text="{loc:Loc 'free today'}"
+                                                               FontSize="10"
+                                                               Foreground="{DynamicResource TextTertiaryBrush}" />
+                                                </StackPanel>
+                                                <StackPanel Grid.Column="1" Spacing="2" HorizontalAlignment="Right">
+                                                    <TextBlock Text="{Binding RentedNow}"
+                                                               FontSize="20"
+                                                               FontWeight="Bold"
+                                                               Foreground="{DynamicResource WarningBrush}"
+                                                               HorizontalAlignment="Right" />
+                                                    <TextBlock Text="{loc:Loc 'on rent'}"
+                                                               FontSize="10"
+                                                               Foreground="{DynamicResource TextTertiaryBrush}"
+                                                               HorizontalAlignment="Right" />
+                                                </StackPanel>
+                                            </Grid>
+                                        </Border>
+                                    </StackPanel>
+
+                                    <!-- Active rentals list -->
+                                    <StackPanel Spacing="8" IsVisible="{Binding HasActiveRentals}">
+                                        <TextBlock Text="{loc:Loc 'ACTIVE RENTALS'}"
+                                                   FontSize="10"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                                   />
+                                        <ItemsControl ItemsSource="{Binding ActiveRentals}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate DataType="vm:ActiveRentalDisplay">
+                                                    <TextBlock Text="{Binding Description}"
+                                                               FontSize="11"
+                                                               LineHeight="18"
+                                                               TextWrapping="Wrap"
+                                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+
+                                </StackPanel>
+                            </ScrollViewer>
+                        </Border>
+
+                        <!-- Calendar -->
+                        <Grid Grid.Column="1" RowDefinitions="Auto,Auto,*" Margin="22">
+                            <!-- Month nav -->
+                            <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,16">
+                                <TextBlock Grid.Column="0"
+                                           Text="{Binding MonthLabel}"
+                                           FontSize="15"
+                                           FontWeight="SemiBold"
+                                           VerticalAlignment="Center"
+                                           Foreground="{DynamicResource TextPrimaryBrush}" />
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6">
+                                    <Button Classes="icon-button"
+                                            Command="{Binding PreviousMonthCommand}"
+                                            Width="30" Height="30"
+                                            ToolTip.Tip="{loc:Loc 'Previous month'}">
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronLeft}"
+                                                  Width="14" Height="14" />
+                                    </Button>
+                                    <Button Command="{Binding GoToTodayCommand}"
+                                            Width="64"
+                                            Height="30"
+                                            Padding="0"
+                                            Background="Transparent"
+                                            BorderBrush="{DynamicResource BorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="6"
+                                            Cursor="Hand"
+                                            Content="{loc:Loc 'Today'}"
+                                            HorizontalContentAlignment="Center"
+                                            VerticalContentAlignment="Center"
+                                            FontSize="11" />
+                                    <Button Classes="icon-button"
+                                            Command="{Binding NextMonthCommand}"
+                                            Width="30" Height="30"
+                                            ToolTip.Tip="{loc:Loc 'Next month'}">
+                                        <PathIcon Data="{x:Static icons:Icons.ChevronRight}"
+                                                  Width="14" Height="14" />
+                                    </Button>
+                                </StackPanel>
+                            </Grid>
+
+                            <!-- Day-of-week headers -->
+                            <UniformGrid Grid.Row="1" Columns="7" Margin="0,0,0,4">
+                                <TextBlock Text="{loc:Loc 'Sun'}" FontSize="10" FontWeight="SemiBold" Foreground="{DynamicResource TextTertiaryBrush}" HorizontalAlignment="Center" Padding="0,6" />
+                                <TextBlock Text="{loc:Loc 'Mon'}" FontSize="10" FontWeight="SemiBold" Foreground="{DynamicResource TextTertiaryBrush}" HorizontalAlignment="Center" Padding="0,6" />
+                                <TextBlock Text="{loc:Loc 'Tue'}" FontSize="10" FontWeight="SemiBold" Foreground="{DynamicResource TextTertiaryBrush}" HorizontalAlignment="Center" Padding="0,6" />
+                                <TextBlock Text="{loc:Loc 'Wed'}" FontSize="10" FontWeight="SemiBold" Foreground="{DynamicResource TextTertiaryBrush}" HorizontalAlignment="Center" Padding="0,6" />
+                                <TextBlock Text="{loc:Loc 'Thu'}" FontSize="10" FontWeight="SemiBold" Foreground="{DynamicResource TextTertiaryBrush}" HorizontalAlignment="Center" Padding="0,6" />
+                                <TextBlock Text="{loc:Loc 'Fri'}" FontSize="10" FontWeight="SemiBold" Foreground="{DynamicResource TextTertiaryBrush}" HorizontalAlignment="Center" Padding="0,6" />
+                                <TextBlock Text="{loc:Loc 'Sat'}" FontSize="10" FontWeight="SemiBold" Foreground="{DynamicResource TextTertiaryBrush}" HorizontalAlignment="Center" Padding="0,6" />
+                            </UniformGrid>
+
+                            <!-- Day grid -->
+                            <ItemsControl Grid.Row="2"
+                                          ItemsSource="{Binding Days}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <UniformGrid Columns="7" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="vm:AvailabilityDayDisplay">
+                                        <Panel Margin="2">
+                                            <Border Padding="6"
+                                                    CornerRadius="5"
+                                                    MinHeight="74"
+                                                    Background="{Binding State, Converter={x:Static converters:StringConverters.ToAvailabilityDayBackground}}"
+                                                    BorderBrush="{Binding State, Converter={x:Static converters:StringConverters.ToAvailabilityDayBorder}}"
+                                                    BorderThickness="1"
+                                                    Opacity="{Binding IsOutsideMonth, Converter={x:Static converters:BoolConverters.OutsideMonthOpacity}}">
+                                                <Grid RowDefinitions="Auto,Auto,*">
+                                                    <TextBlock Grid.Row="0"
+                                                               Text="{Binding DayNumber}"
+                                                               FontSize="11"
+                                                               FontWeight="SemiBold"
+                                                               Foreground="{Binding State, Converter={x:Static converters:StringConverters.ToAvailabilityDayForeground}}" />
+                                                    <TextBlock Grid.Row="1"
+                                                               Text="{Binding FreeLabel}"
+                                                               FontSize="11"
+                                                               FontWeight="SemiBold"
+                                                               Margin="0,4,0,0"
+                                                               IsVisible="{Binding ShowFreeLabel}"
+                                                               Foreground="{Binding State, Converter={x:Static converters:StringConverters.ToAvailabilityDayForeground}}" />
+                                                    <Border Grid.Row="2"
+                                                            Margin="0,4,0,0"
+                                                            Padding="3,1"
+                                                            CornerRadius="2"
+                                                            VerticalAlignment="Top"
+                                                            Background="{DynamicResource PrimaryBrush}"
+                                                            IsVisible="{Binding HasEvent}">
+                                                        <TextBlock Text="{Binding EventLabel}"
+                                                                   FontSize="9"
+                                                                   TextTrimming="CharacterEllipsis"
+                                                                   Foreground="White" />
+                                                    </Border>
+                                                </Grid>
+                                            </Border>
+                                            <!-- Today outline overlay -->
+                                            <Border IsVisible="{Binding IsToday}"
+                                                    CornerRadius="5"
+                                                    BorderBrush="{DynamicResource PrimaryBrush}"
+                                                    BorderThickness="2"
+                                                    IsHitTestVisible="False" />
+                                        </Panel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Grid>
+                    </Grid>
+
+                    <!-- Legend -->
+                    <Border Grid.Row="2" Padding="22,12"
+                            BorderBrush="{DynamicResource BorderBrush}"
+                            BorderThickness="0,1,0,0">
+                        <StackPanel Orientation="Horizontal" Spacing="20">
+                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                                <Border Width="14" Height="14" CornerRadius="3"
+                                        Background="{DynamicResource SuccessLightBrush}"
+                                        BorderBrush="{DynamicResource SuccessBrush}"
+                                        BorderThickness="1" />
+                                <TextBlock Text="{Binding MeetsNeedLegendText}"
+                                           FontSize="10"
+                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                                <Border Width="14" Height="14" CornerRadius="3"
+                                        Background="{DynamicResource WarningLightBrush}"
+                                        BorderBrush="{DynamicResource WarningBrush}"
+                                        BorderThickness="1" />
+                                <TextBlock Text="{loc:Loc 'Partially booked'}"
+                                           FontSize="10"
+                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                                <Border Width="14" Height="14" CornerRadius="3"
+                                        Background="{DynamicResource ErrorLightBrush}"
+                                        BorderBrush="{DynamicResource ErrorBrush}"
+                                        BorderThickness="1" />
+                                <TextBlock Text="{loc:Loc 'Fully booked'}"
+                                           FontSize="10"
+                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                                <Border Width="14" Height="14" CornerRadius="3"
+                                        Background="Transparent"
+                                        BorderBrush="{DynamicResource PrimaryBrush}"
+                                        BorderThickness="2" />
+                                <TextBlock Text="{loc:Loc 'Today'}"
+                                           FontSize="10"
+                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Border>
+        </controls:ModalOverlay.ModalContent>
+    </controls:ModalOverlay>
+
+</UserControl>

--- a/ArgoBooks/Modals/RentalAvailabilityModal.axaml.cs
+++ b/ArgoBooks/Modals/RentalAvailabilityModal.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace ArgoBooks.Modals;
+
+public partial class RentalAvailabilityModal : UserControl
+{
+    public RentalAvailabilityModal()
+    {
+        InitializeComponent();
+    }
+}

--- a/ArgoBooks/ViewModels/AppShellViewModel.cs
+++ b/ArgoBooks/ViewModels/AppShellViewModel.cs
@@ -25,6 +25,7 @@ public partial class AppShellViewModel : ViewModelBase
     private DepartmentModalsViewModel? _departmentModalsViewModel;
     private SupplierModalsViewModel? _supplierModalsViewModel;
     private RentalInventoryModalsViewModel? _rentalInventoryModalsViewModel;
+    private RentalAvailabilityModalViewModel? _rentalAvailabilityModalViewModel;
     private RentalRecordsModalsViewModel? _rentalRecordsModalsViewModel;
     private PaymentModalsViewModel? _paymentModalsViewModel;
     private InvoiceModalsViewModel? _invoiceModalsViewModel;
@@ -277,6 +278,22 @@ public partial class AppShellViewModel : ViewModelBase
                 OnPropertyChanged();
             }
             return _rentalInventoryModalsViewModel;
+        }
+    }
+
+    /// <summary>
+    /// Gets the rental availability modal view model (per-item calendar).
+    /// </summary>
+    public RentalAvailabilityModalViewModel RentalAvailabilityModalViewModel
+    {
+        get
+        {
+            if (_rentalAvailabilityModalViewModel == null)
+            {
+                _rentalAvailabilityModalViewModel = new RentalAvailabilityModalViewModel();
+                OnPropertyChanged();
+            }
+            return _rentalAvailabilityModalViewModel;
         }
     }
 

--- a/ArgoBooks/ViewModels/RentalAvailabilityModalViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalAvailabilityModalViewModel.cs
@@ -98,13 +98,12 @@ public partial class RentalAvailabilityModalViewModel : ViewModelBase
         ItemSubtitle = BuildSubtitle(item, displayItem);
         TotalQty = ComputeTotalFleet(data, item.Id, displayItem.InStock);
 
-        // Reset quantity to 1 each open so the user starts fresh.
+        // Reset quantity to 1 each open so the user starts fresh on a new item.
         _syncingQuantity = true;
         try
         {
-            if (QuantityNeeded < 1) QuantityNeeded = 1;
-            if (QuantityNeeded > TotalQty && TotalQty > 0) QuantityNeeded = TotalQty;
-            QuantityNeededText = QuantityNeeded.ToString(CultureInfo.InvariantCulture);
+            QuantityNeeded = 1;
+            QuantityNeededText = "1";
         }
         finally
         {
@@ -166,11 +165,22 @@ public partial class RentalAvailabilityModalViewModel : ViewModelBase
     partial void OnQuantityNeededTextChanged(string value)
     {
         if (_syncingQuantity) return;
-        if (string.IsNullOrWhiteSpace(value)) return;
-        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)) return;
-        if (parsed < 1) parsed = 1;
-        // Don't clamp to TotalQty — we want the calendar and answer card to clearly
-        // show that the user's request is impossible (all cells unmet, "Need exceeds fleet").
+
+        int parsed;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            // Treat empty/whitespace as 1 so the calendar doesn't lag behind a cleared
+            // textbox. We don't sync the text back here — that would interfere with the
+            // user mid-edit; the textbox visually stays blank until they type a digit.
+            parsed = 1;
+        }
+        else
+        {
+            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed)) return;
+            if (parsed < 1) parsed = 1;
+            // Don't clamp to TotalQty — we want the calendar and answer card to clearly
+            // show that the user's request is impossible (all cells unmet, "Need exceeds fleet").
+        }
 
         _syncingQuantity = true;
         try
@@ -300,13 +310,18 @@ public partial class RentalAvailabilityModalViewModel : ViewModelBase
 
     private void UpdateNextAvailable(List<RentalSpan> rentals, int qtyNeeded)
     {
-        if (TotalQty == 0 || qtyNeeded > TotalQty)
+        if (TotalQty == 0)
         {
             HasNextAvailable = false;
             NextAvailableDate = "—";
-            NextAvailableDetail = qtyNeeded > TotalQty
-                ? Loc.Tr("Need exceeds total fleet of {0}", TotalQty)
-                : Loc.Tr("No items in fleet");
+            NextAvailableDetail = Loc.Tr("No items in fleet");
+            return;
+        }
+        if (qtyNeeded > TotalQty)
+        {
+            HasNextAvailable = false;
+            NextAvailableDate = "—";
+            NextAvailableDetail = Loc.Tr("Need exceeds total fleet of {0}", TotalQty);
             return;
         }
 
@@ -369,7 +384,7 @@ public partial class RentalAvailabilityModalViewModel : ViewModelBase
             var endLabel = span.End.ToString("MMM d", CultureInfo.CurrentCulture);
             ActiveRentals.Add(new ActiveRentalDisplay
             {
-                Description = $"{span.Quantity}× {Loc.Tr("until")} {endLabel} — {customerName}",
+                Description = Loc.Tr("{0}× until {1} — {2}", span.Quantity, endLabel, customerName),
                 IsOverdue = span.IsOverdue
             });
         }

--- a/ArgoBooks/ViewModels/RentalAvailabilityModalViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalAvailabilityModalViewModel.cs
@@ -1,0 +1,522 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using ArgoBooks.Core.Data;
+using ArgoBooks.Core.Enums;
+using ArgoBooks.Core.Models.Rentals;
+using ArgoBooks.Localization;
+using ArgoBooks.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ArgoBooks.ViewModels;
+
+/// <summary>
+/// ViewModel for the rental availability modal — shows a month calendar of free/booked
+/// counts for a single rental item, plus a quantity-aware "next available" answer.
+/// </summary>
+public partial class RentalAvailabilityModalViewModel : ViewModelBase
+{
+    #region State
+
+    [ObservableProperty]
+    private bool _isOpen;
+
+    [ObservableProperty]
+    private string _itemId = string.Empty;
+
+    [ObservableProperty]
+    private string _itemName = string.Empty;
+
+    [ObservableProperty]
+    private string _itemSubtitle = string.Empty;
+
+    [ObservableProperty]
+    private int _totalQty;
+
+    [ObservableProperty]
+    private int _quantityNeeded = 1;
+
+    [ObservableProperty]
+    private string _quantityNeededText = "1";
+
+    private bool _syncingQuantity;
+
+    [ObservableProperty]
+    private DateTime _currentMonth = new(DateTime.Today.Year, DateTime.Today.Month, 1);
+
+    [ObservableProperty]
+    private string _monthLabel = string.Empty;
+
+    [ObservableProperty]
+    private int _freeNow;
+
+    [ObservableProperty]
+    private int _rentedNow;
+
+    [ObservableProperty]
+    private string _nextAvailableDate = string.Empty;
+
+    [ObservableProperty]
+    private string _nextAvailableDetail = string.Empty;
+
+    [ObservableProperty]
+    private bool _hasNextAvailable;
+
+    [ObservableProperty]
+    private bool _quantityExceedsTotal;
+
+    [ObservableProperty]
+    private bool _hasActiveRentals;
+
+    [ObservableProperty]
+    private string _meetsNeedLegendText = string.Empty;
+
+    public ObservableCollection<AvailabilityDayDisplay> Days { get; } = [];
+
+    public ObservableCollection<ActiveRentalDisplay> ActiveRentals { get; } = [];
+
+    private RentalItem? _currentItem;
+
+    #endregion
+
+    #region Open / Close
+
+    /// <summary>
+    /// Opens the modal for the given rental item, computing initial availability.
+    /// </summary>
+    public void OpenForItem(RentalItemDisplayItem? displayItem)
+    {
+        if (displayItem == null) return;
+        var data = App.CompanyManager?.CompanyData;
+        if (data == null) return;
+        var item = data.RentalInventory.FirstOrDefault(r => r.Id == displayItem.Id);
+        if (item == null) return;
+
+        _currentItem = item;
+        ItemId = item.Id;
+        ItemName = displayItem.Name;
+        ItemSubtitle = BuildSubtitle(item, displayItem);
+        TotalQty = ComputeTotalFleet(data, item.Id, displayItem.InStock);
+
+        // Reset quantity to 1 each open so the user starts fresh.
+        _syncingQuantity = true;
+        try
+        {
+            if (QuantityNeeded < 1) QuantityNeeded = 1;
+            if (QuantityNeeded > TotalQty && TotalQty > 0) QuantityNeeded = TotalQty;
+            QuantityNeededText = QuantityNeeded.ToString(CultureInfo.InvariantCulture);
+        }
+        finally
+        {
+            _syncingQuantity = false;
+        }
+
+        // Anchor calendar to today's month.
+        CurrentMonth = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1);
+
+        Recompute();
+        IsOpen = true;
+    }
+
+    [RelayCommand]
+    private void Close() => IsOpen = false;
+
+    private static string BuildSubtitle(RentalItem item, RentalItemDisplayItem displayItem)
+    {
+        var parts = new List<string>();
+        parts.Add($"{item.Id}");
+        if (item.DailyRate > 0) parts.Add($"{CurrencyService.Format(item.DailyRate)}/day");
+        if (item.WeeklyRate > 0) parts.Add($"{CurrencyService.Format(item.WeeklyRate)}/wk");
+        return string.Join(" · ", parts);
+    }
+
+    #endregion
+
+    #region Quantity controls
+
+    [RelayCommand]
+    private void IncrementQuantity()
+    {
+        // Allow exceeding TotalQty — the answer card and calendar will surface "impossible".
+        QuantityNeeded++;
+    }
+
+    [RelayCommand]
+    private void DecrementQuantity()
+    {
+        if (QuantityNeeded > 1) QuantityNeeded--;
+    }
+
+    partial void OnQuantityNeededChanged(int value)
+    {
+        if (value < 1)
+        {
+            QuantityNeeded = 1;
+            return;
+        }
+        if (!_syncingQuantity)
+        {
+            _syncingQuantity = true;
+            QuantityNeededText = value.ToString(CultureInfo.InvariantCulture);
+            _syncingQuantity = false;
+        }
+        Recompute();
+    }
+
+    partial void OnQuantityNeededTextChanged(string value)
+    {
+        if (_syncingQuantity) return;
+        if (string.IsNullOrWhiteSpace(value)) return;
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)) return;
+        if (parsed < 1) parsed = 1;
+        // Don't clamp to TotalQty — we want the calendar and answer card to clearly
+        // show that the user's request is impossible (all cells unmet, "Need exceeds fleet").
+
+        _syncingQuantity = true;
+        try
+        {
+            QuantityNeeded = parsed;
+        }
+        finally
+        {
+            _syncingQuantity = false;
+        }
+        Recompute();
+    }
+
+    #endregion
+
+    #region Month navigation
+
+    [RelayCommand]
+    private void PreviousMonth()
+    {
+        CurrentMonth = CurrentMonth.AddMonths(-1);
+        Recompute();
+    }
+
+    [RelayCommand]
+    private void NextMonth()
+    {
+        CurrentMonth = CurrentMonth.AddMonths(1);
+        Recompute();
+    }
+
+    [RelayCommand]
+    private void GoToToday()
+    {
+        CurrentMonth = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1);
+        Recompute();
+    }
+
+    #endregion
+
+    #region Compute
+
+    /// <summary>
+    /// Recomputes calendar days, status snapshot, next-available date, and active-rentals list.
+    /// </summary>
+    private void Recompute()
+    {
+        var data = App.CompanyManager?.CompanyData;
+        if (data == null || _currentItem == null) return;
+
+        var qtyNeeded = Math.Max(1, QuantityNeeded);
+        QuantityExceedsTotal = TotalQty > 0 && qtyNeeded > TotalQty;
+
+        MonthLabel = CurrentMonth.ToString("MMMM yyyy", CultureInfo.CurrentCulture);
+
+        var rentals = GetRentalsForItem(data, _currentItem.Id);
+
+        BuildCalendar(rentals, qtyNeeded);
+        UpdateNowStats(rentals);
+        UpdateNextAvailable(rentals, qtyNeeded);
+        UpdateActiveRentalsList(data, rentals);
+
+        MeetsNeedLegendText = Loc.Tr("Meets your need (≥ {0} free)", qtyNeeded);
+    }
+
+    private void BuildCalendar(List<RentalSpan> rentals, int qtyNeeded)
+    {
+        Days.Clear();
+        var firstOfMonth = CurrentMonth;
+
+        // Calendar grid starts on Sunday — pad with previous month's tail.
+        var leadingPad = (int)firstOfMonth.DayOfWeek; // Sunday=0
+        var firstCell = firstOfMonth.AddDays(-leadingPad);
+
+        // Always render 6 rows × 7 = 42 cells for a stable layout.
+        const int totalCells = 42;
+        var today = DateTime.Today;
+
+        for (int i = 0; i < totalCells; i++)
+        {
+            var date = firstCell.AddDays(i);
+            var rented = SumRentedOn(rentals, date);
+            var free = Math.Max(0, TotalQty - rented);
+            var meets = TotalQty > 0 && free >= qtyNeeded;
+            var hasOverdue = rentals.Any(r => r.IsOverdue && date >= r.Start.Date && date <= r.End.Date);
+
+            string label = string.Empty;
+            if (rented > 0)
+                label = hasOverdue ? Loc.Tr("⚠ {0} overdue", rented)
+                                   : Loc.Tr("{0}× rented", rented);
+
+            var isOutside = date.Month != firstOfMonth.Month;
+            var isFull = TotalQty > 0 && free == 0;
+            string state;
+            if (TotalQty == 0) state = "Empty";
+            else if (isFull) state = "Full";
+            else if (meets) state = "Met";
+            else state = "Partial";
+
+            Days.Add(new AvailabilityDayDisplay
+            {
+                Date = date,
+                DayNumber = date.Day,
+                IsOutsideMonth = isOutside,
+                IsToday = date.Date == today,
+                IsPast = date.Date < today,
+                FreeCount = free,
+                RentedCount = rented,
+                MeetsNeed = meets,
+                IsFullyBooked = isFull,
+                HasOverdue = hasOverdue,
+                State = isOutside ? "Outside" : state,
+                EventLabel = label,
+                FreeLabel = TotalQty == 0
+                    ? "—"
+                    : (meets ? $"{free} " + Loc.Tr("free") + " ✓" : $"{free} " + Loc.Tr("free"))
+            });
+        }
+    }
+
+    private void UpdateNowStats(List<RentalSpan> rentals)
+    {
+        var rented = SumRentedOn(rentals, DateTime.Today);
+        RentedNow = rented;
+        FreeNow = Math.Max(0, TotalQty - rented);
+    }
+
+    private void UpdateNextAvailable(List<RentalSpan> rentals, int qtyNeeded)
+    {
+        if (TotalQty == 0 || qtyNeeded > TotalQty)
+        {
+            HasNextAvailable = false;
+            NextAvailableDate = "—";
+            NextAvailableDetail = qtyNeeded > TotalQty
+                ? Loc.Tr("Need exceeds total fleet of {0}", TotalQty)
+                : Loc.Tr("No items in fleet");
+            return;
+        }
+
+        // Free today already?
+        var today = DateTime.Today;
+        if (TotalQty - SumRentedOn(rentals, today) >= qtyNeeded)
+        {
+            var stretch = MeasureStretch(rentals, today, qtyNeeded);
+            HasNextAvailable = true;
+            NextAvailableDate = Loc.Tr("Now");
+            NextAvailableDetail = stretch >= 365
+                ? Loc.Tr("{0} units free indefinitely", qtyNeeded)
+                : Loc.Tr("{0} units free for {1} days", qtyNeeded, stretch);
+            return;
+        }
+
+        // Scan up to 1 year ahead for first day where free >= qtyNeeded.
+        for (int offset = 1; offset <= 365; offset++)
+        {
+            var d = today.AddDays(offset);
+            if (TotalQty - SumRentedOn(rentals, d) >= qtyNeeded)
+            {
+                var stretch = MeasureStretch(rentals, d, qtyNeeded);
+                HasNextAvailable = true;
+                NextAvailableDate = d.ToString("MMM d, yyyy", CultureInfo.CurrentCulture);
+                NextAvailableDetail = stretch >= 365
+                    ? Loc.Tr("{0} units free indefinitely", qtyNeeded)
+                    : Loc.Tr("{0} units free for {1} days", qtyNeeded, stretch);
+                return;
+            }
+        }
+
+        HasNextAvailable = false;
+        NextAvailableDate = "—";
+        NextAvailableDetail = Loc.Tr("Not free in the next 12 months");
+    }
+
+    private int MeasureStretch(List<RentalSpan> rentals, DateTime startDay, int qtyNeeded)
+    {
+        var count = 0;
+        for (int offset = 0; offset < 365; offset++)
+        {
+            var d = startDay.AddDays(offset);
+            if (TotalQty - SumRentedOn(rentals, d) >= qtyNeeded)
+                count++;
+            else
+                break;
+        }
+        return count;
+    }
+
+    private void UpdateActiveRentalsList(CompanyData data, List<RentalSpan> rentals)
+    {
+        ActiveRentals.Clear();
+        var customersById = data.Customers.ToDictionary(c => c.Id, c => c);
+        foreach (var span in rentals.Where(s => s.IsActive).OrderBy(s => s.End))
+        {
+            customersById.TryGetValue(span.CustomerId, out var customer);
+            var customerName = customer?.Name ?? Loc.Tr("Unknown customer");
+            var endLabel = span.End.ToString("MMM d", CultureInfo.CurrentCulture);
+            ActiveRentals.Add(new ActiveRentalDisplay
+            {
+                Description = $"{span.Quantity}× {Loc.Tr("until")} {endLabel} — {customerName}",
+                IsOverdue = span.IsOverdue
+            });
+        }
+        HasActiveRentals = ActiveRentals.Count > 0;
+    }
+
+    #endregion
+
+    #region Data helpers
+
+    /// <summary>
+    /// Total fleet = current InStock (linked InventoryItem) + currently-rented quantity.
+    /// InStock decrements on rental creation and increments on return, so we add back
+    /// active rentals' quantities to recover the original total.
+    /// </summary>
+    private static int ComputeTotalFleet(CompanyData data, string rentalItemId, int displayedInStock)
+    {
+        var reserved = 0;
+        foreach (var rental in data.Rentals)
+        {
+            if (!IsCurrentlyHeld(rental)) continue;
+            foreach (var qty in QuantitiesForItem(rental, rentalItemId))
+                reserved += qty;
+        }
+        return Math.Max(0, displayedInStock) + reserved;
+    }
+
+    private static bool IsCurrentlyHeld(RentalRecord rental) =>
+        rental.Status == RentalStatus.Active || rental.Status == RentalStatus.Overdue;
+
+    private static List<RentalSpan> GetRentalsForItem(CompanyData data, string rentalItemId)
+    {
+        var spans = new List<RentalSpan>();
+        var today = DateTime.Today;
+        foreach (var rental in data.Rentals)
+        {
+            // Cancelled rentals occupy nothing.
+            if (rental.Status == RentalStatus.Cancelled) continue;
+
+            foreach (var qty in QuantitiesForItem(rental, rentalItemId))
+            {
+                if (qty <= 0) continue;
+                // End of occupancy: ReturnDate if returned, else DueDate; if currently held
+                // and overdue, extend through today so the user sees it in past cells.
+                DateTime end;
+                bool isOverdue = false;
+                bool isStillHeld = IsCurrentlyHeld(rental);
+                if (rental.Status == RentalStatus.Returned && rental.ReturnDate.HasValue)
+                {
+                    end = rental.ReturnDate.Value;
+                }
+                else
+                {
+                    end = rental.DueDate;
+                    if (isStillHeld && rental.DueDate.Date < today)
+                    {
+                        isOverdue = true;
+                        if (today > end) end = today;
+                    }
+                }
+
+                spans.Add(new RentalSpan
+                {
+                    Start = rental.StartDate,
+                    End = end,
+                    Quantity = qty,
+                    IsActive = isStillHeld,
+                    IsOverdue = isOverdue,
+                    CustomerId = rental.CustomerId
+                });
+            }
+        }
+        return spans;
+    }
+
+    /// <summary>
+    /// Yields each quantity reserved for the given rental item ID across a rental's line items
+    /// (or the legacy top-level fields when no line items exist).
+    /// </summary>
+    private static IEnumerable<int> QuantitiesForItem(RentalRecord rental, string rentalItemId)
+    {
+        if (rental.LineItems.Count > 0)
+        {
+            foreach (var li in rental.LineItems)
+                if (li.RentalItemId == rentalItemId)
+                    yield return li.Quantity;
+        }
+        else if (rental.RentalItemId == rentalItemId)
+        {
+            yield return rental.Quantity;
+        }
+    }
+
+    private static int SumRentedOn(List<RentalSpan> spans, DateTime day)
+    {
+        var d = day.Date;
+        var total = 0;
+        foreach (var span in spans)
+        {
+            if (d >= span.Start.Date && d <= span.End.Date)
+                total += span.Quantity;
+        }
+        return total;
+    }
+
+    private struct RentalSpan
+    {
+        public DateTime Start;
+        public DateTime End;
+        public int Quantity;
+        public bool IsActive;
+        public bool IsOverdue;
+        public string CustomerId;
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Display model for a single calendar day cell. Created fresh on each recompute,
+/// so simple POCO without change notification.
+/// </summary>
+public class AvailabilityDayDisplay
+{
+    public DateTime Date { get; set; }
+    public int DayNumber { get; set; }
+    public bool IsOutsideMonth { get; set; }
+    public bool IsToday { get; set; }
+    public bool IsPast { get; set; }
+    public int FreeCount { get; set; }
+    public int RentedCount { get; set; }
+    public bool MeetsNeed { get; set; }
+    public bool IsFullyBooked { get; set; }
+    public bool HasOverdue { get; set; }
+    public string State { get; set; } = "Empty";
+    public string EventLabel { get; set; } = string.Empty;
+    public string FreeLabel { get; set; } = string.Empty;
+
+    public bool HasEvent => !string.IsNullOrEmpty(EventLabel);
+    public bool ShowFreeLabel => !IsOutsideMonth;
+}
+
+/// <summary>
+/// Display model for an active rental row in the side panel.
+/// </summary>
+public class ActiveRentalDisplay
+{
+    public string Description { get; set; } = string.Empty;
+    public bool IsOverdue { get; set; }
+}

--- a/ArgoBooks/ViewModels/RentalInventoryPageViewModel.cs
+++ b/ArgoBooks/ViewModels/RentalInventoryPageViewModel.cs
@@ -492,6 +492,12 @@ public partial class RentalInventoryPageViewModel : SortablePageViewModelBase
         App.RentalInventoryModalsViewModel?.OpenRentOutModal(item);
     }
 
+    [RelayCommand]
+    private void OpenAvailabilityModal(RentalItemDisplayItem? item)
+    {
+        App.RentalAvailabilityModalViewModel?.OpenForItem(item);
+    }
+
     #endregion
 }
 

--- a/ArgoBooks/Views/AppShell.axaml
+++ b/ArgoBooks/Views/AppShell.axaml
@@ -244,6 +244,7 @@
         <modals:PurchaseOrdersModals DataContext="{Binding PurchaseOrdersModalsViewModel}" />
         <modals:StockLevelsModals DataContext="{Binding StockLevelsModalsViewModel}" />
         <modals:RentalInventoryModals DataContext="{Binding RentalInventoryModalsViewModel}" />
+        <modals:RentalAvailabilityModal DataContext="{Binding RentalAvailabilityModalViewModel}" />
 
         <!-- Entity creation modals (top layer, opened from other modals) -->
         <modals:CustomerModals DataContext="{Binding CustomerModalsViewModel}" />

--- a/ArgoBooks/Views/RentalInventoryPage.axaml
+++ b/ArgoBooks/Views/RentalInventoryPage.axaml
@@ -192,6 +192,13 @@
                                                             VerticalAlignment="Center"
                                                             Spacing="4">
                                                     <Button Classes="icon-button"
+                                                            ToolTip.Tip="{loc:Loc 'View Availability Calendar'}"
+                                                            Command="{Binding $parent[ItemsControl].((vm:RentalInventoryPageViewModel)DataContext).OpenAvailabilityModalCommand}"
+                                                            CommandParameter="{Binding}">
+                                                        <PathIcon Data="{x:Static icons:Icons.Calendar}"
+                                                                  Width="16" Height="16" />
+                                                    </Button>
+                                                    <Button Classes="icon-button"
                                                             ToolTip.Tip="{loc:Loc 'Rent Out'}"
                                                             Command="{Binding $parent[ItemsControl].((vm:RentalInventoryPageViewModel)DataContext).OpenRentOutModalCommand}"
                                                             CommandParameter="{Binding}"


### PR DESCRIPTION
## Summary
- **Add per-item rental availability calendar.** Each row in Rental Inventory has a new calendar action button that opens a wide modal with a month-grid view of free/booked counts, a quantity-aware "next available" answer card, and a list of active rentals. The user types `I need N units` and the calendar highlights days where free ≥ N green, partial amber, fully booked red. Today's cell has a blue outline. If N exceeds the fleet, the "Total fleet" hint turns red and the answer flips to "NOT AVAILABLE / Need exceeds total fleet of N".
- **Fix sample rental items showing "Unknown Item".** The Rental Inventory sheet links rental items to products via `Product ID`, but `ImportRentalInventory` was reading `Inventory Item ID`, leaving `RentalItem.InventoryItemId` empty for every row and breaking the `RentalItem → InventoryItem → Product` lookup chain. Also fixed `ImportWorksheet` not forwarding `ImportOptions` to sub-importers, which had silently disabled `AutoCreateMissingReferences` for the standard import path.

## Test plan
- [x] Open the sample company; rental items on the Rental Inventory page show their real product names (HD Projector, AV Kit, etc.) instead of "Unknown Item"
- [x] Rental records page shows the same — no "Unknown Item" entries
- [x] Click the new 📅 button next to any row → modal opens showing that item's calendar
- [x] Type a valid quantity → "NEXT AVAILABLE" green card shows the date and stretch length; calendar cells color-code green / amber / red
- [x] Type a quantity above total fleet → "Total fleet: N" turns red, card flips to "NOT AVAILABLE / Need exceeds total fleet of N", no green cells appear
- [x] +/- buttons increment/decrement the quantity (non-digits blocked at the keystroke level)
- [x] Navigate months via chevrons; "Today" button returns to the current month
- [x] Today's cell shows the blue outline
- [x] Active rentals list in the side panel matches what's shown on the Rental Records page

🤖 Generated with [Claude Code](https://claude.com/claude-code)