### PR TITLE
Signup source survey + onboarding polish

### DIFF
--- a/ArgoBooks.Core/Models/GlobalSettings.cs
+++ b/ArgoBooks.Core/Models/GlobalSettings.cs
@@ -229,4 +229,20 @@ public class TutorialSettings
     /// When the user first started using the app.
     /// </summary>
     public DateTime? FirstLaunchDate { get; set; }
+
+    /// <summary>
+    /// Whether the post-onboarding source survey has been shown to the user.
+    /// </summary>
+    public bool HasShownSourceSurvey { get; set; } = false;
+
+    /// <summary>
+    /// The user's answer to "Where did you hear about Argo Books?". One of:
+    /// google, bing, youtube, reddit, friend, email, other. Null if not answered.
+    /// </summary>
+    public string? SourceSurveyAnswer { get; set; }
+
+    /// <summary>
+    /// Whether the user explicitly dismissed the source survey without answering.
+    /// </summary>
+    public bool IsSourceSurveyDismissed { get; set; } = false;
 }

--- a/ArgoBooks.Core/Services/InstallAttributionReason.cs
+++ b/ArgoBooks.Core/Services/InstallAttributionReason.cs
@@ -1,0 +1,40 @@
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Reads the FirstRunReporter marker file so the rest of the app can tell whether
+/// the install came in with a referral token, without depending on FirstRunReporter itself.
+/// </summary>
+public static class InstallAttributionReason
+{
+    private const string MarkerFileName = "first_run_reported.marker";
+
+    /// <summary>
+    /// Returns the <c>reason=</c> value from the first-run marker:
+    /// <c>"token"</c>, <c>"no_token"</c>, <c>"gave_up_after_retries"</c>, or
+    /// <c>null</c> if the marker doesn't exist yet (FirstRunReporter hasn't finished).
+    /// </summary>
+    public static string? ReadFirstRunMarkerReason()
+    {
+        try
+        {
+            var path = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "ArgoBooks",
+                MarkerFileName);
+            if (!File.Exists(path)) return null;
+
+            foreach (var line in File.ReadAllLines(path))
+            {
+                if (line.StartsWith("reason=", StringComparison.Ordinal))
+                {
+                    return line.Substring("reason=".Length).Trim();
+                }
+            }
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/ArgoBooks.Core/Services/SourceSurveyReporter.cs
+++ b/ArgoBooks.Core/Services/SourceSurveyReporter.cs
@@ -1,0 +1,109 @@
+using System.Net.Http.Json;
+using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
+using ArgoBooks.Core.Models.Telemetry;
+
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Posts the post-onboarding "Where did you hear about Argo Books?" answer to
+/// the website. The answer updates the existing <c>app_first_run</c> row for
+/// this machine on the server, so installs without a referral token can still
+/// be attributed to a source.
+///
+/// Idempotency lives in <c>TutorialSettings.SourceSurveyAnswer</c> on the
+/// client and in a server-side <c>WHERE source_survey_answer IS NULL</c> guard.
+/// </summary>
+public sealed class SourceSurveyReporter
+{
+    private const string EndpointPath = "/api/track-app-event.php";
+
+    private readonly HttpClient _httpClient;
+    private readonly IErrorLogger? _errorLogger;
+    private readonly string _appVersion;
+
+    public SourceSurveyReporter(
+        HttpClient httpClient,
+        string appVersion,
+        IErrorLogger? errorLogger = null)
+    {
+        _httpClient = httpClient;
+        _errorLogger = errorLogger;
+        _appVersion = appVersion;
+    }
+
+    /// <summary>
+    /// POSTs the survey answer. Returns true on HTTP 2xx, false otherwise.
+    /// Network errors are caught and logged.
+    /// </summary>
+    public async Task<bool> ReportAsync(
+        string answer,
+        string machineUuid,
+        string? otherText = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var payload = new SurveyPayload
+            {
+                Event = "signup_survey",
+                Platform = GetPlatformKey(),
+                AppVersion = _appVersion,
+                MachineUuid = machineUuid,
+                Answer = answer,
+                OtherText = answer == "other" ? otherText : null,
+            };
+
+            var url = $"{ApiConfig.BaseUrl}{EndpointPath}";
+            using var response = await _httpClient.PostAsJsonAsync(url, payload, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _errorLogger?.LogWarning(
+                    $"SourceSurveyReporter received HTTP {(int)response.StatusCode}",
+                    context: "SourceSurveyReporter.ReportAsync");
+                return false;
+            }
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _errorLogger?.LogError(ex, ErrorCategory.Network,
+                context: "SourceSurveyReporter.ReportAsync");
+            return false;
+        }
+    }
+
+    private static string GetPlatformKey()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "win";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))     return "mac";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))   return "linux";
+        return "unknown";
+    }
+
+    private sealed class SurveyPayload
+    {
+        [JsonPropertyName("event")]
+        public string Event { get; set; } = string.Empty;
+
+        [JsonPropertyName("platform")]
+        public string Platform { get; set; } = string.Empty;
+
+        [JsonPropertyName("app_version")]
+        public string AppVersion { get; set; } = string.Empty;
+
+        [JsonPropertyName("machine_uuid")]
+        public string MachineUuid { get; set; } = string.Empty;
+
+        [JsonPropertyName("answer")]
+        public string Answer { get; set; } = string.Empty;
+
+        [JsonPropertyName("other_text")]
+        public string? OtherText { get; set; }
+    }
+}

--- a/ArgoBooks.Tests/ViewModels/AppTourViewModelTests.cs
+++ b/ArgoBooks.Tests/ViewModels/AppTourViewModelTests.cs
@@ -18,9 +18,9 @@ public class AppTourViewModelTests
     #region Default State Tests
 
     [Fact]
-    public void Constructor_DefaultState_TotalStepsIsFive()
+    public void Constructor_DefaultState_TotalStepsIsFour()
     {
-        Assert.Equal(5, _viewModel.TotalSteps);
+        Assert.Equal(4, _viewModel.TotalSteps);
     }
 
     [Fact]
@@ -227,11 +227,11 @@ public class AppTourViewModelTests
     }
 
     [Fact]
-    public void StartTour_FirstStepTitle_IsWelcome()
+    public void StartTour_FirstStepTitle_IsNavigationSidebar()
     {
         _viewModel.StartTour();
 
-        Assert.Equal("Welcome to Argo Books", _viewModel.CurrentTitle);
+        Assert.Equal("Navigation Sidebar", _viewModel.CurrentTitle);
     }
 
     #endregion

--- a/ArgoBooks/App.EventWiring.cs
+++ b/ArgoBooks/App.EventWiring.cs
@@ -1612,4 +1612,39 @@ public partial class App
         }
     }
 
+    /// <summary>
+    /// When the user finishes the setup checklist, opens the "Where did you hear about
+    /// Argo Books?" survey. Deferred until any in-flight completion guidance card
+    /// (which fires simultaneously for the final VisitAnalytics step) has been dismissed.
+    /// </summary>
+    private static bool _surveyPendingAfterGuidance;
+
+    private static void WireSourceSurveyEvents()
+    {
+        TutorialService.Instance.AllChecklistItemsCompleted += (_, _) =>
+        {
+            if (!TutorialService.Instance.ShouldShowSourceSurvey())
+                return;
+
+            // If the Analytics completion guidance just opened in the same
+            // call-stack (VisitAnalytics is the last checklist item), wait for
+            // the user to dismiss it before showing the survey on top.
+            if (TutorialService.Instance.ShowCompletionGuidance)
+            {
+                _surveyPendingAfterGuidance = true;
+            }
+            else
+            {
+                TutorialService.Instance.RequestShowSourceSurvey();
+            }
+        };
+
+        TutorialService.Instance.CompletionGuidanceChanged += (_, show) =>
+        {
+            if (show || !_surveyPendingAfterGuidance) return;
+            _surveyPendingAfterGuidance = false;
+            TutorialService.Instance.RequestShowSourceSurvey();
+        };
+    }
+
 }

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -87,6 +87,11 @@ public partial class App : Application
     public static ITelemetryManager? TelemetryManager { get; private set; }
 
     /// <summary>
+    /// Gets the reporter used by the post-onboarding source survey overlay.
+    /// </summary>
+    public static SourceSurveyReporter? SourceSurveyReporter { get; private set; }
+
+    /// <summary>
     /// Gets the shared undo/redo manager instance.
     /// </summary>
     public static UndoRedoManager UndoRedoManager => HeaderViewModel.SharedUndoRedoManager;
@@ -818,6 +823,12 @@ public partial class App : Application
             // Initialize refund service (uses the same shared HttpClient)
             RefundService = new RefundService(httpClient);
 
+            // Source survey reporter shares the long-lived telemetry HttpClient. The
+            // survey may fire long after first run (after the user finishes the setup
+            // checklist), so we keep the reporter alive rather than scoping it to a
+            // one-shot task like FirstRunReporter.
+            SourceSurveyReporter = new SourceSurveyReporter(httpClient, appVersion, errorLogger);
+
             // Create navigation service
             NavigationService = new NavigationService();
 
@@ -885,6 +896,9 @@ public partial class App : Application
 
             // Wire up modal change events (separate from company manager)
             WireModalChangeEvents();
+
+            // Wire up the post-onboarding source survey trigger
+            WireSourceSurveyEvents();
 
             // Sync HasUnsavedChanges with undo/redo state (both MainWindow and Header)
             UndoRedoManager.StateChanged += (_, _) =>
@@ -2998,8 +3012,6 @@ public partial class App : Application
             if (_productsPageViewModel == null)
             {
                 _productsPageViewModel = new ProductsPageViewModel();
-                // Wire up upgrade request to open upgrade modal (only once)
-                _productsPageViewModel.UpgradeRequested += (_, _) => _appShellViewModel!.UpgradeModalViewModel.OpenCommand.Execute(null);
             }
             // Update plan status each time (may have changed)
             _productsPageViewModel.HasPremium = _appShellViewModel!.SidebarViewModel.HasPremium;

--- a/ArgoBooks/Controls/SetupChecklist.axaml
+++ b/ArgoBooks/Controls/SetupChecklist.axaml
@@ -17,10 +17,11 @@
     </Design.DataContext>
 
     <Border Background="{DynamicResource SurfaceBrush}"
-            BorderBrush="{DynamicResource BorderBrush}"
-            BorderThickness="1"
+            BorderBrush="{DynamicResource PrimaryBrush}"
+            BorderThickness="2"
             CornerRadius="12"
-            Margin="0,0,0,24">
+            Margin="0,0,0,24"
+            BoxShadow="0 0 20 0 #4040A0FF">
 
         <Grid RowDefinitions="Auto,*">
             <!-- Header -->
@@ -76,27 +77,6 @@
                 </Border.Transitions>
 
                 <StackPanel>
-                    <!-- Progress Bar (hidden when complete) -->
-                    <Border Padding="20,12"
-                            IsVisible="{Binding !IsAllCompleted}">
-                        <Grid>
-                            <Border Background="{DynamicResource BackgroundSecondaryBrush}"
-                                    CornerRadius="4"
-                                    Height="8" />
-                            <Border Background="{DynamicResource PrimaryBrush}"
-                                    CornerRadius="4"
-                                    Height="8"
-                                    HorizontalAlignment="Left">
-                                <Border.Width>
-                                    <MultiBinding Converter="{x:Static conv:MathConverters.Percentage}">
-                                        <Binding Path="ProgressPercentage" />
-                                        <Binding Path="$parent[Border].Bounds.Width" />
-                                    </MultiBinding>
-                                </Border.Width>
-                            </Border>
-                        </Grid>
-                    </Border>
-
                     <!-- Checklist Items -->
                     <ItemsControl ItemsSource="{Binding Items}"
                                   IsVisible="{Binding !IsAllCompleted}"
@@ -133,33 +113,48 @@
                                             </Panel>
                                         </Border>
 
-                                        <!-- Title and Description -->
+                                        <!-- Title (with inline "Click here" pill on the active item) and Description -->
                                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
-                                            <TextBlock Text="{Binding Title}"
-                                                       FontSize="14"
-                                                       FontWeight="Medium"
-                                                       Foreground="{DynamicResource TextPrimaryBrush}">
-                                                <TextBlock.TextDecorations>
-                                                    <Binding Path="IsCompleted">
-                                                        <Binding.Converter>
-                                                            <conv:BoolToTextDecorationConverter />
-                                                        </Binding.Converter>
-                                                    </Binding>
-                                                </TextBlock.TextDecorations>
-                                            </TextBlock>
+                                            <StackPanel Orientation="Horizontal" Spacing="18" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding Title}"
+                                                           FontSize="14"
+                                                           FontWeight="Medium"
+                                                           VerticalAlignment="Center"
+                                                           Foreground="{DynamicResource TextPrimaryBrush}">
+                                                    <TextBlock.TextDecorations>
+                                                        <Binding Path="IsCompleted">
+                                                            <Binding.Converter>
+                                                                <conv:BoolToTextDecorationConverter />
+                                                            </Binding.Converter>
+                                                        </Binding>
+                                                    </TextBlock.TextDecorations>
+                                                </TextBlock>
+
+                                                <!-- Active item: accent-color "Click here" pill, inline with the title -->
+                                                <Border IsVisible="{Binding IsCurrentItem}"
+                                                        Background="{DynamicResource PrimaryBrush}"
+                                                        CornerRadius="12"
+                                                        Padding="10,4"
+                                                        VerticalAlignment="Center">
+                                                    <StackPanel Orientation="Horizontal" Spacing="5" VerticalAlignment="Center">
+                                                        <PathIcon Data="{x:Static local:Icons.ArrowBack}"
+                                                                  Width="12" Height="12"
+                                                                  Foreground="White"
+                                                                  VerticalAlignment="Center" />
+                                                        <TextBlock Text="{loc:Loc 'Click here'}"
+                                                                   FontSize="11"
+                                                                   FontWeight="SemiBold"
+                                                                   Foreground="White"
+                                                                   VerticalAlignment="Center" />
+                                                    </StackPanel>
+                                                </Border>
+                                            </StackPanel>
+
                                             <TextBlock Text="{Binding Description}"
                                                        FontSize="12"
                                                        Foreground="{DynamicResource TextTertiaryBrush}"
                                                        IsVisible="{Binding !IsCompleted}" />
                                         </StackPanel>
-
-                                        <!-- Arrow (only for incomplete items) -->
-                                        <PathIcon Grid.Column="2"
-                                                  Data="{x:Static local:Icons.ChevronRightNav}"
-                                                  Width="16" Height="16"
-                                                  Foreground="{DynamicResource TextTertiaryBrush}"
-                                                  VerticalAlignment="Center"
-                                                  IsVisible="{Binding !IsCompleted}" />
                                     </Grid>
                                 </Button>
                             </DataTemplate>
@@ -185,7 +180,7 @@
                                            FontWeight="SemiBold"
                                            Foreground="{DynamicResource TextPrimaryBrush}"
                                            HorizontalAlignment="Center" />
-                                <TextBlock Text="{loc:Loc 'You''re ready to start tracking your business finances.'}"
+                                <TextBlock Text="{loc:Loc 'You’re ready to start tracking your business finances.'}"
                                            FontSize="13"
                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                            HorizontalAlignment="Center"
@@ -194,13 +189,13 @@
 
                             <!-- Free Tier Info -->
                             <StackPanel Spacing="8" HorizontalAlignment="Center">
-                                <TextBlock Text="{loc:Loc 'You can use Argo Books for free with up to 10 products.'}"
+                                <TextBlock Text="{loc:Loc 'You can use Argo Books for free — all core features, plus 25 invoices and 5 AI receipt scans every month.'}"
                                            FontSize="12"
                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                            TextWrapping="Wrap"
                                            TextAlignment="Center"
                                            HorizontalAlignment="Center" />
-                                <TextBlock Text="{loc:Loc 'Upgrade for unlimited products, AI receipt scanning, and more.'}"
+                                <TextBlock Text="{loc:Loc 'Upgrade for unlimited invoices, more AI receipt scans, and predictive analytics.'}"
                                            FontSize="12"
                                            Foreground="{DynamicResource TextSecondaryBrush}"
                                            TextWrapping="Wrap"

--- a/ArgoBooks/Controls/SourceSurveyOverlay.axaml
+++ b/ArgoBooks/Controls/SourceSurveyOverlay.axaml
@@ -70,6 +70,13 @@
                                  Margin="28,4,0,0" />
                     </StackPanel>
 
+                    <!-- Inline error message (POST failure / no reporter / no machine_uuid) -->
+                    <TextBlock Text="{Binding SubmitError}"
+                               IsVisible="{Binding SubmitError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                               Foreground="{DynamicResource ErrorBrush}"
+                               FontSize="12"
+                               TextWrapping="Wrap" />
+
                     <!-- Actions: Submit only — no dismiss path, the user must answer. -->
                     <Button Classes="primary"
                             Content="{loc:Loc 'Submit'}"

--- a/ArgoBooks/Controls/SourceSurveyOverlay.axaml
+++ b/ArgoBooks/Controls/SourceSurveyOverlay.axaml
@@ -1,0 +1,85 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="using:ArgoBooks"
+             xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:icons="using:ArgoBooks"
+             xmlns:loc="using:ArgoBooks.Localization"
+             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="500"
+             x:Class="ArgoBooks.Controls.SourceSurveyOverlay"
+             x:DataType="controls:SourceSurveyOverlayViewModel">
+
+    <controls:ModalOverlay x:Name="Overlay"
+                           CloseOnBackdropClick="False"
+                           CloseOnEscape="False">
+        <controls:ModalOverlay.ModalContent>
+            <Border Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource PrimaryBrush}"
+                    BorderThickness="2"
+                    CornerRadius="16"
+                    Padding="32,28"
+                    MaxWidth="460"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    BoxShadow="0 4 20 0 #26000000">
+                <StackPanel Spacing="20">
+
+                    <!-- Title + subtitle -->
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="{loc:Loc 'Where did you hear about Argo Books?'}"
+                                   FontSize="20"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextPrimaryBrush}"
+                                   TextWrapping="Wrap" />
+                        <TextBlock Text="{loc:Loc 'A quick one-question survey to help us know how people are finding us.'}"
+                                   FontSize="13"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"
+                                   TextWrapping="Wrap" />
+                    </StackPanel>
+
+                    <!-- Options -->
+                    <StackPanel Spacing="6">
+                        <RadioButton GroupName="SourceSurveyOption"
+                                     Content="{loc:Loc 'Google'}"
+                                     IsChecked="{Binding IsGoogleSelected, Mode=TwoWay}" />
+                        <RadioButton GroupName="SourceSurveyOption"
+                                     Content="{loc:Loc 'Bing'}"
+                                     IsChecked="{Binding IsBingSelected, Mode=TwoWay}" />
+                        <RadioButton GroupName="SourceSurveyOption"
+                                     Content="{loc:Loc 'YouTube'}"
+                                     IsChecked="{Binding IsYouTubeSelected, Mode=TwoWay}" />
+                        <RadioButton GroupName="SourceSurveyOption"
+                                     Content="{loc:Loc 'Reddit'}"
+                                     IsChecked="{Binding IsRedditSelected, Mode=TwoWay}" />
+                        <RadioButton GroupName="SourceSurveyOption"
+                                     Content="{loc:Loc 'A friend'}"
+                                     IsChecked="{Binding IsFriendSelected, Mode=TwoWay}" />
+                        <RadioButton GroupName="SourceSurveyOption"
+                                     Content="{loc:Loc 'Email'}"
+                                     IsChecked="{Binding IsEmailSelected, Mode=TwoWay}" />
+                        <RadioButton GroupName="SourceSurveyOption"
+                                     Content="{loc:Loc 'Other'}"
+                                     IsChecked="{Binding IsOtherSelected, Mode=TwoWay}" />
+
+                        <!-- Freeform input shown when "Other" is selected -->
+                        <TextBox IsVisible="{Binding IsOtherSelected}"
+                                 Text="{Binding OtherText, Mode=TwoWay}"
+                                 PlaceholderText="{loc:Loc 'Tell us where you heard about us'}"
+                                 MaxLength="200"
+                                 Margin="28,4,0,0" />
+                    </StackPanel>
+
+                    <!-- Actions: Submit only — no dismiss path, the user must answer. -->
+                    <Button Classes="primary"
+                            Content="{loc:Loc 'Submit'}"
+                            Command="{Binding SubmitCommand}"
+                            IsEnabled="{Binding CanSubmit}"
+                            HorizontalAlignment="Right"
+                            Margin="0,4,0,0" />
+
+                </StackPanel>
+            </Border>
+        </controls:ModalOverlay.ModalContent>
+    </controls:ModalOverlay>
+</UserControl>

--- a/ArgoBooks/Controls/SourceSurveyOverlay.axaml.cs
+++ b/ArgoBooks/Controls/SourceSurveyOverlay.axaml.cs
@@ -1,4 +1,5 @@
 using ArgoBooks.Core.Services;
+using ArgoBooks.Localization;
 using ArgoBooks.Services;
 using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -49,6 +50,9 @@ public partial class SourceSurveyOverlayViewModel : ObservableObject
     [ObservableProperty]
     private string _otherText = string.Empty;
 
+    [ObservableProperty]
+    private string? _submitError;
+
     public bool CanSubmit
     {
         get
@@ -60,7 +64,20 @@ public partial class SourceSurveyOverlayViewModel : ObservableObject
         }
     }
 
-    partial void OnSelectedAnswerChanged(string? value) => OnPropertyChanged(nameof(CanSubmit));
+    // Notify every derived Is*Selected property so radio buttons and the freeform
+    // textbox visibility binding refresh whenever SelectedAnswer changes (including
+    // null after Reset).
+    partial void OnSelectedAnswerChanged(string? value)
+    {
+        OnPropertyChanged(nameof(CanSubmit));
+        OnPropertyChanged(nameof(IsGoogleSelected));
+        OnPropertyChanged(nameof(IsBingSelected));
+        OnPropertyChanged(nameof(IsYouTubeSelected));
+        OnPropertyChanged(nameof(IsRedditSelected));
+        OnPropertyChanged(nameof(IsFriendSelected));
+        OnPropertyChanged(nameof(IsEmailSelected));
+        OnPropertyChanged(nameof(IsOtherSelected));
+    }
     partial void OnIsSubmittingChanged(bool value) => OnPropertyChanged(nameof(CanSubmit));
     partial void OnOtherTextChanged(string value) => OnPropertyChanged(nameof(CanSubmit));
 
@@ -111,6 +128,7 @@ public partial class SourceSurveyOverlayViewModel : ObservableObject
         SelectedAnswer = null;
         OtherText = string.Empty;
         IsSubmitting = false;
+        SubmitError = null;
     }
 
     [RelayCommand]
@@ -123,14 +141,26 @@ public partial class SourceSurveyOverlayViewModel : ObservableObject
         if (answer == "other" && string.IsNullOrEmpty(otherText)) return;
 
         IsSubmitting = true;
+        SubmitError = null;
         try
         {
             var reporter = App.SourceSurveyReporter;
             var machineUuid = ReadMachineUuid();
-            if (reporter != null && machineUuid != null)
+            if (reporter == null || machineUuid == null)
             {
-                await reporter.ReportAsync(answer, machineUuid, otherText);
+                SubmitError = "Could not record your answer. Please try again later.".Translate();
+                return;
             }
+
+            var ok = await reporter.ReportAsync(answer, machineUuid, otherText);
+            if (!ok)
+            {
+                SubmitError = "Could not record your answer. Please check your connection and try again.".Translate();
+                return;
+            }
+
+            // Only mark answered after a successful POST so a failure doesn't
+            // permanently suppress the survey with no record on the server.
             TutorialService.Instance.MarkSourceSurveyAnswered(answer);
         }
         finally

--- a/ArgoBooks/Controls/SourceSurveyOverlay.axaml.cs
+++ b/ArgoBooks/Controls/SourceSurveyOverlay.axaml.cs
@@ -1,0 +1,159 @@
+using ArgoBooks.Core.Services;
+using ArgoBooks.Services;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ArgoBooks.Controls;
+
+public partial class SourceSurveyOverlay : UserControl
+{
+    private ModalOverlay? _overlay;
+    private readonly SourceSurveyOverlayViewModel _viewModel;
+
+    public SourceSurveyOverlay()
+    {
+        InitializeComponent();
+
+        _viewModel = new SourceSurveyOverlayViewModel();
+        DataContext = _viewModel;
+
+        _overlay = this.FindControl<ModalOverlay>("Overlay");
+
+        TutorialService.Instance.SourceSurveyVisibilityChanged += OnVisibilityChanged;
+    }
+
+    private void OnVisibilityChanged(object? sender, bool show)
+    {
+        if (_overlay != null)
+            _overlay.IsOpen = show;
+        if (!show)
+            _viewModel.Reset();
+    }
+
+    protected override void OnUnloaded(Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        base.OnUnloaded(e);
+        TutorialService.Instance.SourceSurveyVisibilityChanged -= OnVisibilityChanged;
+    }
+}
+
+public partial class SourceSurveyOverlayViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string? _selectedAnswer;
+
+    [ObservableProperty]
+    private bool _isSubmitting;
+
+    [ObservableProperty]
+    private string _otherText = string.Empty;
+
+    public bool CanSubmit
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(SelectedAnswer) || IsSubmitting) return false;
+            // When "Other" is selected, require a non-empty freeform answer.
+            if (SelectedAnswer == "other" && string.IsNullOrWhiteSpace(OtherText)) return false;
+            return true;
+        }
+    }
+
+    partial void OnSelectedAnswerChanged(string? value) => OnPropertyChanged(nameof(CanSubmit));
+    partial void OnIsSubmittingChanged(bool value) => OnPropertyChanged(nameof(CanSubmit));
+    partial void OnOtherTextChanged(string value) => OnPropertyChanged(nameof(CanSubmit));
+
+    public bool IsGoogleSelected
+    {
+        get => SelectedAnswer == "google";
+        set { if (value) SelectedAnswer = "google"; }
+    }
+
+    public bool IsBingSelected
+    {
+        get => SelectedAnswer == "bing";
+        set { if (value) SelectedAnswer = "bing"; }
+    }
+
+    public bool IsYouTubeSelected
+    {
+        get => SelectedAnswer == "youtube";
+        set { if (value) SelectedAnswer = "youtube"; }
+    }
+
+    public bool IsRedditSelected
+    {
+        get => SelectedAnswer == "reddit";
+        set { if (value) SelectedAnswer = "reddit"; }
+    }
+
+    public bool IsFriendSelected
+    {
+        get => SelectedAnswer == "friend";
+        set { if (value) SelectedAnswer = "friend"; }
+    }
+
+    public bool IsEmailSelected
+    {
+        get => SelectedAnswer == "email";
+        set { if (value) SelectedAnswer = "email"; }
+    }
+
+    public bool IsOtherSelected
+    {
+        get => SelectedAnswer == "other";
+        set { if (value) SelectedAnswer = "other"; }
+    }
+
+    public void Reset()
+    {
+        SelectedAnswer = null;
+        OtherText = string.Empty;
+        IsSubmitting = false;
+    }
+
+    [RelayCommand]
+    private async Task SubmitAsync()
+    {
+        var answer = SelectedAnswer;
+        if (string.IsNullOrEmpty(answer)) return;
+
+        var otherText = answer == "other" ? OtherText.Trim() : null;
+        if (answer == "other" && string.IsNullOrEmpty(otherText)) return;
+
+        IsSubmitting = true;
+        try
+        {
+            var reporter = App.SourceSurveyReporter;
+            var machineUuid = ReadMachineUuid();
+            if (reporter != null && machineUuid != null)
+            {
+                await reporter.ReportAsync(answer, machineUuid, otherText);
+            }
+            TutorialService.Instance.MarkSourceSurveyAnswered(answer);
+        }
+        finally
+        {
+            IsSubmitting = false;
+        }
+    }
+
+    private static string? ReadMachineUuid()
+    {
+        try
+        {
+            var path = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "ArgoBooks",
+                "machine_uuid.txt");
+            if (!File.Exists(path)) return null;
+            var raw = File.ReadAllText(path).Trim();
+            return Guid.TryParse(raw, out _) ? raw : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/ArgoBooks/Converters/Converters.cs
+++ b/ArgoBooks/Converters/Converters.cs
@@ -16,7 +16,8 @@ public static class Converters
     public static readonly IMultiValueConverter ThemeBorderBrushMulti = new ThemeBorderBrushMultiConverter();
 
     /// <summary>
-    /// Converts a boolean to "Finish" or "Next" text.
+    /// Converts a boolean to "Finish" or "Next" text. Used by tutorial overlays
+    /// where the last step actually ends the flow (Products, Categories).
     /// </summary>
     public static readonly IValueConverter BoolToFinishNext = new BoolToFixedStringConverter("Finish", "Next");
 

--- a/ArgoBooks/Modals/AppTourOverlay.axaml
+++ b/ArgoBooks/Modals/AppTourOverlay.axaml
@@ -136,7 +136,8 @@
                                 Command="{Binding NextStepCommand}"
                                 Width="90"
                                 HorizontalContentAlignment="Center">
-                            <TextBlock Text="{Binding IsLastStep, Converter={x:Static conv:Converters.BoolToFinishNext}}" />
+                            <!-- Always "Next" — the last slide tells the user the Setup Checklist is the actual final step. -->
+                            <TextBlock Text="Next" />
                         </Button>
                     </StackPanel>
                 </Grid>

--- a/ArgoBooks/Modals/CheckForUpdateModal.axaml
+++ b/ArgoBooks/Modals/CheckForUpdateModal.axaml
@@ -116,7 +116,7 @@
                                               Width="20" Height="20"
                                               Foreground="White" />
                                 </Border>
-                                <TextBlock Text="{loc:Loc 'You''re up to date!'}"
+                                <TextBlock Text="{loc:Loc 'You’re up to date!'}"
                                            FontSize="14"
                                            FontWeight="Medium"
                                            Foreground="{DynamicResource TextPrimaryBrush}"

--- a/ArgoBooks/Panels/NotificationPanel.axaml
+++ b/ArgoBooks/Panels/NotificationPanel.axaml
@@ -81,7 +81,7 @@
                                        FontSize="14"
                                        Foreground="{DynamicResource TextTertiaryBrush}"
                                        HorizontalAlignment="Center" />
-                            <TextBlock Text="{loc:Loc 'You''re all caught up!'}"
+                            <TextBlock Text="{loc:Loc 'You’re all caught up!'}"
                                        FontSize="12"
                                        Foreground="{DynamicResource TextTertiaryBrush}"
                                        HorizontalAlignment="Center"

--- a/ArgoBooks/Services/TutorialService.cs
+++ b/ArgoBooks/Services/TutorialService.cs
@@ -80,6 +80,11 @@ public class TutorialService
     public event EventHandler<bool>? CompletionGuidanceChanged;
 
     /// <summary>
+    /// Event raised when the post-onboarding source survey should be shown/hidden.
+    /// </summary>
+    public event EventHandler<bool>? SourceSurveyVisibilityChanged;
+
+    /// <summary>
     /// Gets or sets whether the completion guidance overlay should be shown.
     /// </summary>
     public bool ShowCompletionGuidance
@@ -153,6 +158,11 @@ public class TutorialService
     /// Gets whether the welcome tutorial has been completed.
     /// </summary>
     public bool HasCompletedWelcomeTutorial => Settings.HasCompletedWelcomeTutorial;
+
+    /// <summary>
+    /// Gets whether the user explicitly skipped the tutorial.
+    /// </summary>
+    public bool HasSkippedTutorial => Settings.HasSkippedTutorial;
 
     /// <summary>
     /// Gets whether the app tour has been completed.
@@ -523,6 +533,71 @@ public class TutorialService
             Pages.RentalRecords => "Record rental transactions and manage rental periods.",
             _ => null
         };
+    }
+
+    /// <summary>
+    /// The allowed survey answer wire values. Server validates against the same list.
+    /// </summary>
+    public static readonly IReadOnlyList<string> SourceSurveyOptions =
+        ["google", "bing", "youtube", "reddit", "friend", "email", "other"];
+
+    /// <summary>
+    /// Whether the source survey should be presented to this user. True only when
+    /// FirstRunReporter has run and recorded a no-token install, and the user
+    /// hasn't already answered or dismissed.
+    /// </summary>
+    public bool ShouldShowSourceSurvey()
+    {
+        if (Settings.SourceSurveyAnswer != null) return false;
+        if (Settings.IsSourceSurveyDismissed) return false;
+
+        var reason = InstallAttributionReason.ReadFirstRunMarkerReason();
+        return reason == "no_token";
+    }
+
+    /// <summary>
+    /// Requests the survey overlay to open if <see cref="ShouldShowSourceSurvey"/> is true.
+    /// Safe to call from any path that wants to surface the survey (checklist-completion
+    /// handler, dashboard banner button, etc).
+    /// </summary>
+    public void RequestShowSourceSurvey()
+    {
+        if (ShouldShowSourceSurvey())
+        {
+            SourceSurveyVisibilityChanged?.Invoke(this, true);
+        }
+    }
+
+    /// <summary>
+    /// Persists the user's survey answer and closes the overlay. Caller is responsible
+    /// for POSTing the answer to the server before invoking this.
+    /// </summary>
+    public void MarkSourceSurveyAnswered(string answer)
+    {
+        var settings = _globalSettingsService?.GetSettings();
+        if (settings?.Tutorial != null)
+        {
+            settings.Tutorial.SourceSurveyAnswer = answer;
+            settings.Tutorial.HasShownSourceSurvey = true;
+            SaveSettings();
+        }
+        SourceSurveyVisibilityChanged?.Invoke(this, false);
+    }
+
+    /// <summary>
+    /// Persists that the user dismissed the survey without answering. Closes the overlay
+    /// and prevents the dashboard banner from showing on future loads.
+    /// </summary>
+    public void MarkSourceSurveyDismissed()
+    {
+        var settings = _globalSettingsService?.GetSettings();
+        if (settings?.Tutorial != null)
+        {
+            settings.Tutorial.IsSourceSurveyDismissed = true;
+            settings.Tutorial.HasShownSourceSurvey = true;
+            SaveSettings();
+        }
+        SourceSurveyVisibilityChanged?.Invoke(this, false);
     }
 
     private void SaveSettings()

--- a/ArgoBooks/ViewModels/AppTourViewModel.cs
+++ b/ArgoBooks/ViewModels/AppTourViewModel.cs
@@ -42,13 +42,6 @@ public partial class AppTourViewModel : ViewModelBase
     [
         new TourStep
         {
-            Title = "Welcome to Argo Books".Translate(),
-            Description = "Let's take a quick tour to help you get started. This will only take a minute.".Translate(),
-            TargetArea = "center",
-            Icon = Icons.Dashboard
-        },
-        new TourStep
-        {
             Title = "Navigation Sidebar".Translate(),
             Description = "Use the sidebar to navigate between different sections of the app. You can collapse it by clicking the menu icon at the top.".Translate(),
             TargetArea = "sidebar",
@@ -70,8 +63,8 @@ public partial class AppTourViewModel : ViewModelBase
         },
         new TourStep
         {
-            Title = "You're All Set!".Translate(),
-            Description = "Check the Setup Checklist on your Dashboard to complete your first tasks. You can restart this tour anytime from the Help menu.".Translate(),
+            Title = "One last step".Translate(),
+            Description = "Head back to the Dashboard and follow the Setup Checklist to finish getting your books ready. You can restart this tour anytime from the Help menu.".Translate(),
             TargetArea = "center",
             Icon = Icons.Check
         }

--- a/ArgoBooks/ViewModels/BankMatchingPageViewModel.cs
+++ b/ArgoBooks/ViewModels/BankMatchingPageViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using ArgoBooks.Controls;
 using ArgoBooks.Core;
+using ArgoBooks.Core.Data;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.BankMatching;
 using ArgoBooks.Core.Services;

--- a/ArgoBooks/ViewModels/DashboardPageViewModel.cs
+++ b/ArgoBooks/ViewModels/DashboardPageViewModel.cs
@@ -8,6 +8,7 @@ using ArgoBooks.Localization;
 using ArgoBooks.Services;
 using ArgoBooks.ViewModels.Dashboard;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace ArgoBooks.ViewModels;
 
@@ -321,7 +322,48 @@ public partial class DashboardPageViewModel : ChartContextMenuViewModelBase
 
         // Subscribe to currency changes to refresh all monetary displays
         CurrencyService.CurrencyChanged += OnCurrencyChanged;
+
+        // Re-evaluate the source-survey banner whenever the user answers,
+        // dismisses, or the tutorial state changes.
+        TutorialService.Instance.SourceSurveyVisibilityChanged += OnSourceSurveyVisibilityChanged;
+        TutorialService.Instance.TutorialStateChanged += (_, _) => RefreshSourceSurveyBanner();
+        RefreshSourceSurveyBanner();
     }
+
+    #region Source Survey Banner
+
+    [ObservableProperty]
+    private bool _showSourceSurveyBanner;
+
+    public void RefreshSourceSurveyBanner()
+    {
+        var tutorial = TutorialService.Instance;
+        ShowSourceSurveyBanner =
+            tutorial.HasSkippedTutorial &&
+            tutorial.ShouldShowSourceSurvey();
+    }
+
+    private void OnSourceSurveyVisibilityChanged(object? sender, bool shown)
+    {
+        // After the overlay opens/closes, recompute banner visibility.
+        // Once the user answers or dismisses, ShouldShowSourceSurvey() returns false.
+        RefreshSourceSurveyBanner();
+    }
+
+    [RelayCommand]
+    private void OpenSourceSurvey()
+    {
+        TutorialService.Instance.RequestShowSourceSurvey();
+    }
+
+    [RelayCommand]
+    private void DismissSourceSurveyBanner()
+    {
+        TutorialService.Instance.MarkSourceSurveyDismissed();
+        ShowSourceSurveyBanner = false;
+    }
+
+    #endregion
 
     private void OnThemeChanged(object? sender, ThemeMode e)
     {

--- a/ArgoBooks/ViewModels/ProductsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ProductsPageViewModel.cs
@@ -128,7 +128,6 @@ public partial class ProductsPageViewModel : SortablePageViewModelBase
     {
         OnPropertyChanged(nameof(IsExpensesTabSelected));
         OnPropertyChanged(nameof(IsRevenueTabSelected));
-        OnPropertyChanged(nameof(RemainingProductsText));
         OnPropertyChanged(nameof(CanAddProduct));
         ColumnWidths.SetTabMode(IsExpensesTabSelected);
         FilterProducts();
@@ -173,39 +172,6 @@ public partial class ProductsPageViewModel : SortablePageViewModelBase
     /// Products are always unlimited — no free-tier limit.
     /// </summary>
     public bool CanAddProduct => true;
-
-    /// <summary>
-    /// No remaining-products text needed — products are unlimited.
-    /// </summary>
-    public string RemainingProductsText => string.Empty;
-
-    /// <summary>
-    /// Never show the upgrade button for products — they are unlimited.
-    /// </summary>
-    public bool ShowUpgradeButton => false;
-
-    /// <summary>
-    /// Event raised when the upgrade button is clicked.
-    /// </summary>
-    public event EventHandler? UpgradeRequested;
-
-    /// <summary>
-    /// No remaining products label needed — products are unlimited.
-    /// </summary>
-    public bool ShowRemainingProducts => false;
-
-    partial void OnHasPremiumChanged(bool value)
-    {
-        OnPropertyChanged(nameof(CanAddProduct));
-        OnPropertyChanged(nameof(ShowRemainingProducts));
-        OnPropertyChanged(nameof(ShowUpgradeButton));
-    }
-
-    [RelayCommand]
-    private void Upgrade()
-    {
-        UpgradeRequested?.Invoke(this, EventArgs.Empty);
-    }
 
     #endregion
 

--- a/ArgoBooks/ViewModels/ProductsTutorialViewModel.cs
+++ b/ArgoBooks/ViewModels/ProductsTutorialViewModel.cs
@@ -22,14 +22,14 @@ public partial class ProductsTutorialViewModel : ViewModelBase
         },
         new TutorialStep
         {
-            Title = "Track Your Inventory",
+            Title = "Track Your Products",
             Description = "Add products to keep track of what you buy and sell. Each product can have a category, supplier, and inventory thresholds.",
             HighlightArea = "content"
         },
         new TutorialStep
         {
             Title = "Products & Services",
-            Description = "Products can be physical items or services. Physical products support inventory tracking with reorder points and overstock thresholds.\n\nServices are tracked by usage without inventory management.",
+            Description = "Products can be physical items or services. Pick whichever fits what you're tracking.",
             HighlightArea = "none"
         }
     ];

--- a/ArgoBooks/ViewModels/SetupChecklistViewModel.cs
+++ b/ArgoBooks/ViewModels/SetupChecklistViewModel.cs
@@ -139,6 +139,15 @@ public partial class SetupChecklistViewModel : ViewModelBase
             return;
         }
 
+        // Hide the checklist until the app tour has been finished or skipped.
+        // The tour ends on a slide that explicitly tells the user the checklist
+        // is the next step, so showing it earlier would steal attention from the tour.
+        if (!tutorialService.HasCompletedAppTour && !tutorialService.HasSkippedTutorial)
+        {
+            IsVisible = false;
+            return;
+        }
+
         IsVisible = true;
     }
 
@@ -225,6 +234,6 @@ public partial class SetupChecklistViewModel : ViewModelBase
     [RelayCommand]
     private void OpenUpgradeUrl()
     {
-        UrlHelper.SafeOpenUrl("https://www.argorobots.com/upgrade/");
+        UrlHelper.SafeOpenUrl("https://www.argorobots.com/pricing/");
     }
 }

--- a/ArgoBooks/Views/DashboardPage.axaml
+++ b/ArgoBooks/Views/DashboardPage.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:icons="using:ArgoBooks"
              xmlns:loc="using:ArgoBooks.Localization"
              mc:Ignorable="d" d:DesignWidth="1400" d:DesignHeight="900"
              x:Class="ArgoBooks.Views.DashboardPage"
@@ -110,6 +111,16 @@
                     <!-- Date Range Selector -->
                     <controls:DateRangeSelector Grid.Column="3" VerticalAlignment="Top" />
                 </Grid>
+
+                <!-- Source Survey Banner (shown to users who skipped the tutorial) -->
+                <controls:InfoBanner ShowBanner="{Binding ShowSourceSurveyBanner}"
+                                     Message="{loc:Loc 'Quick question: where did you hear about Argo Books?'}"
+                                     ActionText="{loc:Loc 'Answer'}"
+                                     ActionCommand="{Binding OpenSourceSurveyCommand}"
+                                     DismissCommand="{Binding DismissSourceSurveyBannerCommand}"
+                                     IconData="{x:Static icons:Icons.Info}"
+                                     BannerBackground="{DynamicResource InfoBrush}"
+                                     DismissBackground="{DynamicResource InfoDarkBrush}" />
 
                 <!-- Edit Mode Toolbar -->
                 <Border Classes="card"

--- a/ArgoBooks/Views/MainWindow.axaml
+++ b/ArgoBooks/Views/MainWindow.axaml
@@ -42,9 +42,12 @@
     </Design.DataContext>
 
     <Panel>
-        <!-- Window Caption Buttons — high ZIndex so they're always visible above all overlays -->
+        <!-- Window Caption Buttons — ZIndex above ALL modals/overlays so the user can
+             always minimize, maximize, or close the window. Closing while a critical
+             dialog (UnsavedChanges, Confirmation) is open still routes through the
+             window's Closing handler, so data-safety prompts re-trigger as normal. -->
         <StackPanel x:Name="WindowControls"
-                    ZIndex="200"
+                    ZIndex="300"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
@@ -193,6 +196,11 @@
                                HorizontalAlignment="Stretch"
                                VerticalAlignment="Stretch"
                                ZIndex="215" />
+
+        <!-- Source Survey Overlay (post-onboarding "where did you hear about us?") -->
+        <controls:SourceSurveyOverlay HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch"
+                                      ZIndex="218" />
 
         <!-- Categories Page Tutorial Overlay -->
         <modals:CategoriesTutorialOverlay DataContext="{Binding CategoriesTutorialViewModel}"

--- a/ArgoBooks/Views/ProductsPage.axaml
+++ b/ArgoBooks/Views/ProductsPage.axaml
@@ -65,61 +65,9 @@
                                 EmptyIcon="{x:Static icons:Icons.Products}"
                                 EmptyTitle="{loc:Loc 'No products found'}"
                                 EmptyMessage="{loc:Loc 'Add your first product to start tracking your inventory.'}"
-                                ShowHeaderBorder="{Binding !ShowRemainingProducts}"
+                                ShowHeaderBorder="True"
                                 BorderSizeChanged="OnHeaderSizeChanged"
                                 TableGridSizeChanged="OnTableSizeChanged">
-
-                <!-- Product Limit Warning Banner (shown on Free plan, below header bar) -->
-                <table:ArgoTable.InfoBannerContent>
-                    <StackPanel>
-                        <!-- Remaining count banner (when still have room) -->
-                        <Border HorizontalAlignment="Center"
-                                Background="{DynamicResource WarningLightBrush}"
-                                BorderBrush="{DynamicResource WarningBrush}"
-                                BorderThickness="1"
-                                CornerRadius="8"
-                                Padding="14,8"
-                                Margin="0,8,0,8"
-                                IsVisible="{Binding ShowRemainingProducts}">
-                            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                                <PathIcon Data="{x:Static icons:Icons.WarningCircle}"
-                                          Foreground="{DynamicResource WarningBrush}"
-                                          Width="14" Height="14"
-                                          VerticalAlignment="Center" />
-                                <TextBlock Text="{Binding RemainingProductsText}"
-                                           FontSize="13"
-                                           Foreground="{DynamicResource WarningTextBrush}"
-                                           VerticalAlignment="Center"
-                                           IsVisible="{Binding !ShowUpgradeButton}" />
-                                <TextBlock Text="{loc:Loc 'Product limit reached — upgrade for unlimited products'}"
-                                           FontSize="13"
-                                           Foreground="{DynamicResource WarningTextBrush}"
-                                           VerticalAlignment="Center"
-                                           IsVisible="{Binding ShowUpgradeButton}" />
-                                <Button Command="{Binding UpgradeCommand}"
-                                        Classes="primary-button"
-                                        Padding="12,4"
-                                        IsVisible="{Binding ShowUpgradeButton}">
-                                    <TextBlock Text="{loc:Loc 'Upgrade Now'}"
-                                               FontSize="12"
-                                               FontWeight="SemiBold" />
-                                </Button>
-                                <Button Command="{Binding UpgradeCommand}"
-                                        Background="Transparent"
-                                        BorderThickness="0"
-                                        Padding="0"
-                                        Cursor="Hand"
-                                        IsVisible="{Binding !ShowUpgradeButton}">
-                                    <TextBlock Text="{loc:Loc Upgrade}"
-                                               FontSize="13"
-                                               FontWeight="SemiBold"
-                                               Foreground="{DynamicResource WarningTextBrush}"
-                                               TextDecorations="Underline" />
-                                </Button>
-                            </StackPanel>
-                        </Border>
-                    </StackPanel>
-                </table:ArgoTable.InfoBannerContent>
 
                 <!-- Table Header Content - Using ArgoTableHeader for reduced boilerplate -->
                 <table:ArgoTable.HeaderContent>


### PR DESCRIPTION
## Summary

- **Source survey** (`feat(source-survey)`): adds a forced one-question modal — "Where did you hear about Argo Books?" — for installs without a referral token, so the marketing funnel can attribute users whose download arrived without a referral cookie. Seven canonical options plus a freeform textbox when "Other" is picked. Two trigger paths: post-checklist modal, or a Dashboard banner for users who skipped the tutorial.
- **Setup Checklist visual upgrade** (`feat(setup-checklist)`): accent border + soft glow on the widget, inline "← Click here" pill on the active step (jumps as each step completes), and refreshed copy that matches the current Free vs Premium feature set (no more product-limit references).
- **Tutorial tightening** (`refactor(tutorial)`): dropped the redundant "Welcome to Argo Books" tour slide, renamed the final slide so users don't think the tour is the end of onboarding, made the AppTour button always "Next", hid the Setup Checklist until the tour completes, and renamed "Track Your Inventory" → "Track Your Products" (Inventory is a different feature).
- **Products page cleanup** (`refactor(products)`): removed the dead product-limit banner and the chain of stub VM members it depended on.
- **Misc fixes**: missing `using ArgoBooks.Core.Data;` in BankMatchingPageViewModel (V.2.0.8 build error), curly-apostrophe substitutions to fix three AVLN5001 parser warnings, and bumped `WindowControls` ZIndex to 300 so the min/max/close caption buttons sit above every modal (you can always close the window now).

## Test plan

- [ ] Reset markers (`first_run_reported.marker`, `machine_uuid.txt`, `install_token.txt`) and `Tutorial.*SourceSurvey*` flags in `global_settings.json`; launch app; complete the setup checklist; verify the survey modal opens after the Analytics-step guidance is dismissed.
- [ ] Pick "Other", verify the freeform textbox appears and Submit stays disabled until text is entered.
- [ ] Set `HasSkippedTutorial=true`; verify the Dashboard banner appears and clicking Answer opens the modal.
- [ ] Place an `install_token.txt` before first launch; verify the survey never fires (token install attribution path).
- [ ] Walk the app tour end-to-end; verify it's 4 slides, the last says "One last step", the primary button always says "Next", and the Setup Checklist only appears after clicking Next on the final slide.
- [ ] Open any modal/overlay that previously covered the title bar (AppTour, Loading, ConfirmationDialog); verify the minimize/maximize/close caption buttons are clickable.
- [ ] Open ProductsPage; verify the product-limit warning banner is gone and adding a new product still works.
- [ ] `dotnet build ArgoBooks.sln` is clean (no AVLN5001 / CS0103 / CS1061).
- [ ] `dotnet test ArgoBooks.Tests --filter "FullyQualifiedName~AppTourViewModelTests"` passes.

## Companion changes (separate repo)

Website changes live in `argo-books-website` and need to ship via the deploy workflow before this can be tested end-to-end against `dev.argorobots.com`:
- `api/track-app-event.php` extended to accept `signup_survey` events
- New `source_survey_answer` / `source_survey_other_text` / `source_survey_answered_at` columns on `referral_events`
- Doughnut breakdown + "Other" freeform list on the admin marketing-funnel page

🤖 Generated with [Claude Code](https://claude.com/claude-code)