### PR TITLE
fix(country-dropdown): show full list, refresh priorities, fix re-open

### DIFF
--- a/ArgoBooks/Controls/CountryInput.axaml.cs
+++ b/ArgoBooks/Controls/CountryInput.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.Input;
 
@@ -203,6 +204,10 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
         {
             _countrySearchBox.GotFocus += OnCountrySearchBoxGotFocus;
             _countrySearchBox.KeyDown += OnCountrySearchBoxKeyDown;
+            // Tunneling so we re-open the dropdown even when the textbox already has focus.
+            // Without this, clicking-elsewhere light-dismisses the popup but the textbox keeps
+            // focus, and the next click on the textbox doesn't fire GotFocus.
+            _countrySearchBox.AddHandler(PointerPressedEvent, OnCountrySearchBoxPointerPressed, RoutingStrategies.Tunnel);
         }
 
     }
@@ -215,6 +220,7 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
         {
             _countrySearchBox.GotFocus -= OnCountrySearchBoxGotFocus;
             _countrySearchBox.KeyDown -= OnCountrySearchBoxKeyDown;
+            _countrySearchBox.RemoveHandler(PointerPressedEvent, OnCountrySearchBoxPointerPressed);
         }
 
     }
@@ -223,6 +229,14 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
     {
         IsDropdownOpen = true;
         _countrySearchBox?.SelectAll();
+    }
+
+    private void OnCountrySearchBoxPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!IsDropdownOpen)
+        {
+            IsDropdownOpen = true;
+        }
     }
 
     private void OnCountrySearchBoxKeyDown(object? sender, KeyEventArgs e)
@@ -323,7 +337,7 @@ public partial class CountryInput : UserControl, INotifyPropertyChanged
         // Get the last priority country code (Canada = "CA")
         var lastPriorityCode = Countries.Priority.LastOrDefault()?.Code;
 
-        foreach (var item in filtered.Take(50))
+        foreach (var item in filtered)
         {
             // Only show separator when displaying the full list, after the last priority country
             item.ShowSeparatorAfter = showingFullList && item.Code == lastPriorityCode;

--- a/ArgoBooks/Controls/PhoneInput.axaml.cs
+++ b/ArgoBooks/Controls/PhoneInput.axaml.cs
@@ -344,6 +344,10 @@ public partial class PhoneInput : UserControl, INotifyPropertyChanged
         {
             _countrySearchBox.GotFocus += OnCountrySearchBoxGotFocus;
             _countrySearchBox.KeyDown += OnCountrySearchBoxKeyDown;
+            // Tunneling so we re-open the dropdown even when the textbox already has focus.
+            // Without this, clicking-elsewhere light-dismisses the popup but the textbox keeps
+            // focus, and the next click on the textbox doesn't fire GotFocus.
+            _countrySearchBox.AddHandler(PointerPressedEvent, OnCountrySearchBoxPointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         }
 
         _countryListBox = this.FindControl<ListBox>("CountryListBox");
@@ -494,6 +498,14 @@ public partial class PhoneInput : UserControl, INotifyPropertyChanged
         _countrySearchBox?.SelectAll();
     }
 
+    private void OnCountrySearchBoxPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!IsCountryDropdownOpen)
+        {
+            IsCountryDropdownOpen = true;
+        }
+    }
+
     private void OnCountrySearchBoxKeyDown(object? sender, KeyEventArgs e)
     {
         switch (e.Key)
@@ -594,7 +606,7 @@ public partial class PhoneInput : UserControl, INotifyPropertyChanged
         // Get the last priority country code (Canada = "CA")
         var lastPriorityCode = Countries.Priority.LastOrDefault()?.Code;
 
-        foreach (var item in filtered.Take(50))
+        foreach (var item in filtered)
         {
             // Only show separator when displaying the full list, after the last priority country
             item.ShowSeparatorAfter = showingFullList && item.Code == lastPriorityCode;

--- a/ArgoBooks/Data/Countries.cs
+++ b/ArgoBooks/Data/Countries.cs
@@ -11,13 +11,14 @@ public static class Countries
     private static readonly string[] PriorityCodes =
     [
         "US", // United States
-        "CN", // China
         "DE", // Germany
-        "JP", // Japan
         "GB", // United Kingdom
         "FR", // France
         "IT", // Italy
-        "CA"  // Canada
+        "CA", // Canada
+        "AU", // Australia
+        "ES", // Spain
+        "NL"  // Netherlands
     ];
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Removed the `Take(50)` cap in `CountryInput` and `PhoneInput` so the entire country list is scrollable. With 8+ priority countries on top, the cap was cutting the alphabetical list off partway through C.
- Refreshed `PriorityCodes`: dropped China and Japan, added Australia, Spain, and Netherlands. Reordered by nominal GDP (US, DE, GB, FR, IT, CA, AU, ES, NL).
- Added a tunneling `PointerPressed` handler on the search textbox that re-opens the dropdown on every click. `GotFocus` only fires on the initial focus acquisition, so once the popup was light-dismissed by clicking elsewhere, the textbox kept focus and the next click on it couldn't reopen the dropdown until focus was given up. Tunneling is required because the TextBox handles bubbling `PointerPressed` itself.

## Test plan
- [ ] Open the country dropdown in a customer/supplier/location/edit-company modal and scroll past C — all ~190 countries should be reachable.
- [ ] Verify the priority section at the top shows US, DE, GB, FR, IT, CA, AU, ES, NL with a separator, and China/Japan are gone from the top (still present alphabetically).
- [ ] Click the country search textbox, click outside to dismiss, then click the textbox again — the dropdown should reopen.
- [ ] Same checks in the `PhoneInput` country picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)