### PR TITLE
feat(company-file): refuse to open files saved by a newer app version

### DIFF
--- a/ArgoBooks.Core/Services/CompanyFileTooNewException.cs
+++ b/ArgoBooks.Core/Services/CompanyFileTooNewException.cs
@@ -1,0 +1,24 @@
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Thrown when a company file's stamped AppVersion is newer than the running app's version.
+/// Opening a newer file in an older app is unsafe because the newer app may have added enum
+/// values, fields, or structural changes that the older deserializer can't handle.
+/// </summary>
+public class CompanyFileTooNewException : Exception
+{
+    /// <summary>Version stamped in the file's appSettings.json.</summary>
+    public string FileVersion { get; }
+
+    /// <summary>Version of the currently running app.</summary>
+    public string AppVersion { get; }
+
+    public CompanyFileTooNewException(string fileVersion, string appVersion)
+        : base($"This company file was created by Argo Books {fileVersion}. " +
+               $"You are running Argo Books {appVersion}. " +
+               $"Please update to Argo Books {fileVersion} or later to open it.")
+    {
+        FileVersion = fileVersion;
+        AppVersion = appVersion;
+    }
+}

--- a/ArgoBooks.Core/Services/CompanyManager.cs
+++ b/ArgoBooks.Core/Services/CompanyManager.cs
@@ -473,7 +473,7 @@ public class CompanyManager : IDisposable
             // Create default company data
             CompanyData = new CompanyData();
             CompanyData.Settings.Company.Name = companyName;
-            CompanyData.Settings.AppVersion = "1.0.0";
+            CompanyData.Settings.AppVersion = AppInfo.VersionNumber;
 
             // Apply company info if provided
             if (companyInfo != null)

--- a/ArgoBooks.Core/Services/FileService.cs
+++ b/ArgoBooks.Core/Services/FileService.cs
@@ -259,6 +259,21 @@ public class FileService(
     }
 
     /// <summary>
+    /// Attaches a continuation to each task that reads its <see cref="Task.Exception"/> if it
+    /// faults, so the fault doesn't surface later as <c>UnobservedTaskException</c>. Used when
+    /// we're about to throw on the load path and want to discard the in-flight reads cleanly.
+    /// </summary>
+    private static void ObserveFaults(IEnumerable<Task> tasks)
+    {
+        foreach (var t in tasks)
+        {
+            _ = t.ContinueWith(
+                static x => { _ = x.Exception; },
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+        }
+    }
+
+    /// <summary>
     /// Throws <see cref="CompanyFileTooNewException"/> if the file's stamped version is greater
     /// than the running app's version. Legacy files (stamped "1.0.0" before the version-check
     /// feature shipped) and files with unparseable versions are allowed to load.
@@ -327,20 +342,32 @@ public class FileService(
         // Validate version BEFORE awaiting the rest. If the file was saved by a newer app
         // version, the other data files may contain enum values or fields this build can't
         // deserialize, and we'd surface that as an opaque JSON exception. Awaiting just the
-        // settings task here lets us throw a clear "update Argo Books" error instead. The
-        // other reads are already in flight; if we throw, their results go unobserved, which
-        // the runtime tolerates.
-        var settings = await settingsTask;
-        ValidateAppVersion(settings?.AppVersion);
-
-        await Task.WhenAll(
+        // settings task here lets us throw a clear "update Argo Books" error instead.
+        Task[] otherReads =
+        [
             idCountersTask, customersTask, productsTask, suppliersTask,
             employeesTask, departmentsTask, categoriesTask, accountantsTask, locationsTask,
             revenuesTask, expensesTask, invoicesTask, paymentsTask, recurringInvoicesTask,
             inventoryTask, stockAdjustmentsTask, stockTransfersTask, purchaseOrdersTask,
             rentalInventoryTask, rentalsTask, returnsTask, lostDamagedTask, receiptsTask,
             reportTemplatesTask, invoiceTemplatesTask, eventLogTask, pendingConversionsTask,
-            forecastRecordsTask);
+            forecastRecordsTask
+        ];
+
+        var settings = await settingsTask;
+        try
+        {
+            ValidateAppVersion(settings?.AppVersion);
+        }
+        catch (CompanyFileTooNewException)
+        {
+            // Don't let the in-flight reads fault into UnobservedTaskException. Their results
+            // would likely be JsonExceptions from newer enum values; we discard them.
+            ObserveFaults(otherReads);
+            throw;
+        }
+
+        await Task.WhenAll(otherReads);
 
         return new CompanyData
         {

--- a/ArgoBooks.Core/Services/FileService.cs
+++ b/ArgoBooks.Core/Services/FileService.cs
@@ -259,6 +259,30 @@ public class FileService(
     }
 
     /// <summary>
+    /// Throws <see cref="CompanyFileTooNewException"/> if the file's stamped version is greater
+    /// than the running app's version. Legacy files (stamped "1.0.0" before the version-check
+    /// feature shipped) and files with unparseable versions are allowed to load.
+    /// </summary>
+    private static void ValidateAppVersion(string? fileVersion)
+    {
+        if (string.IsNullOrEmpty(fileVersion) || !Version.TryParse(fileVersion, out var fileVer))
+        {
+            return;
+        }
+        if (!Version.TryParse(AppInfo.VersionNumber, out var appVer))
+        {
+            return;
+        }
+        // Compare on Major.Minor.Build only to keep things in lockstep with the public version string.
+        var normalizedFile = new Version(fileVer.Major, fileVer.Minor, Math.Max(0, fileVer.Build));
+        var normalizedApp = new Version(appVer.Major, appVer.Minor, Math.Max(0, appVer.Build));
+        if (normalizedFile > normalizedApp)
+        {
+            throw new CompanyFileTooNewException(fileVersion, AppInfo.VersionNumber);
+        }
+    }
+
+    /// <summary>
     /// Loads all company data from a temporary directory.
     /// </summary>
     /// <remarks>
@@ -300,8 +324,17 @@ public class FileService(
         var pendingConversionsTask = ReadJsonAsync<List<PendingConversion>>(tempDirectory, "pendingConversions.json", cancellationToken);
         var forecastRecordsTask   = ReadJsonAsync<List<Models.Insights.ForecastAccuracyRecord>>(tempDirectory, "forecastRecords.json", cancellationToken);
 
+        // Validate version BEFORE awaiting the rest. If the file was saved by a newer app
+        // version, the other data files may contain enum values or fields this build can't
+        // deserialize, and we'd surface that as an opaque JSON exception. Awaiting just the
+        // settings task here lets us throw a clear "update Argo Books" error instead. The
+        // other reads are already in flight; if we throw, their results go unobserved, which
+        // the runtime tolerates.
+        var settings = await settingsTask;
+        ValidateAppVersion(settings?.AppVersion);
+
         await Task.WhenAll(
-            settingsTask, idCountersTask, customersTask, productsTask, suppliersTask,
+            idCountersTask, customersTask, productsTask, suppliersTask,
             employeesTask, departmentsTask, categoriesTask, accountantsTask, locationsTask,
             revenuesTask, expensesTask, invoicesTask, paymentsTask, recurringInvoicesTask,
             inventoryTask, stockAdjustmentsTask, stockTransfersTask, purchaseOrdersTask,
@@ -311,7 +344,7 @@ public class FileService(
 
         return new CompanyData
         {
-            Settings = settingsTask.Result ?? new CompanySettings(),
+            Settings = settings ?? new CompanySettings(),
             IdCounters = idCountersTask.Result ?? new IdCounters(),
             Customers = customersTask.Result ?? [],
             Products = productsTask.Result ?? [],
@@ -354,6 +387,11 @@ public class FileService(
         CompanyData data,
         CancellationToken cancellationToken = default)
     {
+        // Stamp the running app's version into the file so a future older app can detect
+        // that the file is too new for it to safely open. This runs on every save path
+        // because all save flows route through here.
+        data.Settings.AppVersion = AppInfo.VersionNumber;
+
         // Write directly to the provided company directory - caller is responsible for providing the correct path
         await WriteJsonAsync(companyDirectory, "appSettings.json", data.Settings, cancellationToken);
         await WriteJsonAsync(companyDirectory, "idCounters.json", data.IdCounters, cancellationToken);

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -3954,7 +3954,7 @@ public class App : Application
                 await ConfirmationDialog.ShowAsync(new ConfirmationDialogOptions
                 {
                     Title = "Update Argo Books".Translate(),
-                    Message = ex.Message,
+                    Message = "This company file was created by Argo Books {0}. You are running Argo Books {1}. Please update to Argo Books {0} or later to open it.".TranslateFormat(ex.FileVersion, ex.AppVersion),
                     PrimaryButtonText = "OK".Translate(),
                     SecondaryButtonText = null,
                     CancelButtonText = null

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -3939,6 +3939,28 @@ public class App : Application
             SettingsService?.RemoveRecentCompany(filePath);
             await LoadRecentCompaniesAsync();
         }
+        catch (CompanyFileTooNewException ex)
+        {
+            // File was saved by a newer Argo Books build. Use ConfirmationDialog (same path as
+            // the FileNotFoundException case) rather than the message-box service, because the
+            // latter races with the loading overlay and the dialog ends up queued behind the
+            // next user action.
+            _isOpeningCompany = false;
+            _mainWindowViewModel.HideLoading();
+            passwordModal.Close();
+            ErrorLogger?.LogError(ex, ErrorCategory.FileSystem, "Cannot open company file: newer than running app");
+            if (ConfirmationDialog != null)
+            {
+                await ConfirmationDialog.ShowAsync(new ConfirmationDialogOptions
+                {
+                    Title = "Update Argo Books".Translate(),
+                    Message = ex.Message,
+                    PrimaryButtonText = "OK".Translate(),
+                    SecondaryButtonText = null,
+                    CancelButtonText = null
+                });
+            }
+        }
         catch (Exception ex)
         {
             _isOpeningCompany = false;


### PR DESCRIPTION
## Summary

Closes the silent forward-compat failure where opening a company file from a newer Argo Books build would throw an opaque JSON exception (e.g., `JsonException: The JSON value could not be converted to ArgoBooks.Core.Enums.InvoiceStatus`) when the older deserializer hit a newer enum value like `Refunded` / `PartiallyRefunded`.

- `CompanySettings.AppVersion` was already a field but was hardcoded to `"1.0.0"` on create and never updated on save, so the plumbing existed but did nothing.
- `FileService.SaveCompanyDataAsync` now stamps `AppInfo.VersionNumber` into `Settings.AppVersion` on every save. All save paths route through this method, so one change covers them all.
- `FileService.LoadCompanyDataAsync` awaits the `appSettings.json` task first, runs the version check, and throws `CompanyFileTooNewException` with a clear "Please update to Argo Books X.Y.Z or later" message if the file is newer than the running app. The other reads stay in parallel so load performance is unchanged on the happy path.
- `CompanyManager.CreateCompanyAsync` stamps `AppInfo.VersionNumber` on create instead of `"1.0.0"`.

## Behavior matrix

| File stamp | App version | Result |
|---|---|---|
| (no field / unparseable) | any | Loads. Legacy fallback. |
| `1.0.0` (legacy default) | `2.0.7` | Loads. |
| `2.0.7` | `2.0.7` | Loads. |
| `2.0.7` | `2.0.6` | Throws `CompanyFileTooNewException`; user sees "Please update to Argo Books 2.0.7 or later". |

Comparison is on Major.Minor.Build only.

## Test plan

- [ ] Open an existing company file (stamped `1.0.0` from previous builds): loads without warning.
- [ ] Open and save a company; inspect `appSettings.json` inside the `.argo` archive: `AppVersion` reflects the running build's version.
- [ ] On a `V.2.0.6` checkout, attempt to open a `.argo` file saved by `V.2.0.7`: error dialog says "This company file was created by Argo Books 2.0.7. Please update to Argo Books 2.0.7 or later to open it."
- [ ] Create a brand-new company; inspect `appSettings.json`: `AppVersion` reflects the running build (not `1.0.0`).