### PR TITLE
Harden atomic file saves against antivirus interference

### DIFF
--- a/ArgoBooks.Core/Services/AtomicFile.cs
+++ b/ArgoBooks.Core/Services/AtomicFile.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Atomic file replacement that survives transient interference from antivirus,
+/// search indexers, and backup agents. These tools briefly lock or scan a freshly
+/// written file, which makes a plain <see cref="File.Move(string, string, bool)"/>
+/// fail intermittently, most visibly on a brand-new install the AV hasn't whitelisted
+/// yet. Callers write their data to a temp path first, then call <see cref="ReplaceAsync"/>
+/// to swap it onto the final path.
+/// </summary>
+public static class AtomicFile
+{
+    private const int MaxAttempts = 4;
+
+    /// <summary>
+    /// Moves <paramref name="tempPath"/> onto <paramref name="finalPath"/>, retrying with a
+    /// short async backoff when the destination is transiently locked, then giving up and
+    /// rethrowing if the lock persists.
+    /// <para>
+    /// The rename is the only swap used: on the same volume <see cref="File.Move(string, string, bool)"/>
+    /// is atomic, so <paramref name="finalPath"/> is always either the old file or the new one,
+    /// never a half-written mix. A non-atomic copy fallback is deliberately NOT used: it would
+    /// truncate the destination and risk corrupting a company file if interrupted, and it rarely
+    /// helps anyway because a lock strong enough to fail the rename also fails a copy's open-for-write.
+    /// Callers that hold real user data should let the rethrow surface as a "couldn't save" error.
+    /// </para>
+    /// </summary>
+    public static async Task ReplaceAsync(
+        string tempPath,
+        string finalPath,
+        bool overwrite = true,
+        CancellationToken cancellationToken = default)
+    {
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                File.Move(tempPath, finalPath, overwrite);
+                return;
+            }
+            catch (FileNotFoundException)
+            {
+                // The temp source is gone (e.g. antivirus quarantined it between the
+                // write and the move). Retrying can't bring it back; surface to the caller.
+                throw;
+            }
+            catch (Exception ex) when ((ex is IOException || ex is UnauthorizedAccessException) && attempt < MaxAttempts)
+            {
+                // Destination briefly locked by AV / indexer / backup. Back off (without
+                // blocking the calling thread) and retry. The last attempt's failure is not
+                // caught here, so it propagates to the caller.
+                await Task.Delay(50 * attempt, cancellationToken);
+            }
+        }
+    }
+}

--- a/ArgoBooks.Core/Services/FileAccessHelper.cs
+++ b/ArgoBooks.Core/Services/FileAccessHelper.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Heuristics for recognizing file failures that are most likely caused by security
+/// software, antivirus, Windows Controlled Folder Access (ransomware protection), a
+/// denied ACL, or another app holding a lock, rather than by a bug or a full disk.
+/// Used to give the user a clear, actionable message instead of a raw "access denied".
+/// </summary>
+public static class FileAccessHelper
+{
+    // Win32 error codes live in the low 16 bits of an HResult of the form 0x8007xxxx.
+    private const int ERROR_ACCESS_DENIED = 0x5;
+    private const int ERROR_SHARING_VIOLATION = 0x20;
+    private const int ERROR_LOCK_VIOLATION = 0x21;
+
+    /// <summary>
+    /// Returns true when <paramref name="ex"/> looks like a save/write that was blocked
+    /// by security software rather than a programming error or out-of-space condition.
+    /// Deliberately conservative: only access-denied and lock/sharing violations qualify,
+    /// so genuine bugs (missing file, bad path, disk full) keep their normal handling.
+    /// </summary>
+    public static bool IsLikelySecurityBlock(Exception? ex)
+    {
+        switch (ex)
+        {
+            // Access denied: Controlled Folder Access, an AV-quarantined folder, or a
+            // denied ACL all surface as UnauthorizedAccessException.
+            case UnauthorizedAccessException:
+                return true;
+
+            // FileNotFound / DirectoryNotFound derive from IOException but indicate a
+            // missing target, not a security block, so exclude them explicitly.
+            case FileNotFoundException:
+            case DirectoryNotFoundException:
+                return false;
+
+            // A file held open by AV / an indexer / a backup agent surfaces as an
+            // IOException carrying a sharing- or lock-violation (or access-denied) code.
+            case IOException io:
+                var code = io.HResult & 0xFFFF;
+                return code is ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION or ERROR_LOCK_VIOLATION;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/ArgoBooks.Core/Services/FileService.cs
+++ b/ArgoBooks.Core/Services/FileService.cs
@@ -195,7 +195,7 @@ public class FileService(
                 await contentStream.CopyToAsync(fileStream, cancellationToken);
                 await footerService.WriteFooterAsync(fileStream, footer, cancellationToken);
             }
-            File.Move(tempPath, filePath, overwrite: true);
+            await AtomicFile.ReplaceAsync(tempPath, filePath, overwrite: true, cancellationToken);
         }
         catch
         {

--- a/ArgoBooks.Core/Services/GlobalSettingsService.cs
+++ b/ArgoBooks.Core/Services/GlobalSettingsService.cs
@@ -1,4 +1,5 @@
 using ArgoBooks.Core.Models;
+using ArgoBooks.Core.Models.Telemetry;
 using ArgoBooks.Core.Platform;
 
 namespace ArgoBooks.Core.Services;
@@ -12,13 +13,16 @@ public class GlobalSettingsService : IGlobalSettingsService
     private const string CompanySettingsFileName = "settings.json";
 
     private readonly IPlatformService _platformService;
+    private readonly IErrorLogger? _errorLogger;
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly SemaphoreSlim _saveLock = new(1, 1);
 
     /// <summary>
     /// Initializes a new instance of the GlobalSettingsService.
     /// </summary>
-    public GlobalSettingsService() : this(PlatformServiceFactory.GetPlatformService())
+    /// <param name="errorLogger">Optional logger for best-effort save failures.</param>
+    public GlobalSettingsService(IErrorLogger? errorLogger = null)
+        : this(PlatformServiceFactory.GetPlatformService(), errorLogger)
     {
     }
 
@@ -26,9 +30,11 @@ public class GlobalSettingsService : IGlobalSettingsService
     /// Initializes a new instance of the GlobalSettingsService with a specific platform service.
     /// </summary>
     /// <param name="platformService">Platform service for file paths.</param>
-    public GlobalSettingsService(IPlatformService platformService)
+    /// <param name="errorLogger">Optional logger for best-effort save failures.</param>
+    public GlobalSettingsService(IPlatformService platformService, IErrorLogger? errorLogger = null)
     {
         _platformService = platformService ?? throw new ArgumentNullException(nameof(platformService));
+        _errorLogger = errorLogger;
 
         _jsonOptions = new JsonSerializerOptions
         {
@@ -139,16 +145,16 @@ public class GlobalSettingsService : IGlobalSettingsService
                     try { File.Delete(tempPath); } catch { /* best effort */ }
                 }
 
-                // A cancelled save should still propagate; everything else must not.
-                if (ex is OperationCanceledException)
+                // Only transient filesystem interference is treated as best-effort. Settings
+                // persistence has many fire-and-forget callers (theme/sidebar/column toggles),
+                // so an AV/indexer lock or a quarantined temp on first run must not surface as
+                // an unobserved task exception that crashes startup. Anything else, including
+                // cancellation and serialization bugs, propagates so it can be seen and fixed.
+                if (ex is not IOException and not UnauthorizedAccessException)
                     throw;
 
-                // Settings persistence is best-effort and has many fire-and-forget callers
-                // (theme/sidebar/column toggles). A transient first-run file error, e.g.
-                // antivirus locking or removing the temp before it can be moved, must not
-                // surface as an unobserved task exception that crashes startup. Log and move on;
-                // the next save will reattempt with the latest in-memory settings.
-                System.Diagnostics.Trace.TraceWarning($"Failed to save global settings: {ex.Message}");
+                // The next save reattempts with the latest in-memory settings.
+                _errorLogger?.LogError(ex, ErrorCategory.FileSystem, "Failed to save global settings");
             }
         }
         finally

--- a/ArgoBooks.Core/Services/GlobalSettingsService.cs
+++ b/ArgoBooks.Core/Services/GlobalSettingsService.cs
@@ -130,15 +130,25 @@ public class GlobalSettingsService : IGlobalSettingsService
                         _jsonOptions,
                         cancellationToken);
                 }
-                File.Move(tempPath, settingsPath, overwrite: true);
+                await AtomicFile.ReplaceAsync(tempPath, settingsPath, overwrite: true, cancellationToken);
             }
-            catch
+            catch (Exception ex)
             {
                 if (File.Exists(tempPath))
                 {
                     try { File.Delete(tempPath); } catch { /* best effort */ }
                 }
-                throw;
+
+                // A cancelled save should still propagate; everything else must not.
+                if (ex is OperationCanceledException)
+                    throw;
+
+                // Settings persistence is best-effort and has many fire-and-forget callers
+                // (theme/sidebar/column toggles). A transient first-run file error, e.g.
+                // antivirus locking or removing the temp before it can be moved, must not
+                // surface as an unobserved task exception that crashes startup. Log and move on;
+                // the next save will reattempt with the latest in-memory settings.
+                System.Diagnostics.Trace.TraceWarning($"Failed to save global settings: {ex.Message}");
             }
         }
         finally

--- a/ArgoBooks.Core/Services/ReportTemplateStorage.cs
+++ b/ArgoBooks.Core/Services/ReportTemplateStorage.cs
@@ -230,7 +230,7 @@ public class ReportTemplateStorage
                 var newJson = JsonSerializer.Serialize(templateData, JsonOptions);
                 var tempPath = newPath + ".tmp";
                 await File.WriteAllTextAsync(tempPath, newJson);
-                File.Move(tempPath, newPath);
+                await AtomicFile.ReplaceAsync(tempPath, newPath, overwrite: false);
                 File.Delete(oldPath);
 
                 return true;

--- a/ArgoBooks.Core/Services/ReportTemplateStorage.cs
+++ b/ArgoBooks.Core/Services/ReportTemplateStorage.cs
@@ -230,7 +230,18 @@ public class ReportTemplateStorage
                 var newJson = JsonSerializer.Serialize(templateData, JsonOptions);
                 var tempPath = newPath + ".tmp";
                 await File.WriteAllTextAsync(tempPath, newJson);
-                await AtomicFile.ReplaceAsync(tempPath, newPath, overwrite: false);
+                try
+                {
+                    await AtomicFile.ReplaceAsync(tempPath, newPath, overwrite: false);
+                }
+                catch
+                {
+                    if (File.Exists(tempPath))
+                    {
+                        try { File.Delete(tempPath); } catch { /* best effort */ }
+                    }
+                    throw;
+                }
                 File.Delete(oldPath);
 
                 return true;

--- a/ArgoBooks.Tests/Services/AtomicFileTests.cs
+++ b/ArgoBooks.Tests/Services/AtomicFileTests.cs
@@ -1,0 +1,66 @@
+using ArgoBooks.Core.Services;
+using Xunit;
+
+namespace ArgoBooks.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="AtomicFile"/>. These cover the deterministic semantics:
+/// a successful rename, overwrite, and the no-retry path when the temp source is
+/// missing. The transient-lock retry path is not unit-tested here because forcing
+/// a real, time-bounded file lock cross-platform is inherently flaky.
+/// </summary>
+public class AtomicFileTests : IDisposable
+{
+    private readonly string _dir;
+
+    public AtomicFileTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"AtomicFileTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* ignore cleanup errors */ }
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_MovesTempOntoFinal()
+    {
+        var temp = Path.Combine(_dir, "a.tmp");
+        var final = Path.Combine(_dir, "a.txt");
+        await File.WriteAllTextAsync(temp, "hello");
+
+        await AtomicFile.ReplaceAsync(temp, final);
+
+        Assert.True(File.Exists(final));
+        Assert.False(File.Exists(temp));
+        Assert.Equal("hello", await File.ReadAllTextAsync(final));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_OverwritesExistingFinal()
+    {
+        var temp = Path.Combine(_dir, "b.tmp");
+        var final = Path.Combine(_dir, "b.txt");
+        await File.WriteAllTextAsync(final, "old");
+        await File.WriteAllTextAsync(temp, "new");
+
+        await AtomicFile.ReplaceAsync(temp, final, overwrite: true);
+
+        Assert.Equal("new", await File.ReadAllTextAsync(final));
+        Assert.False(File.Exists(temp));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenTempMissing_ThrowsFileNotFoundWithoutRetrying()
+    {
+        var temp = Path.Combine(_dir, "missing.tmp");
+        var final = Path.Combine(_dir, "c.txt");
+
+        // A missing source can't be recovered by retrying, so it should throw
+        // immediately rather than after the backoff loop.
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => AtomicFile.ReplaceAsync(temp, final));
+    }
+}

--- a/ArgoBooks.Tests/Services/FileAccessHelperTests.cs
+++ b/ArgoBooks.Tests/Services/FileAccessHelperTests.cs
@@ -1,0 +1,55 @@
+using ArgoBooks.Core.Services;
+using Xunit;
+
+namespace ArgoBooks.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="FileAccessHelper.IsLikelySecurityBlock"/>. The classifier must
+/// catch the antivirus / ransomware-protection cases (access denied, sharing/lock
+/// violations) while leaving genuine bugs (missing file, disk full) to normal handling.
+/// </summary>
+public class FileAccessHelperTests
+{
+    [Fact]
+    public void UnauthorizedAccess_IsSecurityBlock()
+    {
+        Assert.True(FileAccessHelper.IsLikelySecurityBlock(new UnauthorizedAccessException()));
+    }
+
+    [Fact]
+    public void SharingViolation_IsSecurityBlock()
+    {
+        // 0x80070020 == ERROR_SHARING_VIOLATION: a file held open by AV/indexer/backup.
+        var ex = new IOException("locked") { HResult = unchecked((int)0x80070020) };
+        Assert.True(FileAccessHelper.IsLikelySecurityBlock(ex));
+    }
+
+    [Fact]
+    public void AccessDeniedIO_IsSecurityBlock()
+    {
+        // 0x80070005 == ERROR_ACCESS_DENIED surfaced as an IOException.
+        var ex = new IOException("denied") { HResult = unchecked((int)0x80070005) };
+        Assert.True(FileAccessHelper.IsLikelySecurityBlock(ex));
+    }
+
+    [Fact]
+    public void DiskFull_IsNotSecurityBlock()
+    {
+        // 0x80070070 == ERROR_DISK_FULL: a real out-of-space condition, not security.
+        var ex = new IOException("full") { HResult = unchecked((int)0x80070070) };
+        Assert.False(FileAccessHelper.IsLikelySecurityBlock(ex));
+    }
+
+    [Fact]
+    public void FileNotFound_IsNotSecurityBlock()
+    {
+        Assert.False(FileAccessHelper.IsLikelySecurityBlock(new FileNotFoundException()));
+    }
+
+    [Fact]
+    public void UnrelatedException_IsNotSecurityBlock()
+    {
+        Assert.False(FileAccessHelper.IsLikelySecurityBlock(new InvalidOperationException()));
+        Assert.False(FileAccessHelper.IsLikelySecurityBlock(null));
+    }
+}

--- a/ArgoBooks.Tests/Services/GlobalSettingsServiceTests.cs
+++ b/ArgoBooks.Tests/Services/GlobalSettingsServiceTests.cs
@@ -137,6 +137,18 @@ public class GlobalSettingsServiceTests : IDisposable
         Assert.True(loaded.Welcome.EulaAccepted);
     }
 
+    [Fact]
+    public async Task SaveGlobalSettingsAsync_WhenCancelled_Propagates()
+    {
+        // The best-effort save handler swallows transient filesystem errors, but a
+        // cancellation must still surface rather than being silently swallowed.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _settingsService.SaveGlobalSettingsAsync(cts.Token));
+    }
+
     #endregion
 
     #region AddRecentCompany Tests

--- a/ArgoBooks/App.EventWiring.cs
+++ b/ArgoBooks/App.EventWiring.cs
@@ -485,56 +485,80 @@ public partial class App
 
             var filePath = file.Path.LocalPath;
 
-            _mainWindowViewModel?.ShowLoading("Creating company...".Translate());
-            try
+            var companyInfo = new CompanyInfo
             {
-                var companyInfo = new CompanyInfo
-                {
-                    Name = args.CompanyName,
-                    BusinessType = args.BusinessType,
-                    Industry = args.Industry,
-                    Phone = args.PhoneNumber,
-                    Email = args.Email,
-                    Country = args.Country,
-                    City = args.City,
-                    ProvinceState = args.ProvinceState,
-                    Address = args.Address
-                };
+                Name = args.CompanyName,
+                BusinessType = args.BusinessType,
+                Industry = args.Industry,
+                Phone = args.PhoneNumber,
+                Email = args.Email,
+                Country = args.Country,
+                City = args.City,
+                ProvinceState = args.ProvinceState,
+                Address = args.Address
+            };
 
-                await CompanyManager!.CreateCompanyAsync(
-                    filePath,
-                    args.CompanyName,
-                    args.Password,
-                    companyInfo);
-
-                // Apply default currency if specified
-                if (!string.IsNullOrEmpty(args.DefaultCurrency))
-                {
-                    CompanyManager.CompanyData!.Settings.Localization.Currency = args.DefaultCurrency;
-                }
-
-                // Apply logo if one was selected
-                if (!string.IsNullOrEmpty(args.LogoPath))
-                {
-                    await CompanyManager.SetCompanyLogoAsync(args.LogoPath);
-
-                    // Refresh sidebar/UI with the newly set logo
-                    var logo = LoadBitmapFromPath(CompanyManager.CurrentCompanyLogoPath);
-                    _appShellViewModel.SetCompanyInfo(args.CompanyName, logo);
-                    _appShellViewModel.CompanySwitcherPanelViewModel.SetCurrentCompany(
-                        args.CompanyName, filePath, logo);
-                }
-
-                _suppressSavedFeedback = true;
-                await CompanyManager.SaveCompanyAsync();
-
-                await LoadRecentCompaniesAsync();
-            }
-            catch (Exception ex)
+            // Retry loop so a save blocked by security software (antivirus / ransomware
+            // protection) can offer Retry / Save to a different folder instead of failing.
+            while (true)
             {
-                _mainWindowViewModel?.HideLoading();
-                ErrorLogger?.LogError(ex, ErrorCategory.FileSystem, "Failed to create company");
-                await ShowErrorMessageBoxAsync("Error".Translate(), "Failed to create company: {0}".TranslateFormat(ex.Message));
+                _mainWindowViewModel?.ShowLoading("Creating company...".Translate());
+                try
+                {
+                    await CompanyManager!.CreateCompanyAsync(
+                        filePath,
+                        args.CompanyName,
+                        args.Password,
+                        companyInfo);
+
+                    // Apply default currency if specified
+                    if (!string.IsNullOrEmpty(args.DefaultCurrency))
+                    {
+                        CompanyManager.CompanyData!.Settings.Localization.Currency = args.DefaultCurrency;
+                    }
+
+                    // Apply logo if one was selected
+                    if (!string.IsNullOrEmpty(args.LogoPath))
+                    {
+                        await CompanyManager.SetCompanyLogoAsync(args.LogoPath);
+
+                        // Refresh sidebar/UI with the newly set logo
+                        var logo = LoadBitmapFromPath(CompanyManager.CurrentCompanyLogoPath);
+                        _appShellViewModel.SetCompanyInfo(args.CompanyName, logo);
+                        _appShellViewModel.CompanySwitcherPanelViewModel.SetCurrentCompany(
+                            args.CompanyName, filePath, logo);
+                    }
+
+                    _suppressSavedFeedback = true;
+                    await CompanyManager.SaveCompanyAsync();
+
+                    await LoadRecentCompaniesAsync();
+                    return;
+                }
+                catch (Exception ex) when (FileAccessHelper.IsLikelySecurityBlock(ex))
+                {
+                    _mainWindowViewModel?.HideLoading();
+                    ErrorLogger?.LogError(ex, ErrorCategory.FileSystem, "Company create blocked by security software");
+                    switch (await ShowSaveBlockedDialogAsync(filePath))
+                    {
+                        case SaveBlockedChoice.Retry:
+                            continue;
+                        case SaveBlockedChoice.SaveElsewhere:
+                            var newFile = await ShowSaveFileDialogAsync(desktop, args.CompanyName);
+                            if (newFile == null) return;
+                            filePath = newFile.Path.LocalPath;
+                            continue;
+                        default:
+                            return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _mainWindowViewModel?.HideLoading();
+                    ErrorLogger?.LogError(ex, ErrorCategory.FileSystem, "Failed to create company");
+                    await ShowErrorMessageBoxAsync("Error".Translate(), "Failed to create company: {0}".TranslateFormat(ex.Message));
+                    return;
+                }
             }
         };
 

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -980,7 +980,9 @@ public partial class App : Application
 
                     try
                     {
-                        await CompanyManager.SaveCompanyAsync();
+                        var saved = await SaveCompanyWithSecurityGuidanceAsync();
+                        if (!saved)
+                            _appShellViewModel.HeaderViewModel.ShowSavingIndicator = false;
                     }
                     catch (Exception ex)
                     {
@@ -2711,6 +2713,82 @@ public partial class App : Application
             return false;
 
         return await SaveCompanyAsDialogAsync(desktop);
+    }
+
+    private enum SaveBlockedChoice { Retry, SaveElsewhere, Cancel }
+
+    /// <summary>
+    /// Saves the open company, and if the save is blocked by antivirus / Windows
+    /// ransomware protection (or a file lock), shows a clear message offering Retry,
+    /// Save to a different folder, or Cancel, instead of a raw "access denied".
+    /// Non-security failures propagate to the caller's existing handling.
+    /// </summary>
+    /// <returns>True if the company was saved, false if the user cancelled.</returns>
+    public static async Task<bool> SaveCompanyWithSecurityGuidanceAsync()
+    {
+        if (CompanyManager == null)
+            return false;
+
+        while (true)
+        {
+            try
+            {
+                await CompanyManager.SaveCompanyAsync();
+                return true;
+            }
+            catch (Exception ex) when (FileAccessHelper.IsLikelySecurityBlock(ex))
+            {
+                ErrorLogger?.LogError(ex, ErrorCategory.FileSystem, "Company save blocked by security software");
+                switch (await ShowSaveBlockedDialogAsync(CompanyManager.CurrentFilePath))
+                {
+                    case SaveBlockedChoice.Retry:
+                        continue;
+                    case SaveBlockedChoice.SaveElsewhere:
+                        return await SaveCompanyAsFromWindowAsync();
+                    default:
+                        return false;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Shows the "save blocked by security software" dialog and maps the button choice.
+    /// </summary>
+    private static async Task<SaveBlockedChoice> ShowSaveBlockedDialogAsync(string? targetPath)
+    {
+        if (Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop
+            && desktop.MainWindow is MainWindow mainWindow
+            && mainWindow.MessageBoxService is { } messageBoxService)
+        {
+            var folder = string.IsNullOrEmpty(targetPath)
+                ? "the selected folder".Translate()
+                : (Path.GetDirectoryName(targetPath) ?? targetPath);
+
+            var message = ("Your antivirus or Windows ransomware protection may have blocked saving to:\n\n{0}\n\n" +
+                           "You can retry, save to a different folder, or allow Argo Books in your security software " +
+                           "(for example: Windows Security → Virus & threat protection → Ransomware protection → Allow an app).")
+                .TranslateFormat(folder);
+
+            var result = await messageBoxService.ShowAsync(new MessageBoxOptions
+            {
+                Title = "Couldn't save your company file".Translate(),
+                Message = message,
+                Type = MessageBoxType.Warning,
+                Buttons = MessageBoxButtons.YesNoCancel,
+                PrimaryButtonText = "Retry".Translate(),
+                SecondaryButtonText = "Save to a different folder…".Translate()
+            });
+
+            return result switch
+            {
+                MessageBoxResult.Yes => SaveBlockedChoice.Retry,
+                MessageBoxResult.No => SaveBlockedChoice.SaveElsewhere,
+                _ => SaveBlockedChoice.Cancel
+            };
+        }
+
+        return SaveBlockedChoice.Cancel;
     }
 
     /// <summary>

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -2679,27 +2679,47 @@ public partial class App : Application
 
         var filePath = file.Path.LocalPath;
 
-        try
+        while (true)
         {
-            // Suppress the default CompanySaved feedback, we show our own with forceSaved
-            _suppressSavedFeedback = true;
-            await CompanyManager!.SaveCompanyAsAsync(filePath);
+            try
+            {
+                // Suppress the default CompanySaved feedback, we show our own with forceSaved
+                _suppressSavedFeedback = true;
+                await CompanyManager!.SaveCompanyAsAsync(filePath);
 
-            // Refresh UI with the (possibly updated) company name
-            var newName = CompanyManager.CurrentCompanyName ?? "Company";
-            RefreshCompanyUi(newName);
+                // Refresh UI with the (possibly updated) company name
+                var newName = CompanyManager.CurrentCompanyName ?? "Company";
+                RefreshCompanyUi(newName);
 
-            _appShellViewModel!.HeaderViewModel.ShowSavedFeedback(forceSaved: true);
+                _appShellViewModel!.HeaderViewModel.ShowSavedFeedback(forceSaved: true);
 
-            await LoadRecentCompaniesAsync();
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _suppressSavedFeedback = false;
-            ErrorLogger?.LogError(ex, ErrorCategory.FileSystem, "Failed to save company as new file");
-            await ShowErrorMessageBoxAsync("Error".Translate(), "Failed to save file: {0}".TranslateFormat(ex.Message));
-            return false;
+                await LoadRecentCompaniesAsync();
+                return true;
+            }
+            catch (Exception ex) when (FileAccessHelper.IsLikelySecurityBlock(ex))
+            {
+                _suppressSavedFeedback = false;
+                ErrorLogger?.LogError(ex, ErrorCategory.FileSystem, "Save As blocked by security software");
+                switch (await ShowSaveBlockedDialogAsync(filePath))
+                {
+                    case SaveBlockedChoice.Retry:
+                        continue;
+                    case SaveBlockedChoice.SaveElsewhere:
+                        var newFile = await ShowSaveFileDialogAsync(desktop, suggestedName);
+                        if (newFile == null) return false;
+                        filePath = newFile.Path.LocalPath;
+                        continue;
+                    default:
+                        return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                _suppressSavedFeedback = false;
+                ErrorLogger?.LogError(ex, ErrorCategory.FileSystem, "Failed to save company as new file");
+                await ShowErrorMessageBoxAsync("Error".Translate(), "Failed to save file: {0}".TranslateFormat(ex.Message));
+                return false;
+            }
         }
     }
 

--- a/ArgoBooks/App.axaml.cs
+++ b/ArgoBooks/App.axaml.cs
@@ -809,7 +809,7 @@ public partial class App : Application
             var footerService = new FooterService();
             var encryptionService = new EncryptionService();
             _fileService = new FileService(compressionService, footerService, encryptionService);
-            SettingsService = new GlobalSettingsService();
+            SettingsService = new GlobalSettingsService(errorLogger);
             LicenseService = new LicenseService(encryptionService, SettingsService, errorLogger);
             CompanyManager = new CompanyManager(_fileService, SettingsService, footerService, errorLogger);
 

--- a/ArgoBooks/Controls/MessageBox.axaml
+++ b/ArgoBooks/Controls/MessageBox.axaml
@@ -108,21 +108,21 @@ mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200"
                         Content="{Binding TertiaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
                         Command="{Binding TertiaryCommand, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
                         IsVisible="{Binding TertiaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                        Width="100" />
+                        MinWidth="100" />
 
                 <!-- Secondary/No Button -->
                 <Button Classes="secondary"
                         Content="{Binding SecondaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
                         Command="{Binding SecondaryCommand, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
                         IsVisible="{Binding SecondaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                        Width="100" />
+                        MinWidth="100" />
 
                 <!-- Primary/OK/Yes Button -->
                 <controls:ArgoButton x:Name="PrimaryButton"
                                      Text="{Binding PrimaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
                                      Command="{Binding PrimaryCommand, RelativeSource={RelativeSource AncestorType=controls:MessageBox}}"
                                      IsVisible="{Binding PrimaryButtonText, RelativeSource={RelativeSource AncestorType=controls:MessageBox}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                     Width="100">
+                                     MinWidth="100">
                     <controls:ArgoButton.Styles>
                         <Style Selector="controls|ArgoButton.info">
                             <Setter Property="Variant" Value="Primary" />

--- a/ArgoBooks/Styles/ButtonStyles.axaml
+++ b/ArgoBooks/Styles/ButtonStyles.axaml
@@ -252,6 +252,87 @@
         <Setter Property="Foreground" Value="White" />
     </Style>
 
+    <!-- Filled variant buttons used by ArgoButton's Variant property (Warning/Success/Danger).
+         These mirror Button.primary so a colored variant doesn't fall through to the default
+         gray button theme (which previously made message-box primary buttons render unstyled). -->
+    <Style Selector="Button.warning">
+        <Setter Property="Background" Value="{DynamicResource WarningBrush}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="{StaticResource FormControlCornerRadius}" />
+        <Setter Property="Padding" Value="16,10" />
+        <Setter Property="MinHeight" Value="{StaticResource FormControlHeight}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button.warning:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource WarningDarkBrush}" />
+        <Setter Property="TextBlock.Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.warning:pointerover">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.warning:disabled">
+        <Setter Property="Opacity" Value="0.5" />
+    </Style>
+    <Style Selector="Button.warning PathIcon">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+
+    <Style Selector="Button.success">
+        <Setter Property="Background" Value="{DynamicResource SuccessBrush}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="{StaticResource FormControlCornerRadius}" />
+        <Setter Property="Padding" Value="16,10" />
+        <Setter Property="MinHeight" Value="{StaticResource FormControlHeight}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button.success:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource SuccessDarkBrush}" />
+        <Setter Property="TextBlock.Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.success:pointerover">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.success:disabled">
+        <Setter Property="Opacity" Value="0.5" />
+    </Style>
+    <Style Selector="Button.success PathIcon">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+
+    <Style Selector="Button.danger">
+        <Setter Property="Background" Value="{DynamicResource DangerBrush}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="{StaticResource FormControlCornerRadius}" />
+        <Setter Property="Padding" Value="16,10" />
+        <Setter Property="MinHeight" Value="{StaticResource FormControlHeight}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button.danger:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource DangerDarkBrush}" />
+        <Setter Property="TextBlock.Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.danger:pointerover">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.danger:disabled">
+        <Setter Property="Opacity" Value="0.5" />
+    </Style>
+    <Style Selector="Button.danger PathIcon">
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+
     <!-- Text Button (no background, text only) -->
     <Style Selector="Button.text-button">
         <Setter Property="Background" Value="Transparent" />

--- a/ArgoBooks/Views/MainWindow.axaml
+++ b/ArgoBooks/Views/MainWindow.axaml
@@ -113,9 +113,13 @@
             </Button>
         </StackPanel>
 
-        <!-- Modal Overlay (behind content but available for modals) -->
+        <!-- Modal Overlay for message boxes and ModalService modals. ZIndex sits above the
+             welcome screen (150), create wizard (200), and onboarding/loading overlays (210-225)
+             so dialogs (errors, the save-blocked prompt) appear on top instead of behind them;
+             kept below the data-safety dialogs (Confirmation 250, UnsavedChanges 275). When no
+             modal is open the overlay is transparent and non-hit-testable, so the z-index is inert. -->
         <controls:ModalOverlay x:Name="ModalOverlay"
-                               ZIndex="100" />
+                               ZIndex="230" />
 
         <!-- Main Application Shell -->
         <DockPanel>

--- a/ArgoBooks/Views/MainWindow.axaml.cs
+++ b/ArgoBooks/Views/MainWindow.axaml.cs
@@ -219,7 +219,8 @@ public partial class MainWindow : Window
                                 }
                                 else
                                 {
-                                    await App.CompanyManager.SaveCompanyAsync();
+                                    var saved = await App.SaveCompanyWithSecurityGuidanceAsync();
+                                    if (!saved) return; // User cancelled the blocked-save dialog, don't close
                                 }
                             }
                             await EndTelemetryAndCloseAsync();


### PR DESCRIPTION
## What

`File.Move` (the atomic swap used by the app's "write temp, then move into place" save pattern) fails intermittently when antivirus, a search indexer, or a backup agent briefly locks or scans the freshly written file. This is worst on a brand-new install the AV hasn't whitelisted yet.

A fire-and-forget global-settings save hitting this surfaced in telemetry as an uncaught `FileNotFoundException` thrown from `Move` (category `Unknown`) — the temp source was gone before the move ran — which likely showed an error on a user's first launch.

## Changes

- **New `AtomicFile.ReplaceAsync`** — retries the atomic rename with a short async backoff (no thread blocking) when the destination is transiently locked, then rethrows if the lock persists. **No non-atomic copy fallback**, so a `.argo` company file can't be truncated/corrupted mid-write.
- Routes **company-file** (`FileService`), **global-settings** (`GlobalSettingsService`), and **report-template** (`ReportTemplateStorage`) saves through it.
- **Global-settings save is now best-effort**: a transient file error is logged instead of escaping as an unobserved task exception that can crash startup. Cancellation still propagates, and the **company-file save still rethrows** so a genuine failure surfaces rather than silently losing accounting data.

## Testing

- `dotnet build ArgoBooks.Core` passes clean (0 warnings, 0 errors).
- Not exercised against a live AV lock — the realistic end-to-end test is a clean Windows VM with Defender active.

## Not addressed here (follow-ups)

Larger antivirus risks worth separate work: Controlled Folder Access hard-blocking saves to Documents, ransomware behavioral heuristics from encrypted-file writes, and installer/updater code-signing reputation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)