### PR TITLE
feat(telemetry): send free-tier uploads + remove consent toggle

### DIFF
--- a/ArgoBooks.Core/Models/GlobalSettings.cs
+++ b/ArgoBooks.Core/Models/GlobalSettings.cs
@@ -13,7 +13,6 @@ public class GlobalSettings
     public UpdateSettings Updates { get; set; } = new();
     public UiSettings Ui { get; set; } = new();
     public LicenseSettings License { get; set; } = new();
-    public PrivacySettings Privacy { get; set; } = new();
     public WindowStateSettings? WindowState { get; set; }
     public ReportExportSettings ReportExport { get; set; } = new();
     public TutorialSettings Tutorial { get; set; } = new();
@@ -171,12 +170,6 @@ public class LicenseSettings
     /// Last license validation date.
     /// </summary>
     public DateTime? LastValidationDate { get; set; }
-}
-
-public class PrivacySettings
-{
-    public bool AnonymousDataCollectionConsent { get; set; } = true;
-    public DateTime? ConsentDate { get; set; }
 }
 
 public class ReportExportSettings

--- a/ArgoBooks.Core/Services/ITelemetryManager.cs
+++ b/ArgoBooks.Core/Services/ITelemetryManager.cs
@@ -8,17 +8,6 @@ namespace ArgoBooks.Core.Services;
 public interface ITelemetryManager
 {
     /// <summary>
-    /// Gets whether the user has consented to anonymous data collection.
-    /// </summary>
-    bool IsConsentGranted { get; }
-
-    /// <summary>
-    /// Sets the user's consent preference for data collection.
-    /// </summary>
-    /// <param name="granted">Whether consent is granted.</param>
-    void SetConsent(bool granted);
-
-    /// <summary>
     /// Initializes the telemetry manager and starts a new session.
     /// </summary>
     Task InitializeAsync(CancellationToken cancellationToken = default);
@@ -49,7 +38,7 @@ public interface ITelemetryManager
     Task TrackErrorAsync(ErrorLogEntry errorEntry, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Uploads all pending telemetry data to the server (requires consent).
+    /// Uploads all pending telemetry data to the server.
     /// </summary>
     Task<TelemetryUploadResult> UploadPendingDataAsync(CancellationToken cancellationToken = default);
 

--- a/ArgoBooks.Core/Services/TelemetryManager.cs
+++ b/ArgoBooks.Core/Services/TelemetryManager.cs
@@ -11,7 +11,6 @@ public class TelemetryManager : ITelemetryManager
     private readonly ITelemetryStorageService _storageService;
     private readonly ITelemetryUploadService _uploadService;
     private readonly IGeoLocationService _geoLocationService;
-    private readonly IGlobalSettingsService _settingsService;
     private readonly IErrorLogger _errorLogger;
 
     private readonly string _appVersion;
@@ -30,14 +29,12 @@ public class TelemetryManager : ITelemetryManager
         ITelemetryStorageService storageService,
         ITelemetryUploadService uploadService,
         IGeoLocationService geoLocationService,
-        IGlobalSettingsService settingsService,
         IErrorLogger errorLogger,
         string? appVersion = null)
     {
         _storageService = storageService;
         _uploadService = uploadService;
         _geoLocationService = geoLocationService;
-        _settingsService = settingsService;
         _errorLogger = errorLogger;
 
         _appVersion = appVersion ?? AppInfo.VersionNumber;

--- a/ArgoBooks.Core/Services/TelemetryManager.cs
+++ b/ArgoBooks.Core/Services/TelemetryManager.cs
@@ -52,22 +52,6 @@ public class TelemetryManager : ITelemetryManager
     }
 
     /// <inheritdoc />
-    public bool IsConsentGranted => _settingsService.GetSettings()?.Privacy.AnonymousDataCollectionConsent ?? false;
-
-    /// <inheritdoc />
-    public void SetConsent(bool granted)
-    {
-        var settings = _settingsService.GetSettings();
-        if (settings?.Privacy == null)
-            return;
-        settings.Privacy.AnonymousDataCollectionConsent = granted;
-        settings.Privacy.ConsentDate = granted ? DateTime.UtcNow : null;
-        _settingsService.SaveSettings(settings);
-
-        _errorLogger.LogInfo($"Telemetry consent {(granted ? "granted" : "revoked")}");
-    }
-
-    /// <inheritdoc />
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         if (_isInitialized)
@@ -81,9 +65,6 @@ public class TelemetryManager : ITelemetryManager
 
             _sessionStartTime = DateTime.UtcNow;
             _isInitialized = true;
-
-            if (!IsConsentGranted)
-                return;
 
             try
             {
@@ -119,7 +100,7 @@ public class TelemetryManager : ITelemetryManager
     /// <inheritdoc />
     public async Task EndSessionAsync(CancellationToken cancellationToken = default)
     {
-        if (!_isInitialized || !IsConsentGranted)
+        if (!_isInitialized)
             return;
 
         try
@@ -143,9 +124,6 @@ public class TelemetryManager : ITelemetryManager
     /// <inheritdoc />
     public async Task TrackFeatureAsync(FeatureName featureName, string? context = null, long? durationMs = null, CancellationToken cancellationToken = default)
     {
-        if (!IsConsentGranted)
-            return;
-
         try
         {
             var featureEvent = await CreateEventAsync<FeatureUsageEvent>(cancellationToken);
@@ -163,9 +141,6 @@ public class TelemetryManager : ITelemetryManager
     /// <inheritdoc />
     public async Task TrackExportAsync(ExportType exportType, long durationMs, long fileSize, CancellationToken cancellationToken = default)
     {
-        if (!IsConsentGranted)
-            return;
-
         try
         {
             var exportEvent = await CreateEventAsync<ExportEvent>(cancellationToken);
@@ -183,9 +158,6 @@ public class TelemetryManager : ITelemetryManager
     /// <inheritdoc />
     public async Task TrackApiCallAsync(ApiName apiName, long durationMs, bool success, string? model = null, int? tokensUsed = null, CancellationToken cancellationToken = default)
     {
-        if (!IsConsentGranted)
-            return;
-
         try
         {
             var apiEvent = await CreateEventAsync<ApiUsageEvent>(cancellationToken);
@@ -205,9 +177,6 @@ public class TelemetryManager : ITelemetryManager
     /// <inheritdoc />
     public async Task TrackErrorAsync(ErrorLogEntry errorEntry, CancellationToken cancellationToken = default)
     {
-        if (!IsConsentGranted)
-            return;
-
         try
         {
             var errorEvent = await CreateEventAsync<ErrorEvent>(cancellationToken);
@@ -228,15 +197,6 @@ public class TelemetryManager : ITelemetryManager
     /// <inheritdoc />
     public async Task<TelemetryUploadResult> UploadPendingDataAsync(CancellationToken cancellationToken = default)
     {
-        if (!IsConsentGranted)
-        {
-            return new TelemetryUploadResult
-            {
-                Success = false,
-                ErrorMessage = "User consent not granted"
-            };
-        }
-
         return await _uploadService.UploadPendingDataAsync(cancellationToken);
     }
 
@@ -267,7 +227,7 @@ public class TelemetryManager : ITelemetryManager
         {
             telemetryEvent.GeoLocation = _cachedGeoLocation;
         }
-        else if (IsConsentGranted)
+        else
         {
             try
             {

--- a/ArgoBooks.Core/Services/TelemetryUploadService.cs
+++ b/ArgoBooks.Core/Services/TelemetryUploadService.cs
@@ -50,12 +50,10 @@ public class TelemetryUploadService : ITelemetryUploadService
 
         try
         {
-            var licenseKey = LicenseAuthHelper.GetLicenseKey();
-            if (string.IsNullOrEmpty(licenseKey))
+            if (!LicenseAuthHelper.IsConfigured)
             {
                 result.Success = false;
-                result.ErrorMessage = "License key not configured";
-                // Save backup when API key is missing
+                result.ErrorMessage = "No authentication available (no license key or device ID)";
                 result.BackupFilePath = await _storageService.SaveBackupFileAsync(cancellationToken);
                 return result;
             }
@@ -81,7 +79,8 @@ public class TelemetryUploadService : ITelemetryUploadService
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var batchResult = await UploadBatchWithRetryAsync(batch, licenseKey, cancellationToken);
+                var batchResult = await UploadBatchWithRetryAsync(batch, cancellationToken);
+
                 if (batchResult.Success)
                 {
                     uploadedIds.AddRange(batch.Select(e => e.DataId));
@@ -131,7 +130,6 @@ public class TelemetryUploadService : ITelemetryUploadService
 
     private async Task<TelemetryUploadResult> UploadBatchWithRetryAsync(
         List<TelemetryEvent> batch,
-        string apiKey,
         CancellationToken cancellationToken)
     {
         var result = new TelemetryUploadResult();
@@ -147,7 +145,7 @@ public class TelemetryUploadService : ITelemetryUploadService
                     await Task.Delay(delay, cancellationToken);
                 }
 
-                var uploadResult = await UploadBatchAsync(batch, apiKey, cancellationToken);
+                var uploadResult = await UploadBatchAsync(batch, cancellationToken);
                 if (uploadResult.Success)
                 {
                     return uploadResult;
@@ -155,7 +153,7 @@ public class TelemetryUploadService : ITelemetryUploadService
 
                 result.ErrorMessage = uploadResult.ErrorMessage;
 
-                // Don't retry on client errors (4xx) — these won't succeed on retry
+                // Don't retry on client errors (4xx) since they won't succeed on retry
                 if (uploadResult.HttpStatusCode is >= 400 and < 500)
                 {
                     break;
@@ -173,50 +171,12 @@ public class TelemetryUploadService : ITelemetryUploadService
 
     private async Task<TelemetryUploadResult> UploadBatchAsync(
         List<TelemetryEvent> batch,
-        string apiKey,
         CancellationToken cancellationToken)
     {
         var result = new TelemetryUploadResult();
 
-        // Extract shared metadata from the first event for compact format
-        var firstEvent = batch[0];
-        var uploadData = new TelemetryUploadData
-        {
-            UploadTime = DateTime.UtcNow,
-            AppVersion = _appVersion,
-            Platform = firstEvent.Platform,
-            UserAgent = firstEvent.UserAgent,
-            GeoLocation = firstEvent.GeoLocation,
-            EventCount = batch.Count,
-            Events = batch
-        };
-
-        // Temporarily null metadata on events so WhenWritingNull excludes them
-        var savedMetadata = batch.Select(e => (e.AppVersion, e.Platform, e.UserAgent, e.GeoLocation)).ToList();
-        foreach (var e in batch)
-        {
-            e.AppVersion = null;
-            e.Platform = null;
-            e.UserAgent = null;
-            e.GeoLocation = null;
-        }
-
-        string json;
-        try
-        {
-            json = JsonSerializer.Serialize(uploadData, _jsonOptions);
-        }
-        finally
-        {
-            // Restore metadata on events for retry scenarios and local storage consistency
-            for (int i = 0; i < batch.Count; i++)
-            {
-                batch[i].AppVersion = savedMetadata[i].AppVersion;
-                batch[i].Platform = savedMetadata[i].Platform;
-                batch[i].UserAgent = savedMetadata[i].UserAgent;
-                batch[i].GeoLocation = savedMetadata[i].GeoLocation;
-            }
-        }
+        var payload = BuildPayload(batch);
+        var json = JsonSerializer.Serialize(payload, _jsonOptions);
         var jsonBytes = Encoding.UTF8.GetBytes(json);
 
         using var content = new MultipartFormDataContent();
@@ -226,8 +186,8 @@ public class TelemetryUploadService : ITelemetryUploadService
 
         using var request = new HttpRequestMessage(HttpMethod.Post, UploadUrl);
         request.Content = content;
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-        request.Headers.Add("X-License-Key", apiKey);
+        // AddAuthHeaders sets X-License-Key (Premium) and/or X-Device-Id (Free). Server picks tier based on which is valid.
+        LicenseAuthHelper.AddAuthHeaders(request);
         request.Headers.UserAgent.ParseAdd($"{UserAgentPrefix}/{_appVersion}");
 
         using var response = await _httpClient.SendAsync(request, cancellationToken);
@@ -249,17 +209,90 @@ public class TelemetryUploadService : ITelemetryUploadService
         return result;
     }
 
-
-    private class TelemetryUploadData
+    /// <summary>
+    /// Build the upload payload using an explicit allowlist of safe fields.
+    /// Same shape for both free and premium tiers. Fields not present here cannot
+    /// leak to the wire by construction.
+    /// Forbidden fields: userAgent, geoLocation.city, geoLocation.hashedIp,
+    /// FeatureUsageEvent.context, ErrorEvent.message, ApiUsageEvent.model, ApiUsageEvent.tokensUsed.
+    /// </summary>
+    private object BuildPayload(List<TelemetryEvent> batch)
     {
-        public DateTime UploadTime { get; set; }
-        public string? AppVersion { get; set; }
-        public string? Platform { get; set; }
-        public string? UserAgent { get; set; }
-        public GeoLocationData? GeoLocation { get; set; }
-        public int EventCount { get; set; }
-        public List<TelemetryEvent> Events { get; set; } = [];
+        var first = batch[0];
+        var events = batch.Select(BuildEventDto).Where(e => e != null).ToList();
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["uploadTime"] = DateTime.UtcNow,
+            ["appVersion"] = _appVersion,
+            ["platform"] = first.Platform,
+            ["eventCount"] = events.Count,
+            ["events"] = events,
+        };
+
+        if (first.GeoLocation != null)
+        {
+            payload["geoLocation"] = new
+            {
+                country = first.GeoLocation.Country,
+                countryCode = first.GeoLocation.CountryCode,
+                region = first.GeoLocation.Region,
+                timezone = first.GeoLocation.Timezone,
+            };
+        }
+
+        return payload;
     }
+
+    private static object? BuildEventDto(TelemetryEvent e) => e switch
+    {
+        SessionEvent s => new
+        {
+            dataId = s.DataId,
+            timestamp = s.Timestamp,
+            dataType = "Session",
+            action = s.Action.ToString(),
+            durationSeconds = s.DurationSeconds,
+        },
+        FeatureUsageEvent f => new
+        {
+            dataId = f.DataId,
+            timestamp = f.Timestamp,
+            dataType = "FeatureUsage",
+            featureName = f.FeatureName.ToString(),
+            durationMs = f.DurationMs,
+        },
+        ErrorEvent err => new
+        {
+            dataId = err.DataId,
+            timestamp = err.Timestamp,
+            dataType = "Error",
+            errorCategory = err.ErrorCategory.ToString(),
+            errorCode = err.ErrorCode,
+            sourceFile = err.SourceFile,
+            lineNumber = err.LineNumber,
+            methodName = err.MethodName,
+        },
+        ExportEvent ex => new
+        {
+            dataId = ex.DataId,
+            timestamp = ex.Timestamp,
+            dataType = "Export",
+            exportType = ex.ExportType.ToString(),
+            durationMs = ex.DurationMs,
+            fileSize = ex.FileSize,
+        },
+        ApiUsageEvent api => new
+        {
+            dataId = api.DataId,
+            timestamp = api.Timestamp,
+            dataType = "ApiUsage",
+            apiName = api.ApiName.ToString(),
+            durationMs = api.DurationMs,
+            success = api.Success,
+        },
+        _ => null,
+    };
 }
 
 /// <summary>

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -804,7 +804,6 @@ public class App : Application
                 telemetryStorageService,
                 telemetryUploadService,
                 geoLocationService,
-                SettingsService,
                 errorLogger,
                 appVersion);
 

--- a/ArgoBooks/Modals/SettingsModal.axaml
+++ b/ArgoBooks/Modals/SettingsModal.axaml
@@ -146,33 +146,25 @@
                                                FontWeight="Medium"
                                                Foreground="{DynamicResource TextSecondaryBrush}" />
 
-                                    <!-- Anonymous Data Collection Toggle -->
                                     <Border Background="{DynamicResource SurfaceAltBrush}"
                                             CornerRadius="8"
                                             Padding="16">
                                         <StackPanel Spacing="12">
-                                            <Grid ColumnDefinitions="*,Auto">
-                                                <StackPanel Grid.Column="0" Spacing="2">
-                                                    <TextBlock Text="{loc:Loc 'Anonymous Data Collection'}"
-                                                               FontSize="14"
-                                                               FontWeight="Medium"
-                                                               Foreground="{DynamicResource TextPrimaryBrush}" />
-                                                    <TextBlock Text="{loc:Loc 'Help improve Argo Books by sharing anonymous usage data.'}"
-                                                               FontSize="12"
-                                                               Foreground="{DynamicResource TextTertiaryBrush}"
-                                                               TextWrapping="Wrap" />
-                                                    <TextBlock Text="{loc:Loc 'No financial or business information is ever sent.'}"
-                                                               FontSize="12"
-                                                               Foreground="{DynamicResource TextTertiaryBrush}"
-                                                               TextWrapping="Wrap" />
-                                                </StackPanel>
-                                                <ToggleSwitch Grid.Column="1"
-                                                              IsChecked="{Binding AnonymousDataCollection}"
-                                                              VerticalAlignment="Center" />
-                                            </Grid>
-                                            <!-- Collected Data buttons (only visible when data collection is enabled) -->
-                                            <StackPanel Orientation="Horizontal" Spacing="8"
-                                                        IsVisible="{Binding AnonymousDataCollection}">
+                                            <StackPanel Spacing="2">
+                                                <TextBlock Text="{loc:Loc 'Anonymous Usage Data'}"
+                                                           FontSize="14"
+                                                           FontWeight="Medium"
+                                                           Foreground="{DynamicResource TextPrimaryBrush}" />
+                                                <TextBlock Text="{loc:Loc 'Argo Books collects anonymous usage data to help improve the app.'}"
+                                                           FontSize="12"
+                                                           Foreground="{DynamicResource TextTertiaryBrush}"
+                                                           TextWrapping="Wrap" />
+                                                <TextBlock Text="{loc:Loc 'No financial or business information is ever sent.'}"
+                                                           FontSize="12"
+                                                           Foreground="{DynamicResource TextTertiaryBrush}"
+                                                           TextWrapping="Wrap" />
+                                            </StackPanel>
+                                            <StackPanel Orientation="Horizontal" Spacing="8">
                                                 <Button Classes="secondary-button"
                                                         Content="{loc:Loc 'View Data'}"
                                                         Command="{Binding OpenTelemetryFolderCommand}"

--- a/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
+++ b/ArgoBooks/ViewModels/InvoiceModalsViewModel.cs
@@ -913,8 +913,8 @@ public partial class InvoiceModalsViewModel : ViewModelBase
 
         // Populate line items — unsubscribe the ResetForm placeholder before clearing
         // so we don't leak its PropertyChanged subscription.
-        foreach (var item in LineItems)
-            item.PropertyChanged -= OnLineItemPropertyChanged;
+        foreach (var existing in LineItems)
+            existing.PropertyChanged -= OnLineItemPropertyChanged;
         LineItems.Clear();
         foreach (var lineItem in invoice.LineItems)
         {

--- a/ArgoBooks/ViewModels/SettingsModalViewModel.cs
+++ b/ArgoBooks/ViewModels/SettingsModalViewModel.cs
@@ -121,18 +121,6 @@ public partial class SettingsModalViewModel : ViewModelBase
     }
 
     [ObservableProperty]
-    private bool _anonymousDataCollection;
-
-    /// <summary>
-    /// Called when anonymous data collection setting changes.
-    /// </summary>
-    partial void OnAnonymousDataCollectionChanged(bool value)
-    {
-        // Update telemetry consent when toggle changes
-        App.TelemetryManager?.SetConsent(value);
-    }
-
-    [ObservableProperty]
     private int _telemetryEventCount;
 
     [ObservableProperty]
@@ -1380,9 +1368,6 @@ public partial class SettingsModalViewModel : ViewModelBase
                 MaxPieSlices = globalSettings.Ui.Chart.MaxPieSlices;
                 SelectedTimeZone = TimeZones.FindById(globalSettings.Ui.TimeZone);
                 SelectedTimeFormat = globalSettings.Ui.TimeFormat;
-
-                // Load privacy settings
-                AnonymousDataCollection = globalSettings.Privacy.AnonymousDataCollectionConsent;
             }
         }
 


### PR DESCRIPTION
## Summary

- `TelemetryUploadService` now sends a single allowlisted payload shape on both Premium and Free paths. Free users authenticate with `X-Device-Id`, Premium with `X-License-Key`; the server picks tier based on which header validates. Sensitive fields (`userAgent`, `geoLocation.city`, `geoLocation.hashedIp`, `FeatureUsageEvent.context`, `ErrorEvent.message`, `ApiUsageEvent.model`, `tokensUsed`) are excluded by construction. The old premium-rich payload and `TelemetryUploadData` class are removed.
- Settings modal loses the Anonymous Data Collection toggle. The View/Delete buttons remain so users can still manage the local copy.
- `TelemetryManager` loses `IsConsentGranted`/`SetConsent` and all consent gates; `GlobalSettings.Privacy` and `PrivacySettings` are removed.
- Fixes CS0136 in `InvoiceModalsViewModel.ContinueDraftInvoice`: the `foreach` variable `item` collided with the method parameter; loop var renamed to `existing`.

Pairs with the matching website PR on `Argo-Books-website` (`feat/free-tier-telemetry`, [#327](https://github.com/ArgoRobots/Argo-Books-website/pull/327)).

## Test plan

- [ ] Build the solution: no warnings or errors (CS0136 confirmed fixed).
- [ ] Start with no license key configured (free tier). Close the app. Verify an upload is made (check server logs / `admin/data-logs/argo_data_free_*.json`).
- [ ] Start with a valid license key. Close the app. Verify a `argo_data_premium_*.json` lands and contains the same field set as the free tier.
- [ ] Inspect a recent uploaded file: confirm `userAgent`, `geoLocation.city`, `geoLocation.hashedIp` are absent, and that `FeatureUsageEvent` events have no `context`, errors have no `message`, ApiUsage events have no `model`/`tokensUsed`.
- [ ] Open Settings -> General -> Privacy: the Anonymous Data Collection toggle is gone; View Data and Delete All Data buttons are present and functional.
- [ ] Old settings.json files with `Privacy: { AnonymousDataCollectionConsent: false }` still load without error (unknown fields ignored).