### PR TITLE
Load source survey options from the server

### DIFF
--- a/ArgoBooks.Core/Services/SourceSurveyOptionsService.cs
+++ b/ArgoBooks.Core/Services/SourceSurveyOptionsService.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using ArgoBooks.Core.Models.Telemetry;
 
 namespace ArgoBooks.Core.Services;
 

--- a/ArgoBooks.Core/Services/SourceSurveyOptionsService.cs
+++ b/ArgoBooks.Core/Services/SourceSurveyOptionsService.cs
@@ -52,7 +52,9 @@ public sealed class SourceSurveyOptionsService
     /// <summary>
     /// GETs the survey options from the website. Returns the parsed server list
     /// on success, or <see cref="DefaultOptions"/> on any failure (network error,
-    /// non-2xx, malformed JSON, or empty list). Never throws.
+    /// timeout, non-2xx, malformed JSON, or empty list). Only throws
+    /// <see cref="OperationCanceledException"/> when the caller cancels
+    /// <paramref name="cancellationToken"/>.
     /// </summary>
     public async Task<IReadOnlyList<SurveyOption>> GetOptionsAsync(
         CancellationToken cancellationToken = default)
@@ -84,8 +86,16 @@ public sealed class SourceSurveyOptionsService
 
             return parsed.Count > 0 ? parsed : DefaultOptions;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Genuine caller cancellation: propagate so callers can stop cleanly
+            // (matches the convention in other ArgoBooks.Core HTTP services).
+            throw;
+        }
         catch (OperationCanceledException)
         {
+            // HttpClient timeout (not a caller cancellation): fall back like any
+            // other transient failure so the survey still renders.
             return DefaultOptions;
         }
         catch (Exception ex)

--- a/ArgoBooks.Core/Services/SourceSurveyOptionsService.cs
+++ b/ArgoBooks.Core/Services/SourceSurveyOptionsService.cs
@@ -1,0 +1,115 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// A single answer option for the "Where did you hear about Argo Books?" survey.
+/// <paramref name="Key"/> is the stable identifier POSTed to and stored by the
+/// server; <paramref name="Label"/> is the (English) display text;
+/// <paramref name="Freeform"/> marks the option that reveals the freeform text box.
+/// </summary>
+public sealed record SurveyOption(string Key, string Label, bool Freeform);
+
+/// <summary>
+/// Fetches the source-survey answer options from the website so new options
+/// (e.g. a newly launched platform) appear in already-installed apps without a
+/// release. On any failure the service returns a bundled default list, so the
+/// survey always renders even offline.
+/// </summary>
+public sealed class SourceSurveyOptionsService
+{
+    private const string EndpointPath = "/api/survey-options.php";
+
+    private readonly HttpClient _httpClient;
+    private readonly IErrorLogger? _errorLogger;
+
+    /// <summary>
+    /// The options baked into the app. Used as a fallback when the server is
+    /// unreachable or returns an unusable payload. Keys must stay in sync with
+    /// the server's <c>config/survey-options.json</c> for consistent reporting.
+    /// </summary>
+    public static IReadOnlyList<SurveyOption> DefaultOptions { get; } = new[]
+    {
+        new SurveyOption("google",      "Google",       false),
+        new SurveyOption("bing",        "Bing",         false),
+        new SurveyOption("youtube",     "YouTube",      false),
+        new SurveyOption("reddit",      "Reddit",       false),
+        new SurveyOption("friend",      "A friend",     false),
+        new SurveyOption("email",       "Email",        false),
+        new SurveyOption("capterra",    "Capterra",     false),
+        new SurveyOption("producthunt", "Product Hunt", false),
+        new SurveyOption("other",       "Other",        true),
+    };
+
+    public SourceSurveyOptionsService(HttpClient httpClient, IErrorLogger? errorLogger = null)
+    {
+        _httpClient = httpClient;
+        _errorLogger = errorLogger;
+    }
+
+    /// <summary>
+    /// GETs the survey options from the website. Returns the parsed server list
+    /// on success, or <see cref="DefaultOptions"/> on any failure (network error,
+    /// non-2xx, malformed JSON, or empty list). Never throws.
+    /// </summary>
+    public async Task<IReadOnlyList<SurveyOption>> GetOptionsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var url = $"{ApiConfig.BaseUrl}{EndpointPath}";
+            using var response = await _httpClient.GetAsync(url, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _errorLogger?.LogWarning(
+                    $"SourceSurveyOptionsService received HTTP {(int)response.StatusCode}",
+                    context: "SourceSurveyOptionsService.GetOptionsAsync");
+                return DefaultOptions;
+            }
+
+            var payload = await response.Content.ReadFromJsonAsync<OptionsPayload>(cancellationToken);
+            var options = payload?.Options;
+            if (options == null || options.Count == 0)
+                return DefaultOptions;
+
+            var parsed = new List<SurveyOption>(options.Count);
+            foreach (var o in options)
+            {
+                if (string.IsNullOrWhiteSpace(o.Key) || string.IsNullOrWhiteSpace(o.Label))
+                    continue;
+                parsed.Add(new SurveyOption(o.Key!, o.Label!, o.Freeform));
+            }
+
+            return parsed.Count > 0 ? parsed : DefaultOptions;
+        }
+        catch (OperationCanceledException)
+        {
+            return DefaultOptions;
+        }
+        catch (Exception ex)
+        {
+            _errorLogger?.LogError(ex, ErrorCategory.Network,
+                context: "SourceSurveyOptionsService.GetOptionsAsync");
+            return DefaultOptions;
+        }
+    }
+
+    private sealed class OptionsPayload
+    {
+        [JsonPropertyName("options")]
+        public List<OptionDto>? Options { get; set; }
+    }
+
+    private sealed class OptionDto
+    {
+        [JsonPropertyName("key")]
+        public string? Key { get; set; }
+
+        [JsonPropertyName("label")]
+        public string? Label { get; set; }
+
+        [JsonPropertyName("freeform")]
+        public bool Freeform { get; set; }
+    }
+}

--- a/ArgoBooks.Core/Services/SourceSurveyReporter.cs
+++ b/ArgoBooks.Core/Services/SourceSurveyReporter.cs
@@ -51,7 +51,10 @@ public sealed class SourceSurveyReporter
                 AppVersion = _appVersion,
                 MachineUuid = machineUuid,
                 Answer = answer,
-                OtherText = answer == "other" ? otherText : null,
+                // The caller supplies otherText only for a freeform option; the
+                // server stores it only for keys flagged freeform. Forwarding it
+                // as-given keeps freeform working regardless of the option's key.
+                OtherText = otherText,
             };
 
             var url = $"{ApiConfig.BaseUrl}{EndpointPath}";

--- a/ArgoBooks.Tests/Services/SourceSurveyOptionsServiceTests.cs
+++ b/ArgoBooks.Tests/Services/SourceSurveyOptionsServiceTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Text;
+using ArgoBooks.Core.Services;
+using Xunit;
+
+namespace ArgoBooks.Tests.Services;
+
+/// <summary>
+/// Tests for SourceSurveyOptionsService. Mocks HttpClient so we can verify
+/// parsing and the bundled-default fallback without standing up the PHP server.
+/// </summary>
+public class SourceSurveyOptionsServiceTests
+{
+    private static SourceSurveyOptionsService BuildService(HttpStatusCode status, string body)
+        => new(new HttpClient(new StubHandler(status, body)));
+
+    private static SourceSurveyOptionsService BuildThrowingService(Exception ex)
+        => new(new HttpClient(new ThrowingHandler(ex)));
+
+    [Fact]
+    public async Task GetOptionsAsync_ValidJson_ParsesOptionsIncludingFreeform()
+    {
+        var service = BuildService(HttpStatusCode.OK,
+            "{\"options\":[" +
+            "{\"key\":\"google\",\"label\":\"Google\"}," +
+            "{\"key\":\"tiktok\",\"label\":\"TikTok\"}," +
+            "{\"key\":\"other\",\"label\":\"Other\",\"freeform\":true}" +
+            "]}");
+
+        var options = await service.GetOptionsAsync();
+
+        Assert.Equal(3, options.Count);
+        Assert.Equal("google", options[0].Key);
+        Assert.Equal("TikTok", options[1].Label);
+        Assert.False(options[1].Freeform);
+        Assert.Equal("other", options[2].Key);
+        Assert.True(options[2].Freeform);
+    }
+
+    [Fact]
+    public async Task GetOptionsAsync_NonSuccessStatus_ReturnsDefaults()
+    {
+        var service = BuildService(HttpStatusCode.InternalServerError, "{\"error\":\"boom\"}");
+
+        var options = await service.GetOptionsAsync();
+
+        Assert.Equal(SourceSurveyOptionsService.DefaultOptions, options);
+    }
+
+    [Fact]
+    public async Task GetOptionsAsync_MalformedJson_ReturnsDefaults()
+    {
+        var service = BuildService(HttpStatusCode.OK, "not json at all");
+
+        var options = await service.GetOptionsAsync();
+
+        Assert.Equal(SourceSurveyOptionsService.DefaultOptions, options);
+    }
+
+    [Fact]
+    public async Task GetOptionsAsync_EmptyList_ReturnsDefaults()
+    {
+        var service = BuildService(HttpStatusCode.OK, "{\"options\":[]}");
+
+        var options = await service.GetOptionsAsync();
+
+        Assert.Equal(SourceSurveyOptionsService.DefaultOptions, options);
+    }
+
+    [Fact]
+    public async Task GetOptionsAsync_SkipsEntriesMissingKeyOrLabel()
+    {
+        var service = BuildService(HttpStatusCode.OK,
+            "{\"options\":[" +
+            "{\"key\":\"\",\"label\":\"No key\"}," +
+            "{\"key\":\"nolabel\"}," +
+            "{\"key\":\"reddit\",\"label\":\"Reddit\"}" +
+            "]}");
+
+        var options = await service.GetOptionsAsync();
+
+        Assert.Single(options);
+        Assert.Equal("reddit", options[0].Key);
+    }
+
+    [Fact]
+    public async Task GetOptionsAsync_AllEntriesInvalid_ReturnsDefaults()
+    {
+        var service = BuildService(HttpStatusCode.OK,
+            "{\"options\":[{\"key\":\"\",\"label\":\"\"}]}");
+
+        var options = await service.GetOptionsAsync();
+
+        Assert.Equal(SourceSurveyOptionsService.DefaultOptions, options);
+    }
+
+    [Fact]
+    public async Task GetOptionsAsync_NetworkError_ReturnsDefaults()
+    {
+        var service = BuildThrowingService(new HttpRequestException("DNS fail"));
+
+        var options = await service.GetOptionsAsync();
+
+        Assert.Equal(SourceSurveyOptionsService.DefaultOptions, options);
+    }
+
+    [Fact]
+    public void DefaultOptions_IncludeNewPlatformsAndSingleFreeform()
+    {
+        var defaults = SourceSurveyOptionsService.DefaultOptions;
+
+        Assert.Contains(defaults, o => o.Key == "capterra");
+        Assert.Contains(defaults, o => o.Key == "producthunt");
+        Assert.Single(defaults, o => o.Freeform);
+        Assert.Equal("other", defaults[^1].Key);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+
+        public StubHandler(HttpStatusCode status, string body)
+        {
+            _status = status;
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        private readonly Exception _ex;
+        public ThrowingHandler(Exception ex) { _ex = ex; }
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw _ex;
+    }
+}

--- a/ArgoBooks.Tests/Services/SourceSurveyOptionsServiceTests.cs
+++ b/ArgoBooks.Tests/Services/SourceSurveyOptionsServiceTests.cs
@@ -68,6 +68,29 @@ public class SourceSurveyOptionsServiceTests
     }
 
     [Fact]
+    public async Task GetOptionsAsync_MissingOptionsKey_ReturnsDefaults()
+    {
+        // 2xx with valid JSON but no "options" property.
+        var service = BuildService(HttpStatusCode.OK, "{}");
+
+        var options = await service.GetOptionsAsync();
+
+        Assert.Equal(SourceSurveyOptionsService.DefaultOptions, options);
+    }
+
+    [Fact]
+    public async Task GetOptionsAsync_CallerCancellation_Throws()
+    {
+        var service = BuildService(HttpStatusCode.OK,
+            "{\"options\":[{\"key\":\"google\",\"label\":\"Google\"}]}");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetOptionsAsync(cts.Token));
+    }
+
+    [Fact]
     public async Task GetOptionsAsync_SkipsEntriesMissingKeyOrLabel()
     {
         var service = BuildService(HttpStatusCode.OK,
@@ -128,10 +151,13 @@ public class SourceSurveyOptionsServiceTests
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
-            => Task.FromResult(new HttpResponseMessage(_status)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(_status)
             {
                 Content = new StringContent(_body, Encoding.UTF8, "application/json"),
             });
+        }
     }
 
     private sealed class ThrowingHandler : HttpMessageHandler

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -92,6 +92,12 @@ public partial class App : Application
     public static SourceSurveyReporter? SourceSurveyReporter { get; private set; }
 
     /// <summary>
+    /// Gets the service that fetches the source survey's answer options from the
+    /// website, so new options appear without an app release.
+    /// </summary>
+    public static SourceSurveyOptionsService? SourceSurveyOptionsService { get; private set; }
+
+    /// <summary>
     /// Gets the shared undo/redo manager instance.
     /// </summary>
     public static UndoRedoManager UndoRedoManager => HeaderViewModel.SharedUndoRedoManager;
@@ -828,6 +834,10 @@ public partial class App : Application
             // checklist), so we keep the reporter alive rather than scoping it to a
             // one-shot task like FirstRunReporter.
             SourceSurveyReporter = new SourceSurveyReporter(httpClient, appVersion, errorLogger);
+
+            // Fetches the survey's answer options from the website (shares the same
+            // long-lived HttpClient). Falls back to a bundled default list offline.
+            SourceSurveyOptionsService = new SourceSurveyOptionsService(httpClient, errorLogger);
 
             // Create navigation service
             NavigationService = new NavigationService();

--- a/ArgoBooks/Controls/SourceSurveyOverlay.axaml
+++ b/ArgoBooks/Controls/SourceSurveyOverlay.axaml
@@ -38,32 +38,25 @@
                                    TextWrapping="Wrap" />
                     </StackPanel>
 
-                    <!-- Options -->
+                    <!-- Options (sourced from the server, falling back to bundled defaults) -->
                     <StackPanel Spacing="6">
-                        <RadioButton GroupName="SourceSurveyOption"
-                                     Content="{loc:Loc 'Google'}"
-                                     IsChecked="{Binding IsGoogleSelected, Mode=TwoWay}" />
-                        <RadioButton GroupName="SourceSurveyOption"
-                                     Content="{loc:Loc 'Bing'}"
-                                     IsChecked="{Binding IsBingSelected, Mode=TwoWay}" />
-                        <RadioButton GroupName="SourceSurveyOption"
-                                     Content="{loc:Loc 'YouTube'}"
-                                     IsChecked="{Binding IsYouTubeSelected, Mode=TwoWay}" />
-                        <RadioButton GroupName="SourceSurveyOption"
-                                     Content="{loc:Loc 'Reddit'}"
-                                     IsChecked="{Binding IsRedditSelected, Mode=TwoWay}" />
-                        <RadioButton GroupName="SourceSurveyOption"
-                                     Content="{loc:Loc 'A friend'}"
-                                     IsChecked="{Binding IsFriendSelected, Mode=TwoWay}" />
-                        <RadioButton GroupName="SourceSurveyOption"
-                                     Content="{loc:Loc 'Email'}"
-                                     IsChecked="{Binding IsEmailSelected, Mode=TwoWay}" />
-                        <RadioButton GroupName="SourceSurveyOption"
-                                     Content="{loc:Loc 'Other'}"
-                                     IsChecked="{Binding IsOtherSelected, Mode=TwoWay}" />
+                        <ItemsControl ItemsSource="{Binding Options}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Spacing="6" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="controls:SurveyOptionItem">
+                                    <RadioButton GroupName="SourceSurveyOption"
+                                                 Content="{Binding Label}"
+                                                 IsChecked="{Binding IsSelected, Mode=TwoWay}" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
 
-                        <!-- Freeform input shown when "Other" is selected -->
-                        <TextBox IsVisible="{Binding IsOtherSelected}"
+                        <!-- Freeform input shown when a freeform option is selected -->
+                        <TextBox IsVisible="{Binding IsFreeformSelected}"
                                  Text="{Binding OtherText, Mode=TwoWay}"
                                  PlaceholderText="{loc:Loc 'Tell us where you heard about us'}"
                                  MaxLength="200"

--- a/ArgoBooks/Controls/SourceSurveyOverlay.axaml.cs
+++ b/ArgoBooks/Controls/SourceSurveyOverlay.axaml.cs
@@ -135,20 +135,37 @@ public partial class SourceSurveyOverlayViewModel : ObservableObject
 
     private void SetOptions(IReadOnlyList<SurveyOption> options)
     {
+        // Preserve any current selection: the overlay opens with bundled defaults
+        // and then awaits the server refresh, so the user may have already picked
+        // an option (and typed freeform text) by the time this runs.
+        var previousKey = SelectedAnswer;
+
         foreach (var existing in Options)
             existing.SelectionRequested -= OnOptionSelectionRequested;
         Options.Clear();
 
+        SurveyOptionItem? toReselect = null;
         foreach (var o in options)
         {
             var item = new SurveyOptionItem(o.Key, o.Label, o.Freeform);
             item.SelectionRequested += OnOptionSelectionRequested;
             Options.Add(item);
+            if (o.Key == previousKey)
+                toReselect = item;
         }
 
-        // The option set changed, so clear any prior selection.
-        SelectedAnswer = null;
-        IsFreeformSelected = false;
+        if (toReselect != null)
+        {
+            // Re-apply the prior choice; OnOptionSelectionRequested restores
+            // SelectedAnswer/IsFreeformSelected. OtherText is intentionally kept.
+            toReselect.IsSelected = true;
+        }
+        else
+        {
+            // The previously selected key is gone (or nothing was selected).
+            SelectedAnswer = null;
+            IsFreeformSelected = false;
+        }
     }
 
     private void OnOptionSelectionRequested(SurveyOptionItem selected)

--- a/ArgoBooks/Controls/SourceSurveyOverlay.axaml.cs
+++ b/ArgoBooks/Controls/SourceSurveyOverlay.axaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Localization;
 using ArgoBooks.Services;
@@ -24,18 +25,57 @@ public partial class SourceSurveyOverlay : UserControl
         TutorialService.Instance.SourceSurveyVisibilityChanged += OnVisibilityChanged;
     }
 
-    private void OnVisibilityChanged(object? sender, bool show)
+    private async void OnVisibilityChanged(object? sender, bool show)
     {
         if (_overlay != null)
             _overlay.IsOpen = show;
-        if (!show)
+
+        if (show)
+        {
+            // The collection already holds the bundled defaults (instant render);
+            // refresh from the server so newly added options appear without a release.
+            await _viewModel.LoadOptionsAsync();
+        }
+        else
+        {
             _viewModel.Reset();
+        }
     }
 
     protected override void OnUnloaded(Avalonia.Interactivity.RoutedEventArgs e)
     {
         base.OnUnloaded(e);
         TutorialService.Instance.SourceSurveyVisibilityChanged -= OnVisibilityChanged;
+    }
+}
+
+/// <summary>
+/// A single selectable survey option in the overlay's options list. Raises
+/// <see cref="SelectionRequested"/> when the user picks it so the parent
+/// view model can enforce single selection and track the chosen key.
+/// </summary>
+public partial class SurveyOptionItem : ObservableObject
+{
+    public string Key { get; }
+    public string Label { get; }
+    public bool Freeform { get; }
+
+    [ObservableProperty]
+    private bool _isSelected;
+
+    public event Action<SurveyOptionItem>? SelectionRequested;
+
+    public SurveyOptionItem(string key, string label, bool freeform)
+    {
+        Key = key;
+        Label = label;
+        Freeform = freeform;
+    }
+
+    partial void OnIsSelectedChanged(bool value)
+    {
+        if (value)
+            SelectionRequested?.Invoke(this);
     }
 }
 
@@ -53,79 +93,83 @@ public partial class SourceSurveyOverlayViewModel : ObservableObject
     [ObservableProperty]
     private string? _submitError;
 
+    // True when the currently selected option is freeform (reveals the text box).
+    [ObservableProperty]
+    private bool _isFreeformSelected;
+
+    /// <summary>The options shown as radio choices. Seeded with bundled defaults.</summary>
+    public ObservableCollection<SurveyOptionItem> Options { get; } = new();
+
+    public SourceSurveyOverlayViewModel()
+    {
+        SetOptions(SourceSurveyOptionsService.DefaultOptions);
+    }
+
     public bool CanSubmit
     {
         get
         {
             if (string.IsNullOrEmpty(SelectedAnswer) || IsSubmitting) return false;
-            // When "Other" is selected, require a non-empty freeform answer.
-            if (SelectedAnswer == "other" && string.IsNullOrWhiteSpace(OtherText)) return false;
+            // A freeform option requires a non-empty freeform answer.
+            if (IsFreeformSelected && string.IsNullOrWhiteSpace(OtherText)) return false;
             return true;
         }
     }
 
-    // Notify every derived Is*Selected property so radio buttons and the freeform
-    // textbox visibility binding refresh whenever SelectedAnswer changes (including
-    // null after Reset).
-    partial void OnSelectedAnswerChanged(string? value)
-    {
-        OnPropertyChanged(nameof(CanSubmit));
-        OnPropertyChanged(nameof(IsGoogleSelected));
-        OnPropertyChanged(nameof(IsBingSelected));
-        OnPropertyChanged(nameof(IsYouTubeSelected));
-        OnPropertyChanged(nameof(IsRedditSelected));
-        OnPropertyChanged(nameof(IsFriendSelected));
-        OnPropertyChanged(nameof(IsEmailSelected));
-        OnPropertyChanged(nameof(IsOtherSelected));
-    }
+    partial void OnSelectedAnswerChanged(string? value) => OnPropertyChanged(nameof(CanSubmit));
     partial void OnIsSubmittingChanged(bool value) => OnPropertyChanged(nameof(CanSubmit));
     partial void OnOtherTextChanged(string value) => OnPropertyChanged(nameof(CanSubmit));
+    partial void OnIsFreeformSelectedChanged(bool value) => OnPropertyChanged(nameof(CanSubmit));
 
-    public bool IsGoogleSelected
+    /// <summary>
+    /// Fetches the latest options from the server and rebuilds the list.
+    /// The service returns bundled defaults on failure, so this never throws.
+    /// </summary>
+    public async Task LoadOptionsAsync()
     {
-        get => SelectedAnswer == "google";
-        set { if (value) SelectedAnswer = "google"; }
+        var service = App.SourceSurveyOptionsService;
+        if (service == null) return;
+        var options = await service.GetOptionsAsync();
+        SetOptions(options);
     }
 
-    public bool IsBingSelected
+    private void SetOptions(IReadOnlyList<SurveyOption> options)
     {
-        get => SelectedAnswer == "bing";
-        set { if (value) SelectedAnswer = "bing"; }
+        foreach (var existing in Options)
+            existing.SelectionRequested -= OnOptionSelectionRequested;
+        Options.Clear();
+
+        foreach (var o in options)
+        {
+            var item = new SurveyOptionItem(o.Key, o.Label, o.Freeform);
+            item.SelectionRequested += OnOptionSelectionRequested;
+            Options.Add(item);
+        }
+
+        // The option set changed, so clear any prior selection.
+        SelectedAnswer = null;
+        IsFreeformSelected = false;
     }
 
-    public bool IsYouTubeSelected
+    private void OnOptionSelectionRequested(SurveyOptionItem selected)
     {
-        get => SelectedAnswer == "youtube";
-        set { if (value) SelectedAnswer = "youtube"; }
-    }
+        // Enforce single selection: deselect every other item.
+        foreach (var item in Options)
+        {
+            if (!ReferenceEquals(item, selected) && item.IsSelected)
+                item.IsSelected = false;
+        }
 
-    public bool IsRedditSelected
-    {
-        get => SelectedAnswer == "reddit";
-        set { if (value) SelectedAnswer = "reddit"; }
-    }
-
-    public bool IsFriendSelected
-    {
-        get => SelectedAnswer == "friend";
-        set { if (value) SelectedAnswer = "friend"; }
-    }
-
-    public bool IsEmailSelected
-    {
-        get => SelectedAnswer == "email";
-        set { if (value) SelectedAnswer = "email"; }
-    }
-
-    public bool IsOtherSelected
-    {
-        get => SelectedAnswer == "other";
-        set { if (value) SelectedAnswer = "other"; }
+        SelectedAnswer = selected.Key;
+        IsFreeformSelected = selected.Freeform;
     }
 
     public void Reset()
     {
+        foreach (var item in Options)
+            item.IsSelected = false;
         SelectedAnswer = null;
+        IsFreeformSelected = false;
         OtherText = string.Empty;
         IsSubmitting = false;
         SubmitError = null;
@@ -137,8 +181,9 @@ public partial class SourceSurveyOverlayViewModel : ObservableObject
         var answer = SelectedAnswer;
         if (string.IsNullOrEmpty(answer)) return;
 
-        var otherText = answer == "other" ? OtherText.Trim() : null;
-        if (answer == "other" && string.IsNullOrEmpty(otherText)) return;
+        var isFreeform = IsFreeformSelected;
+        var otherText = isFreeform ? OtherText.Trim() : null;
+        if (isFreeform && string.IsNullOrEmpty(otherText)) return;
 
         IsSubmitting = true;
         SubmitError = null;


### PR DESCRIPTION
## Summary
The post-onboarding "Where did you hear about Argo Books?" survey had its answer options hardcoded in `SourceSurveyOverlay.axaml` and the view model, so adding an option (e.g. a newly launched platform) required shipping a new app release. This fetches the options from the website instead.

## Changes
- Add `SourceSurveyOptionsService`: GETs `/api/survey-options.php` and returns a **bundled default list** on any failure (offline, non-2xx, malformed JSON), so the survey always renders.
- Replace the fixed radio buttons with a data-bound `ItemsControl`; the freeform text box is now driven by the selected option's `freeform` flag rather than a hardcoded `Other` key.
- On display, the overlay shows bundled defaults instantly, then refreshes from the server.
- `SourceSurveyReporter` forwards `other_text` for any freeform option.
- Wire the service in `App` alongside `SourceSurveyReporter`.
- Add tests covering parsing and every fallback path.

## Notes
- Labels are English-only (dynamic options do not go through `Translate()`).
- **Requires the companion website PR** (serves `/api/survey-options.php` and accepts the new option keys on submit). Without it, new options would be rejected on submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)