### PR TITLE
Add Sales by Product analytics tab and report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -464,3 +464,6 @@ $RECYCLE.BIN/
 # Draw.io
 *.bkp
 *.dtmp
+
+# Superpowers brainstorm scratch files
+.superpowers/

--- a/ArgoBooks.Core/AppColors.cs
+++ b/ArgoBooks.Core/AppColors.cs
@@ -170,6 +170,8 @@ public static class AppColors
     public const string FlatTealLight = "#E8F6F3";
     public const string FlatOrange = "#D35400";
     public const string FlatOrangeLight = "#FBEEE6";
+    public const string FlatIndigo = "#4B5FAB";
+    public const string FlatIndigoLight = "#ECEEF6";
 
     /// <summary>
     /// Ordered color palette for indexed series (pie slices, multi-category charts, etc.).

--- a/ArgoBooks.Core/ChartColors.cs
+++ b/ArgoBooks.Core/ChartColors.cs
@@ -39,6 +39,7 @@ public static class ChartColors
 
             // Money-in (revenue family)
             ChartDataType.TotalRevenue or ChartDataType.RevenueDistribution
+                or ChartDataType.ProductRevenueTrend
                 => Revenue,
 
             // Profit: positive = green (profit), negative = red (loss)

--- a/ArgoBooks.Core/Enums/ReportEnums.cs
+++ b/ArgoBooks.Core/Enums/ReportEnums.cs
@@ -202,7 +202,10 @@ public enum ChartDataType
     TaxByCategory,
     TaxRateDistribution,
     TaxByProduct,
-    ExpenseVsRevenueTax
+    ExpenseVsRevenueTax,
+
+    // Products charts
+    ProductRevenueTrend
 }
 
 /// <summary>
@@ -247,7 +250,8 @@ public enum AccountingReportType
     CashFlowStatement,
     GeneralLedger,
     AccountsReceivableAging,
-    TaxSummary
+    TaxSummary,
+    ProductSales
 }
 
 /// <summary>
@@ -390,6 +394,9 @@ public static class ReportEnumExtensions
             ChartDataType.TaxByProduct => "Tax by Product",
             ChartDataType.ExpenseVsRevenueTax => "Expense vs Revenue Tax",
 
+            // Products charts
+            ChartDataType.ProductRevenueTrend => "Revenue Over Time",
+
             _ => chartType.ToString()
         };
     }
@@ -407,6 +414,7 @@ public static class ReportEnumExtensions
             AccountingReportType.GeneralLedger => "General Ledger",
             AccountingReportType.AccountsReceivableAging => "Accounts Receivable Aging",
             AccountingReportType.TaxSummary => "Tax Summary",
+            AccountingReportType.ProductSales => "Sales by Product",
             _ => reportType.ToString()
         };
     }
@@ -479,6 +487,7 @@ public static class ReportEnumExtensions
         ChartDataType.TaxCollectedVsPaid or ChartDataType.TaxLiabilityTrend
             or ChartDataType.TaxByCategory or ChartDataType.TaxRateDistribution
             or ChartDataType.TaxByProduct or ChartDataType.ExpenseVsRevenueTax => "Taxes",
+        ChartDataType.ProductRevenueTrend => "Products",
         _ => "Charts"
     };
 

--- a/ArgoBooks.Core/Models/Reports/ProductSalesData.cs
+++ b/ArgoBooks.Core/Models/Reports/ProductSalesData.cs
@@ -1,0 +1,27 @@
+namespace ArgoBooks.Core.Models.Reports;
+
+/// <summary>
+/// Per-product sales for a date range, all USD-normalized. Produced by
+/// <see cref="Services.ProductSalesService"/> and consumed by the Analytics
+/// "Products" tab and the "Sales by Product" report. Revenue is gross
+/// (tax-inclusive), matching every other revenue figure in the app
+/// (docs/Calculations.md Rule 1). Display-currency conversion happens at the
+/// presentation layer, never here. See docs/Calculations.md §13.
+/// </summary>
+public class ProductSalesData
+{
+    public string ProductId { get; set; } = string.Empty;
+
+    public string ProductName { get; set; } = string.Empty;
+
+    public string Sku { get; set; } = string.Empty;
+
+    /// <summary>Total units sold across the period.</summary>
+    public decimal UnitsSold { get; set; }
+
+    /// <summary>Gross revenue (USD), allocated proportionally across line items.</summary>
+    public decimal RevenueUSD { get; set; }
+
+    /// <summary>Average revenue per unit sold (USD) = revenue / units.</summary>
+    public decimal AvgSalePriceUSD { get; set; }
+}

--- a/ArgoBooks.Core/Models/Reports/ReportTemplateFactory.cs
+++ b/ArgoBooks.Core/Models/Reports/ReportTemplateFactory.cs
@@ -28,6 +28,7 @@ public static class ReportTemplateFactory
         public const string GeneralLedger = "General Ledger";
         public const string ARaging = "Accounts Receivable Aging";
         public const string TaxSummary = "Tax Summary";
+        public const string ProductSales = "Sales by Product";
     }
 
     /// <summary>
@@ -40,7 +41,8 @@ public static class ReportTemplateFactory
         TemplateNames.CashFlowStatement,
         TemplateNames.GeneralLedger,
         TemplateNames.ARaging,
-        TemplateNames.TaxSummary
+        TemplateNames.TaxSummary,
+        TemplateNames.ProductSales
     ];
 
     /// <summary>
@@ -85,7 +87,8 @@ public static class ReportTemplateFactory
                templateName == TemplateNames.CashFlowStatement ||
                templateName == TemplateNames.GeneralLedger ||
                templateName == TemplateNames.ARaging ||
-               templateName == TemplateNames.TaxSummary;
+               templateName == TemplateNames.TaxSummary ||
+               templateName == TemplateNames.ProductSales;
     }
 
     /// <summary>
@@ -109,6 +112,7 @@ public static class ReportTemplateFactory
             TemplateNames.GeneralLedger => CreateAccountingTemplate(AccountingReportType.GeneralLedger, "General Ledger", DatePresetNames.ThisMonth),
             TemplateNames.ARaging => CreateAccountingTemplate(AccountingReportType.AccountsReceivableAging, "Accounts Receivable Aging", DatePresetNames.AllTime),
             TemplateNames.TaxSummary => CreateAccountingTemplate(AccountingReportType.TaxSummary, "Tax Summary", DatePresetNames.YearToDate),
+            TemplateNames.ProductSales => CreateAccountingTemplate(AccountingReportType.ProductSales, "Sales by Product", DatePresetNames.YearToDate),
             _ => new ReportConfiguration()
         };
     }

--- a/ArgoBooks.Core/Services/AccountingReportDataService.cs
+++ b/ArgoBooks.Core/Services/AccountingReportDataService.cs
@@ -96,6 +96,7 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
             AccountingReportType.GeneralLedger => GetGeneralLedgerData(),
             AccountingReportType.AccountsReceivableAging => GetARAgingData(),
             AccountingReportType.TaxSummary => GetTaxSummaryData(),
+            AccountingReportType.ProductSales => GetProductSalesData(),
             _ => new AccountingTableData { Title = "Unknown Report" }
         };
     }
@@ -814,6 +815,82 @@ public class AccountingReportDataService(CompanyData? companyData, ReportFilters
         public decimal Debit { get; init; }
         public decimal Credit { get; init; }
     }
+
+    #endregion
+
+    #region Sales by Product
+
+    /// <summary>
+    /// Generates Sales by Product data: units, gross revenue, and average sale
+    /// price per product, ranked by revenue. Uses accrual basis (all invoiced
+    /// revenue) to match the other formal reports. See docs/Calculations.md §13.
+    /// </summary>
+    private AccountingTableData GetProductSalesData()
+    {
+        var data = new AccountingTableData
+        {
+            Title = "Sales by Product",
+            Subtitle = GetCurrencySubtitle(),
+            ColumnHeaders = ["Product", "Units", "Revenue", "Avg price"],
+            ColumnWidthRatios = [0.42, 0.16, 0.22, 0.20]
+        };
+
+        if (companyData == null)
+            return data;
+
+        var products = ProductSalesService.GetProductSales(
+            companyData,
+            filters.StartDate ?? DateTime.MinValue,
+            filters.EndDate ?? DateTime.MaxValue,
+            cashBasis: false);
+
+        if (products.Count == 0)
+        {
+            data.Rows.Add(new AccountingRow
+            {
+                Label = "No product sales in this period",
+                RowType = AccountingRowType.DataRow,
+                Values = ["", "", ""]
+            });
+            return data;
+        }
+
+        foreach (var p in products)
+        {
+            data.Rows.Add(new AccountingRow
+            {
+                Label = p.ProductName,
+                Values =
+                [
+                    FormatUnits(p.UnitsSold),
+                    FormatCurrency(p.RevenueUSD),
+                    FormatCurrency(p.AvgSalePriceUSD)
+                ],
+                RowType = AccountingRowType.DataRow
+            });
+        }
+
+        var totalUnits = products.Sum(p => p.UnitsSold);
+        var totalRevenue = products.Sum(p => p.RevenueUSD);
+        var overallAvg = totalUnits > 0 ? totalRevenue / totalUnits : 0;
+
+        data.Rows.Add(new AccountingRow { RowType = AccountingRowType.SeparatorLine, Values = ["", "", ""] });
+        data.Rows.Add(new AccountingRow
+        {
+            Label = "Total",
+            Values =
+            [
+                FormatUnits(totalUnits),
+                FormatCurrency(totalRevenue),
+                FormatCurrency(overallAvg)
+            ],
+            RowType = AccountingRowType.GrandTotalRow
+        });
+
+        return data;
+    }
+
+    private static string FormatUnits(decimal units) => units.ToString("0.##");
 
     #endregion
 

--- a/ArgoBooks.Core/Services/ProductSalesService.cs
+++ b/ArgoBooks.Core/Services/ProductSalesService.cs
@@ -1,0 +1,110 @@
+using ArgoBooks.Core.Data;
+using ArgoBooks.Core.Models.Reports;
+
+namespace ArgoBooks.Core.Services;
+
+/// <summary>
+/// Single source of truth for per-product sales (revenue and units). Both the
+/// Analytics "Products" tab and the "Sales by Product" report call this so their
+/// numbers never diverge; only the cash-basis flag differs. Revenue is gross
+/// (tax-inclusive) and allocated proportionally per line item. See
+/// docs/Calculations.md §13.
+/// </summary>
+public static class ProductSalesService
+{
+    /// <summary>
+    /// Aggregates per-product sales over a date range. When
+    /// <paramref name="cashBasis"/> is true, only collected revenue counts
+    /// (analytics convention); when false, all invoiced revenue counts
+    /// (formal-report convention). Results are ordered by revenue descending.
+    /// </summary>
+    public static List<ProductSalesData> GetProductSales(
+        CompanyData data, DateTime start, DateTime end, bool cashBasis)
+    {
+        var acc = new Dictionary<string, (decimal Revenue, decimal Quantity)>();
+
+        foreach (var s in FilterRevenues(data, start, end, cashBasis))
+        {
+            if (s.LineItems.Count == 0) continue;
+
+            // Allocate the transaction's gross USD total across its line items
+            // in proportion to each item's native pre-tax subtotal.
+            var lineItemsTotal = s.LineItems.Sum(li => li.Subtotal);
+            var totalUSD = s.EffectiveTotalUSD;
+
+            foreach (var li in s.LineItems)
+            {
+                var pid = li.ProductId ?? "";
+                var revenueUSD = lineItemsTotal != 0
+                    ? Math.Round(li.Subtotal / lineItemsTotal * totalUSD, 2)
+                    : 0;
+
+                var cur = acc.GetValueOrDefault(pid);
+                acc[pid] = (cur.Revenue + revenueUSD, cur.Quantity + li.Quantity);
+            }
+        }
+
+        var result = new List<ProductSalesData>(acc.Count);
+        foreach (var kvp in acc)
+        {
+            var product = data.GetProduct(kvp.Key);
+            var (revenue, qty) = kvp.Value;
+            result.Add(new ProductSalesData
+            {
+                ProductId = kvp.Key,
+                ProductName = product?.Name ?? "Unknown",
+                Sku = product?.Sku ?? string.Empty,
+                UnitsSold = qty,
+                RevenueUSD = revenue,
+                AvgSalePriceUSD = qty != 0 ? Math.Round(revenue / qty, 2) : 0
+            });
+        }
+
+        return result.OrderByDescending(p => p.RevenueUSD).ToList();
+    }
+
+    /// <summary>
+    /// Per-day gross revenue (USD) for a single product, for the detail trend
+    /// chart. Same allocation as <see cref="GetProductSales"/>, bucketed by the
+    /// transaction date. Honors the same <paramref name="cashBasis"/> flag.
+    /// </summary>
+    public static Dictionary<DateTime, decimal> GetProductRevenueByDayUSD(
+        CompanyData data, string productId, DateTime start, DateTime end, bool cashBasis)
+    {
+        var byDay = new Dictionary<DateTime, decimal>();
+
+        foreach (var s in FilterRevenues(data, start, end, cashBasis))
+        {
+            if (s.LineItems.Count == 0) continue;
+
+            var lineItemsTotal = s.LineItems.Sum(li => li.Subtotal);
+            var totalUSD = s.EffectiveTotalUSD;
+
+            decimal dayRevenue = 0;
+            var matched = false;
+            foreach (var li in s.LineItems)
+            {
+                if ((li.ProductId ?? "") != productId) continue;
+                matched = true;
+                dayRevenue += lineItemsTotal != 0
+                    ? Math.Round(li.Subtotal / lineItemsTotal * totalUSD, 2)
+                    : 0;
+            }
+
+            if (matched)
+            {
+                var day = s.Date.Date;
+                byDay[day] = byDay.GetValueOrDefault(day, 0m) + dayRevenue;
+            }
+        }
+
+        return byDay;
+    }
+
+    private static IEnumerable<Models.Transactions.Revenue> FilterRevenues(
+        CompanyData data, DateTime start, DateTime end, bool cashBasis)
+    {
+        var revenues = data.Revenues.Where(r => r.Date >= start && r.Date <= end);
+        return cashBasis ? revenues.Where(RevenueAggregator.IsCollected) : revenues;
+    }
+}

--- a/ArgoBooks.Tests/Services/ProductSalesServiceTests.cs
+++ b/ArgoBooks.Tests/Services/ProductSalesServiceTests.cs
@@ -1,0 +1,170 @@
+using ArgoBooks.Core.Data;
+using ArgoBooks.Core.Enums;
+using ArgoBooks.Core.Models.Common;
+using ArgoBooks.Core.Models.Entities;
+using ArgoBooks.Core.Models.Transactions;
+using ArgoBooks.Core.Services;
+using Xunit;
+
+namespace ArgoBooks.Tests.Services;
+
+/// <summary>
+/// Tests for ProductSalesService: per-product gross revenue and units, allocated
+/// per line item. Revenue is gross (EffectiveTotalUSD) per docs/Calculations.md
+/// Rule 1 and §13; analytics is cash-basis, the report is accrual.
+/// </summary>
+public class ProductSalesServiceTests
+{
+    private static readonly DateTime Start = new(2026, 5, 1);
+    private static readonly DateTime End = new(2026, 5, 31);
+
+    private static Product Prod(string id, string name, string sku = "") =>
+        new() { Id = id, Name = name, Sku = sku };
+
+    private static LineItem Line(string productId, decimal qty, decimal unitPrice) =>
+        new() { ProductId = productId, Quantity = qty, UnitPrice = unitPrice };
+
+    private static Revenue PaidRevenue(decimal total, decimal tax, params LineItem[] lines) =>
+        new()
+        {
+            Date = new DateTime(2026, 5, 11),
+            PaymentStatus = RevenuePaymentStatus.Paid,
+            Total = total,
+            TaxAmount = tax,
+            OriginalCurrency = "USD",
+            LineItems = [.. lines]
+        };
+
+    [Fact]
+    public void GetProductSales_SingleProduct_UsesGrossRevenue()
+    {
+        // $119 total ($86.91 + $32.09 tax). Revenue display is gross (Rule 1).
+        var data = new CompanyData();
+        data.Products.Add(Prod("P1", "Widget", "W-1"));
+        data.Revenues.Add(PaidRevenue(119m, 32.09m, Line("P1", 2, 43.455m)));
+
+        var result = ProductSalesService.GetProductSales(data, Start, End, cashBasis: true);
+
+        var p = Assert.Single(result);
+        Assert.Equal("Widget", p.ProductName);
+        Assert.Equal("W-1", p.Sku);
+        Assert.Equal(119m, p.RevenueUSD);          // gross, not the 86.91 pre-tax
+        Assert.Equal(2m, p.UnitsSold);
+        Assert.Equal(59.50m, p.AvgSalePriceUSD);   // 119 / 2
+    }
+
+    [Fact]
+    public void GetProductSales_MultipleLineItems_AllocatesBySubtotalShare()
+    {
+        // One $200 sale split across two products 60/40 by line subtotal.
+        var data = new CompanyData();
+        data.Products.Add(Prod("P1", "Big"));
+        data.Products.Add(Prod("P2", "Small"));
+        data.Revenues.Add(PaidRevenue(200m, 0m,
+            Line("P1", 1, 60m),
+            Line("P2", 1, 40m)));
+
+        var result = ProductSalesService.GetProductSales(data, Start, End, cashBasis: true);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Big", result[0].ProductName);   // ordered by revenue descending
+        Assert.Equal(120m, result[0].RevenueUSD);      // 60/100 * 200
+        Assert.Equal(80m, result[1].RevenueUSD);       // 40/100 * 200
+    }
+
+    [Fact]
+    public void GetProductSales_CashBasis_ExcludesUnpaidButAccrualIncludes()
+    {
+        var data = new CompanyData();
+        data.Products.Add(Prod("P1", "Widget"));
+        data.Revenues.Add(PaidRevenue(100m, 0m, Line("P1", 1, 100m)));
+        var pending = PaidRevenue(50m, 0m, Line("P1", 1, 50m));
+        pending.PaymentStatus = RevenuePaymentStatus.Pending;
+        data.Revenues.Add(pending);
+
+        var cash = ProductSalesService.GetProductSales(data, Start, End, cashBasis: true);
+        var accrual = ProductSalesService.GetProductSales(data, Start, End, cashBasis: false);
+
+        Assert.Equal(100m, Assert.Single(cash).RevenueUSD);
+        Assert.Equal(150m, Assert.Single(accrual).RevenueUSD);
+    }
+
+    [Fact]
+    public void GetProductSales_NonUsd_UsesConvertedGrossUsd()
+    {
+        var data = new CompanyData();
+        data.Products.Add(Prod("P1", "Widget"));
+        var rev = PaidRevenue(100m, 0m, Line("P1", 1, 100m));
+        rev.OriginalCurrency = "EUR";
+        rev.TotalUSD = 110m;   // EffectiveTotalUSD for a non-USD transaction
+        data.Revenues.Add(rev);
+
+        var result = ProductSalesService.GetProductSales(data, Start, End, cashBasis: true);
+
+        Assert.Equal(110m, Assert.Single(result).RevenueUSD);  // converted USD, not the 100 native
+    }
+
+    [Fact]
+    public void GetProductSales_TransactionWithNoLineItems_IsExcluded()
+    {
+        var data = new CompanyData();
+        data.Products.Add(Prod("P1", "Widget"));
+        data.Revenues.Add(PaidRevenue(100m, 0m));   // no line items, nothing to attribute
+
+        var result = ProductSalesService.GetProductSales(data, Start, End, cashBasis: true);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetProductSales_OutsideDateRange_IsExcluded()
+    {
+        var data = new CompanyData();
+        data.Products.Add(Prod("P1", "Widget"));
+        var rev = PaidRevenue(100m, 0m, Line("P1", 1, 100m));
+        rev.Date = new DateTime(2026, 4, 15);  // before Start
+        data.Revenues.Add(rev);
+
+        var result = ProductSalesService.GetProductSales(data, Start, End, cashBasis: true);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetProductSales_UnknownProductId_GroupsAsUnknown()
+    {
+        var data = new CompanyData();   // no product registered for "GHOST"
+        data.Revenues.Add(PaidRevenue(100m, 0m, Line("GHOST", 1, 100m)));
+
+        var result = ProductSalesService.GetProductSales(data, Start, End, cashBasis: true);
+
+        Assert.Equal("Unknown", Assert.Single(result).ProductName);
+    }
+
+    [Fact]
+    public void GetProductSales_EmptyData_ReturnsEmpty()
+    {
+        var result = ProductSalesService.GetProductSales(new CompanyData(), Start, End, cashBasis: true);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetProductRevenueByDayUSD_SumMatchesProductTotal()
+    {
+        var data = new CompanyData();
+        data.Products.Add(Prod("P1", "Widget"));
+        var r1 = PaidRevenue(100m, 0m, Line("P1", 1, 100m));
+        r1.Date = new DateTime(2026, 5, 5);
+        var r2 = PaidRevenue(60m, 0m, Line("P1", 1, 60m));
+        r2.Date = new DateTime(2026, 5, 20);
+        data.Revenues.Add(r1);
+        data.Revenues.Add(r2);
+
+        var byDay = ProductSalesService.GetProductRevenueByDayUSD(data, "P1", Start, End, cashBasis: true);
+        var total = ProductSalesService.GetProductSales(data, Start, End, cashBasis: true).Single().RevenueUSD;
+
+        Assert.Equal(2, byDay.Count);
+        Assert.Equal(160m, byDay.Values.Sum());
+        Assert.Equal(total, byDay.Values.Sum());   // per-day reconciles with the total
+    }
+}

--- a/ArgoBooks/Controls/ColumnWidths/ProductSalesTableColumnWidths.cs
+++ b/ArgoBooks/Controls/ColumnWidths/ProductSalesTableColumnWidths.cs
@@ -1,0 +1,34 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ArgoBooks.Controls.ColumnWidths;
+
+/// <summary>
+/// Manages column widths for the Analytics "Sales by Product" table.
+/// Columns: Product | Units | Revenue | Avg price
+/// </summary>
+public partial class ProductSalesTableColumnWidths : TableColumnWidthsBase
+{
+    [ObservableProperty]
+    private double _productColumnWidth = 280;
+
+    [ObservableProperty]
+    private double _unitsColumnWidth = 110;
+
+    [ObservableProperty]
+    private double _revenueColumnWidth = 150;
+
+    [ObservableProperty]
+    private double _avgPriceColumnWidth = 150;
+
+    public ProductSalesTableColumnWidths()
+    {
+        ColumnOrder = ["Product", "Units", "Revenue", "AvgPrice"];
+
+        RegisterColumn("Product", new ColumnDef { StarValue = 2.6, MinWidth = 160, PreferredWidth = 280 }, w => ProductColumnWidth = w);
+        RegisterColumn("Units", new ColumnDef { StarValue = 1.0, MinWidth = 80, PreferredWidth = 110 }, w => UnitsColumnWidth = w);
+        RegisterColumn("Revenue", new ColumnDef { StarValue = 1.3, MinWidth = 110, PreferredWidth = 150 }, w => RevenueColumnWidth = w);
+        RegisterColumn("AvgPrice", new ColumnDef { StarValue = 1.3, MinWidth = 110, PreferredWidth = 150 }, w => AvgPriceColumnWidth = w);
+
+        RecalculateWidths();
+    }
+}

--- a/ArgoBooks/Services/ChartLoaderService.cs
+++ b/ArgoBooks/Services/ChartLoaderService.cs
@@ -1216,6 +1216,37 @@ public class ChartLoaderService
     }
 
     /// <summary>
+    /// Builds the per-product revenue-over-time series for the Analytics Products
+    /// detail panel. Cash-basis (paid-only) to match the rest of the analytics
+    /// surfaces. Values are USD and converted to display currency at the series
+    /// boundary. See docs/Calculations.md §13.
+    /// </summary>
+    public (ObservableCollection<ISeries> Series, DateTime[] Dates) LoadProductRevenueTrendChart(
+        CompanyData? companyData, string productId, DateTime? startDate = null, DateTime? endDate = null)
+    {
+        var series = new ObservableCollection<ISeries>();
+        if (companyData == null || string.IsNullOrEmpty(productId))
+            return (series, Array.Empty<DateTime>());
+
+        var dailyPoints = ProductSalesService.GetProductRevenueByDayUSD(
+            companyData, productId,
+            startDate ?? DateTime.MinValue,
+            endDate ?? DateTime.MaxValue,
+            cashBasis: true);
+
+        if (dailyPoints.Count == 0)
+            return (series, Array.Empty<DateTime>());
+
+        var ordered = dailyPoints.OrderBy(p => p.Key).ToList();
+        var dates = ordered.Select(p => p.Key).ToArray();
+        var values = ordered.Select(p => (double)p.Value).ToArray();
+
+        series.Add(CreateDateTimeSeries(dates, values, "Revenue", ChartColors.Revenue));
+
+        return (series, dates);
+    }
+
+    /// <summary>
     /// Loads expenses vs revenue comparison chart as a multi-series column chart.
     /// Uses ReportChartDataService for data fetching with daily granularity.
     /// </summary>

--- a/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/AnalyticsPageViewModel.cs
@@ -1,6 +1,9 @@
 #pragma warning disable CS0618 // LabelVisual is obsolete. DrawnLabelVisual is not API-compatible
 using System.Collections.ObjectModel;
+using System.Windows.Input;
 using ArgoBooks.Controls;
+using ArgoBooks.Controls.ColumnWidths;
+using ArgoBooks.Helpers;
 using ArgoBooks.Core.Data;
 using ArgoBooks.Core.Enums;
 using ArgoBooks.Core.Models.Reports;
@@ -8,6 +11,7 @@ using ArgoBooks.Core.Models.Telemetry;
 using ArgoBooks.Core.Services;
 using ArgoBooks.Localization;
 using ArgoBooks.Services;
+using ArgoBooks.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LiveChartsCore;
@@ -54,42 +58,47 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
     /// <summary>
     /// Gets whether the Geographic tab is selected.
     /// </summary>
-    public bool IsGeographicTabSelected => SelectedTabIndex == 1;
+    public bool IsGeographicTabSelected => SelectedTabIndex == 2;
 
     /// <summary>
     /// Gets whether the Operational tab is selected.
     /// </summary>
-    public bool IsOperationalTabSelected => SelectedTabIndex == 2;
+    public bool IsOperationalTabSelected => SelectedTabIndex == 3;
 
     /// <summary>
     /// Gets whether the Performance tab is selected.
     /// </summary>
-    public bool IsPerformanceTabSelected => SelectedTabIndex == 3;
+    public bool IsPerformanceTabSelected => SelectedTabIndex == 4;
 
     /// <summary>
     /// Gets whether the Customers tab is selected.
     /// </summary>
-    public bool IsCustomersTabSelected => SelectedTabIndex == 4;
+    public bool IsCustomersTabSelected => SelectedTabIndex == 5;
 
     /// <summary>
     /// Gets whether the Taxes tab is selected.
     /// </summary>
-    public bool IsTaxesTabSelected => SelectedTabIndex == 5;
+    public bool IsTaxesTabSelected => SelectedTabIndex == 6;
 
     /// <summary>
     /// Gets whether the Returns tab is selected.
     /// </summary>
-    public bool IsReturnsTabSelected => SelectedTabIndex == 6;
+    public bool IsReturnsTabSelected => SelectedTabIndex == 7;
 
     /// <summary>
     /// Gets whether the Losses tab is selected.
     /// </summary>
-    public bool IsLossesTabSelected => SelectedTabIndex == 7;
+    public bool IsLossesTabSelected => SelectedTabIndex == 8;
 
     /// <summary>
     /// Gets whether the Refunds tab is selected.
     /// </summary>
-    public bool IsRefundsTabSelected => SelectedTabIndex == 8;
+    public bool IsRefundsTabSelected => SelectedTabIndex == 9;
+
+    /// <summary>
+    /// Gets whether the Products tab is selected.
+    /// </summary>
+    public bool IsProductsTabSelected => SelectedTabIndex == 1;
 
     partial void OnSelectedTabIndexChanged(int value)
     {
@@ -102,9 +111,270 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
         OnPropertyChanged(nameof(IsLossesTabSelected));
         OnPropertyChanged(nameof(IsTaxesTabSelected));
         OnPropertyChanged(nameof(IsRefundsTabSelected));
+        OnPropertyChanged(nameof(IsProductsTabSelected));
 
         if (IsRefundsTabSelected) RefreshRefundMetrics();
+
+        // Make sure a product is selected when arriving on the Products tab so
+        // the detail panel is populated even if the first load raced the tab.
+        if (IsProductsTabSelected && SelectedProduct == null)
+            SelectedProduct = _filteredSortedProducts.FirstOrDefault();
     }
+
+    #endregion
+
+    #region Products Tab
+
+    private readonly ProductSalesTableColumnWidths _productColumns = new();
+    private List<ProductSalesRow> _allProductRows = [];
+    private List<ProductSalesRow> _filteredSortedProducts = [];
+
+    /// <summary>Column width manager for the Sales by Product table.</summary>
+    public ProductSalesTableColumnWidths ProductColumns => _productColumns;
+
+    /// <summary>Responsive header sizing for the Sales by Product table.</summary>
+    public ResponsiveHeaderHelper ProductsResponsiveHeader { get; } = new();
+
+    /// <summary>The product rows currently shown (after search + sort).</summary>
+    public ObservableCollection<ProductSalesRow> Products { get; } = [];
+
+    [ObservableProperty]
+    private string _productSearchQuery = string.Empty;
+
+    [ObservableProperty]
+    private string _productSortColumn = "Revenue";
+
+    [ObservableProperty]
+    private SortDirection _productSortDirection = SortDirection.Descending;
+
+    [ObservableProperty]
+    private bool _hasProductData;
+
+    [ObservableProperty]
+    private string _totalProductRevenue = string.Empty;
+
+    [ObservableProperty]
+    private string _totalProductUnits = string.Empty;
+
+    [ObservableProperty]
+    private string _avgProductSalePrice = string.Empty;
+
+    [ObservableProperty]
+    private string _productsSoldCount = string.Empty;
+
+    // Pagination for the product table.
+    [ObservableProperty]
+    private int _productCurrentPage = 1;
+
+    [ObservableProperty]
+    private int _productTotalPages = 1;
+
+    [ObservableProperty]
+    private int _productPageSize = 10;
+
+    [ObservableProperty]
+    private string _productPaginationText = string.Empty;
+
+    [ObservableProperty]
+    private ProductSalesRow? _selectedProduct;
+
+    // Per-product detail trend chart.
+    [ObservableProperty]
+    private ObservableCollection<ISeries> _productRevenueTrendSeries = [];
+
+    [ObservableProperty]
+    private Axis[] _productRevenueTrendXAxes = [new Axis()];
+
+    [ObservableProperty]
+    private Axis[] _productRevenueTrendYAxes = [new Axis()];
+
+    [ObservableProperty]
+    private bool _hasProductTrendData;
+
+    /// <summary>True when a product row is selected (drives the detail panel).</summary>
+    public bool HasSelectedProduct => SelectedProduct != null;
+
+    public LabelVisual ProductRevenueTrendTitle =>
+        ChartLoaderService.CreateChartTitle(ChartDataType.ProductRevenueTrend.GetDisplayName());
+
+    private RelayCommand<string>? _productSortByCommand;
+
+    /// <summary>Sorts the product table by a column; toggles direction on repeat.</summary>
+    public ICommand ProductSortByCommand => _productSortByCommand ??= new RelayCommand<string>(ProductSortBy);
+
+    private void ProductSortBy(string? column)
+    {
+        if (string.IsNullOrEmpty(column))
+            return;
+
+        if (ProductSortColumn == column)
+        {
+            ProductSortDirection = ProductSortDirection switch
+            {
+                SortDirection.None => SortDirection.Ascending,
+                SortDirection.Ascending => SortDirection.Descending,
+                SortDirection.Descending => SortDirection.None,
+                _ => SortDirection.Ascending
+            };
+        }
+        else
+        {
+            ProductSortColumn = column;
+            ProductSortDirection = SortDirection.Descending;
+        }
+
+        ProductCurrentPage = 1;
+        ApplyProductFilterAndSort();
+    }
+
+    partial void OnProductSearchQueryChanged(string value)
+    {
+        ProductCurrentPage = 1;
+        ApplyProductFilterAndSort();
+    }
+
+    partial void OnProductPageSizeChanged(int value)
+    {
+        ProductCurrentPage = 1;
+        ApplyProductFilterAndSort();
+    }
+
+    partial void OnProductCurrentPageChanged(int value) => PageProducts();
+
+    [RelayCommand]
+    private void GoToProductPage(int page)
+    {
+        if (page >= 1 && page <= ProductTotalPages && page != ProductCurrentPage)
+            ProductCurrentPage = page;
+    }
+
+    [RelayCommand]
+    private void ProductPreviousPage()
+    {
+        if (ProductCurrentPage > 1)
+            ProductCurrentPage--;
+    }
+
+    [RelayCommand]
+    private void ProductNextPage()
+    {
+        if (ProductCurrentPage < ProductTotalPages)
+            ProductCurrentPage++;
+    }
+
+    /// <summary>
+    /// Aggregates per-product sales for the current date range (cash-basis,
+    /// matching the other analytics tabs) and refreshes the table + KPI cards.
+    /// </summary>
+    private void LoadProductSales(CompanyData data)
+    {
+        var displayDate = EndDate;
+        var rows = ProductSalesService.GetProductSales(data, StartDate, EndDate, cashBasis: true)
+            .Select(d => new ProductSalesRow(d, displayDate))
+            .ToList();
+
+        _allProductRows = rows;
+        HasProductData = rows.Count > 0;
+
+        var totalRevenue = rows.Sum(r => r.RevenueUSD);
+        var totalUnits = rows.Sum(r => r.UnitsSold);
+        var avgPrice = totalUnits > 0 ? totalRevenue / totalUnits : 0;
+
+        TotalProductRevenue = CurrencyService.FormatFromUSD(totalRevenue, displayDate);
+        TotalProductUnits = totalUnits.ToString("0.##");
+        AvgProductSalePrice = CurrencyService.FormatFromUSD(avgPrice, displayDate);
+        ProductsSoldCount = rows.Count.ToString();
+
+        // Preserve the current selection if its product still exists; otherwise
+        // auto-select the top row so the detail panel is populated on arrival.
+        var previouslySelectedId = SelectedProduct?.ProductId;
+
+        ApplyProductFilterAndSort();
+
+        SelectedProduct =
+            (previouslySelectedId != null ? _filteredSortedProducts.FirstOrDefault(r => r.ProductId == previouslySelectedId) : null)
+            ?? _filteredSortedProducts.FirstOrDefault();
+    }
+
+    private void ApplyProductFilterAndSort()
+    {
+        IEnumerable<ProductSalesRow> query = _allProductRows;
+
+        if (!string.IsNullOrWhiteSpace(ProductSearchQuery))
+        {
+            var q = ProductSearchQuery.Trim();
+            query = query.Where(r =>
+                r.ProductName.Contains(q, StringComparison.OrdinalIgnoreCase) ||
+                r.Sku.Contains(q, StringComparison.OrdinalIgnoreCase));
+        }
+
+        _filteredSortedProducts = query.ApplySort(
+            ProductSortColumn,
+            ProductSortDirection,
+            new Dictionary<string, Func<ProductSalesRow, object?>>
+            {
+                ["Product"] = r => r.ProductName,
+                ["Units"] = r => r.UnitsSold,
+                ["Revenue"] = r => r.RevenueUSD,
+                ["AvgPrice"] = r => r.AvgSalePriceUSD
+            },
+            r => r.RevenueUSD);
+
+        ProductTotalPages = Math.Max(1, (int)Math.Ceiling((double)_filteredSortedProducts.Count / ProductPageSize));
+        if (ProductCurrentPage > ProductTotalPages)
+            ProductCurrentPage = ProductTotalPages;  // re-pages via OnProductCurrentPageChanged
+        else
+            PageProducts();
+    }
+
+    /// <summary>Fills the visible <see cref="Products"/> page from the filtered, sorted set.</summary>
+    private void PageProducts()
+    {
+        ProductPaginationText = PaginationTextHelper.FormatPaginationText(
+            _filteredSortedProducts.Count, ProductCurrentPage, ProductPageSize, ProductTotalPages, "product");
+
+        Products.Clear();
+        foreach (var row in _filteredSortedProducts.Skip((ProductCurrentPage - 1) * ProductPageSize).Take(ProductPageSize))
+            Products.Add(row);
+    }
+
+    partial void OnSelectedProductChanged(ProductSalesRow? value)
+    {
+        OnPropertyChanged(nameof(HasSelectedProduct));
+
+        foreach (var row in _allProductRows)
+            row.IsSelected = ReferenceEquals(row, value);
+
+        ReloadProductRevenueTrend();
+    }
+
+    /// <summary>
+    /// (Re)builds the selected product's revenue-trend series. Called when the
+    /// selection changes and whenever the chart style changes (via LoadAllCharts),
+    /// since the series geometry depends on the chosen chart type.
+    /// </summary>
+    private void ReloadProductRevenueTrend()
+    {
+        var value = SelectedProduct;
+        var data = _companyManager?.CompanyData;
+        if (value == null || data == null)
+        {
+            ProductRevenueTrendSeries = [];
+            HasProductTrendData = false;
+            return;
+        }
+
+        var (series, dates) = ChartLoaderService.LoadProductRevenueTrendChart(
+            data, value.ProductId, StartDate, EndDate);
+        ProductRevenueTrendSeries = series;
+        ProductRevenueTrendXAxes = ChartLoaderService.CreateDateXAxes(dates);
+        ProductRevenueTrendYAxes = ChartLoaderService.CreateCurrencyYAxes(CurrencyService.CurrentSymbol);
+        HasProductTrendData = series.Count > 0;
+    }
+
+    /// <summary>Sets the table selection (invoked by row clicks in the view).</summary>
+    [RelayCommand]
+    private void SelectProduct(ProductSalesRow? row) => SelectedProduct = row;
 
     #endregion
 
@@ -1692,6 +1962,9 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
         LoadTaxRateDistributionChart(data);
         LoadExpenseVsRevenueTaxChart(data);
 
+        // Products detail chart (cartesian) reacts to chart-style changes too
+        ReloadProductRevenueTrend();
+
         // Pie charts and geo map are style-independent, only reload on data/filter changes
         if (!styleChangeOnly)
         {
@@ -1726,6 +1999,9 @@ public partial class AnalyticsPageViewModel : ChartContextMenuViewModelBase
             // Taxes pie charts
             LoadTaxByCategoryChart(data);
             LoadTaxByProductChart(data);
+
+            // Products tab
+            LoadProductSales(data);
         }
     }
 

--- a/ArgoBooks/ViewModels/ProductSalesRow.cs
+++ b/ArgoBooks/ViewModels/ProductSalesRow.cs
@@ -1,0 +1,50 @@
+using ArgoBooks.Core.Models.Reports;
+using ArgoBooks.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ArgoBooks.ViewModels;
+
+/// <summary>
+/// Row in the Analytics "Sales by Product" table. Wraps a
+/// <see cref="ProductSalesData"/> and exposes display-currency strings for
+/// binding, plus the raw USD figures for sorting. Currency conversion happens
+/// here, at the presentation boundary (see docs/Calculations.md §13).
+/// </summary>
+public partial class ProductSalesRow : ObservableObject
+{
+    public ProductSalesRow(ProductSalesData data, DateTime displayDate)
+    {
+        ProductId = data.ProductId;
+        ProductName = data.ProductName;
+        Sku = data.Sku;
+
+        UnitsSold = data.UnitsSold;
+        RevenueUSD = data.RevenueUSD;
+        AvgSalePriceUSD = data.AvgSalePriceUSD;
+
+        UnitsDisplay = data.UnitsSold.ToString("0.##");
+        RevenueDisplay = CurrencyService.FormatFromUSD(data.RevenueUSD, displayDate);
+        AvgSalePriceDisplay = CurrencyService.FormatFromUSD(data.AvgSalePriceUSD, displayDate);
+    }
+
+    public string ProductId { get; }
+    public string ProductName { get; }
+    public string Sku { get; }
+
+    // Raw USD values for sorting.
+    public decimal UnitsSold { get; }
+    public decimal RevenueUSD { get; }
+    public decimal AvgSalePriceUSD { get; }
+
+    // Display-currency strings for binding.
+    public string UnitsDisplay { get; }
+    public string RevenueDisplay { get; }
+    public string AvgSalePriceDisplay { get; }
+
+    /// <summary>True when the product has a SKU worth displaying.</summary>
+    public bool HasSku => !string.IsNullOrEmpty(Sku);
+
+    /// <summary>Highlights the row when it is the one shown in the detail panel.</summary>
+    [ObservableProperty]
+    private bool _isSelected;
+}

--- a/ArgoBooks/ViewModels/ReportsPageViewModel.cs
+++ b/ArgoBooks/ViewModels/ReportsPageViewModel.cs
@@ -62,7 +62,9 @@ public partial class ReportsPageViewModel : ViewModelBase
         new(ReportTemplateFactory.TemplateNames.ARaging, "AR Aging", "Who owes you and for how long",
             Icons.DollarCircleAlt, AppColors.FlatTeal, AppColors.FlatTealLight),
         new(ReportTemplateFactory.TemplateNames.TaxSummary, "Tax Summary", "Tax you collected vs. tax you paid",
-            Icons.BarChart, AppColors.FlatOrange, AppColors.FlatOrangeLight)
+            Icons.BarChart, AppColors.FlatOrange, AppColors.FlatOrangeLight),
+        new(ReportTemplateFactory.TemplateNames.ProductSales, "Sales by Product", "Units and revenue per product",
+            Icons.Products, AppColors.FlatIndigo, AppColors.FlatIndigoLight)
     ];
 
     #endregion

--- a/ArgoBooks/Views/AnalyticsPage.axaml
+++ b/ArgoBooks/Views/AnalyticsPage.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:ArgoBooks.ViewModels"
              xmlns:controls="using:ArgoBooks.Controls"
+             xmlns:table="using:ArgoBooks.Controls.ArgoTable"
              xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
              xmlns:loc="using:ArgoBooks.Localization"
              xmlns:enums="using:ArgoBooks.Core.Enums"
@@ -56,6 +57,7 @@
                     <TabControl SelectedIndex="{Binding SelectedTabIndex}"
                                 Classes="page-tabs">
                         <TabItem Header="{loc:Loc Dashboard}" />
+                        <TabItem Header="{loc:Loc Products}" />
                         <TabItem Header="{loc:Loc Geographic}" />
                         <TabItem Header="{loc:Loc Operational}" IsVisible="False" />
                         <TabItem Header="{loc:Loc Performance}" />
@@ -69,10 +71,11 @@
             </Grid>
         </Border>
 
-        <!-- Main Content Area -->
+        <!-- Main Content Area (all tabs except Products, which has its own bounded layout) -->
         <ScrollViewer Grid.Row="1"
                       VerticalScrollBarVisibility="Auto"
                       HorizontalScrollBarVisibility="Disabled"
+                      IsVisible="{Binding !IsProductsTabSelected}"
                       Background="{DynamicResource BackgroundSecondaryBrush}">
             <Panel>
                 <!-- Dashboard Tab Content -->
@@ -1963,6 +1966,184 @@
 
             </Panel>
         </ScrollViewer>
+
+        <!-- Products Tab Content: own bounded layout (Auto/*/Auto) so the table fills width -->
+        <Panel Grid.Row="1"
+               Background="{DynamicResource BackgroundSecondaryBrush}"
+               IsVisible="{Binding IsProductsTabSelected}">
+            <Grid Margin="24" RowDefinitions="Auto,*,Auto">
+                    <!-- Statistics Cards Row -->
+                    <controls:StatCardsRow Grid.Row="0" Margin="0,0,0,24">
+                        <controls:StatCard Label="{loc:Loc 'Product Revenue'}"
+                                           Value="{Binding TotalProductRevenue}"
+                                           Icon="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.91s4.18 1.39 4.18 3.91c-.01 1.83-1.38 2.83-3.12 3.16z"
+                                           IconColor="Success" />
+                        <controls:StatCard Label="{loc:Loc 'Units Sold'}"
+                                           Value="{Binding TotalProductUnits}"
+                                           Icon="M19 14V6c0-1.1-.9-2-2-2H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zm-9-1c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm13-6v11c0 1.1-.9 2-2 2H4v-2h17V7h2z"
+                                           IconColor="Primary" />
+                        <controls:StatCard Label="{loc:Loc 'Avg Sale Price'}"
+                                           Value="{Binding AvgProductSalePrice}"
+                                           Icon="M11.8 10.9c-2.27-.59-3-1.2-3-2.15 0-1.09 1.01-1.85 2.7-1.85 1.78 0 2.44.85 2.5 2.1h2.21c-.07-1.72-1.12-3.3-3.21-3.81V3h-3v2.16c-1.94.42-3.5 1.68-3.5 3.61 0 2.31 1.91 3.46 4.7 4.13 2.5.6 3 1.48 3 2.41 0 .69-.49 1.79-2.7 1.79-2.06 0-2.87-.92-2.98-2.1h-2.2c.12 2.19 1.76 3.42 3.68 3.83V21h3v-2.15c1.95-.37 3.5-1.5 3.5-3.55 0-2.84-2.43-3.81-4.7-4.4z"
+                                           IconColor="Info" />
+                        <controls:StatCard Label="{loc:Loc 'Products Sold'}"
+                                           Value="{Binding ProductsSoldCount}"
+                                           Icon="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.16.12-.36.18-.57.18-.21 0-.41-.06-.57-.18l-7.9-4.44A.991.991 0 0 1 3 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.16-.12.36-.18.57-.18.21 0 .41.06.57.18l7.9 4.44c.32.17.53.5.53.88v9zM12 4.15L6.04 7.5 12 10.85l5.96-3.35L12 4.15z"
+                                           IconColor="Warning" />
+                    </controls:StatCardsRow>
+
+                    <!-- Sales by Product Table -->
+                    <table:ArgoTable Grid.Row="1"
+                                         Title="{loc:Loc 'Sales by Product'}"
+                                         ItemsSource="{Binding Products}"
+                                         ShowAddButton="False"
+                                         ShowFilterButton="False"
+                                         ShowPagination="True"
+                                         ShowSearch="True"
+                                         SearchQuery="{Binding ProductSearchQuery, Mode=TwoWay}"
+                                         SearchPlaceholder="{loc:Loc 'Search products...'}"
+                                         SearchBoxWidth="{Binding ProductsResponsiveHeader.SearchBoxWidth}"
+                                         SearchBoxMinHeight="{Binding ProductsResponsiveHeader.SearchBoxMinHeight}"
+                                         SearchIconMargin="{Binding ProductsResponsiveHeader.SearchIconMargin}"
+                                         HeaderPadding="{Binding ProductsResponsiveHeader.HeaderPadding}"
+                                         HeaderSpacing="{Binding ProductsResponsiveHeader.HeaderSpacing}"
+                                         IsCompactMode="{Binding ProductsResponsiveHeader.IsCompactMode}"
+                                         IsMediumMode="{Binding ProductsResponsiveHeader.IsMediumMode}"
+                                         ShowButtonText="{Binding ProductsResponsiveHeader.ShowButtonText}"
+                                         ColumnWidthsManager="{Binding ProductColumns}"
+                                         CurrentPage="{Binding ProductCurrentPage, Mode=TwoWay}"
+                                         TotalPages="{Binding ProductTotalPages}"
+                                         PageSize="{Binding ProductPageSize, Mode=TwoWay}"
+                                         PaginationText="{Binding ProductPaginationText}"
+                                         GoToPageCommand="{Binding GoToProductPageCommand}"
+                                         GoToPreviousPageCommand="{Binding ProductPreviousPageCommand}"
+                                         GoToNextPageCommand="{Binding ProductNextPageCommand}"
+                                         BorderSizeChanged="OnProductsHeaderSizeChanged"
+                                         TableGridSizeChanged="OnProductsTableSizeChanged"
+                                         EmptyIcon="{x:Static icons:Icons.Products}"
+                                         EmptyTitle="{loc:Loc 'No product sales to show'}"
+                                         EmptyMessage="{loc:Loc 'No products were sold in the selected period. Try a wider date range.'}">
+                            <table:ArgoTable.HeaderContent>
+                                <StackPanel Orientation="Horizontal">
+                                    <table:ArgoTableHeader Header="{loc:Loc Product}" ColumnName="Product" SortProperty="Product"
+                                                           ColumnWidth="{Binding ProductColumns.ProductColumnWidth}" ColumnWidths="{Binding ProductColumns}"
+                                                           SortColumn="{Binding ProductSortColumn}" SortDirection="{Binding ProductSortDirection}" SortCommand="{Binding ProductSortByCommand}" />
+                                    <table:ArgoTableHeader Header="{loc:Loc Units}" ColumnName="Units" SortProperty="Units"
+                                                           ColumnWidth="{Binding ProductColumns.UnitsColumnWidth}" ColumnWidths="{Binding ProductColumns}"
+                                                           SortColumn="{Binding ProductSortColumn}" SortDirection="{Binding ProductSortDirection}" SortCommand="{Binding ProductSortByCommand}" />
+                                    <table:ArgoTableHeader Header="{loc:Loc Revenue}" ColumnName="Revenue" SortProperty="Revenue"
+                                                           ColumnWidth="{Binding ProductColumns.RevenueColumnWidth}" ColumnWidths="{Binding ProductColumns}"
+                                                           SortColumn="{Binding ProductSortColumn}" SortDirection="{Binding ProductSortDirection}" SortCommand="{Binding ProductSortByCommand}" />
+                                    <table:ArgoTableHeader Header="{loc:Loc 'Avg price'}" ColumnName="AvgPrice" SortProperty="AvgPrice" ShowSeparator="False"
+                                                           ColumnWidth="{Binding ProductColumns.AvgPriceColumnWidth}" ColumnWidths="{Binding ProductColumns}"
+                                                           SortColumn="{Binding ProductSortColumn}" SortDirection="{Binding ProductSortDirection}" SortCommand="{Binding ProductSortByCommand}" />
+                                </StackPanel>
+                            </table:ArgoTable.HeaderContent>
+                            <table:ArgoTable.RowsContent>
+                                <ItemsControl Classes="table-rows" ItemsSource="{Binding Products}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="vm:ProductSalesRow">
+                                            <Button Classes="product-row"
+                                                    HorizontalAlignment="Stretch"
+                                                    HorizontalContentAlignment="Stretch"
+                                                    Padding="0"
+                                                    Command="{Binding $parent[ItemsControl].((vm:AnalyticsPageViewModel)DataContext).SelectProductCommand}"
+                                                    CommandParameter="{Binding}">
+                                                <Border Padding="24,0" MinHeight="52"
+                                                        Classes.selected="{Binding IsSelected}"
+                                                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <table:ArgoTableCell ColumnWidth="{Binding $parent[ItemsControl].((vm:AnalyticsPageViewModel)DataContext).ProductColumns.ProductColumnWidth}">
+                                                            <table:ArgoTableCell.CellContent>
+                                                                <StackPanel VerticalAlignment="Center" Spacing="1">
+                                                                    <TextBlock Text="{Binding ProductName}" FontSize="13" FontWeight="Medium"
+                                                                               TextTrimming="CharacterEllipsis" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                                                    <TextBlock Text="{Binding Sku}" FontSize="11" IsVisible="{Binding HasSku}"
+                                                                               TextTrimming="CharacterEllipsis" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                                                </StackPanel>
+                                                            </table:ArgoTableCell.CellContent>
+                                                        </table:ArgoTableCell>
+                                                        <table:ArgoTableCell Text="{Binding UnitsDisplay}"
+                                                                             ColumnWidth="{Binding $parent[ItemsControl].((vm:AnalyticsPageViewModel)DataContext).ProductColumns.UnitsColumnWidth}" />
+                                                        <table:ArgoTableCell Text="{Binding RevenueDisplay}"
+                                                                             ColumnWidth="{Binding $parent[ItemsControl].((vm:AnalyticsPageViewModel)DataContext).ProductColumns.RevenueColumnWidth}" />
+                                                        <table:ArgoTableCell Text="{Binding AvgSalePriceDisplay}"
+                                                                             ColumnWidth="{Binding $parent[ItemsControl].((vm:AnalyticsPageViewModel)DataContext).ProductColumns.AvgPriceColumnWidth}" />
+                                                    </StackPanel>
+                                                </Border>
+                                            </Button>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </table:ArgoTable.RowsContent>
+                    </table:ArgoTable>
+
+                    <!-- Detail panel: selected product's revenue trend + metrics -->
+                    <Border Grid.Row="2" Margin="0,24,0,0"
+                            Background="{DynamicResource SurfaceBrush}"
+                            BorderBrush="{DynamicResource BorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="12"
+                            Padding="20"
+                            IsVisible="{Binding HasSelectedProduct}">
+                        <Grid RowDefinitions="Auto,Auto">
+                            <!-- Header -->
+                            <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,14">
+                                <StackPanel Grid.Column="0" Spacing="2">
+                                    <TextBlock Text="{Binding SelectedProduct.ProductName}"
+                                               FontSize="16" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    <TextBlock Text="{Binding SelectedProduct.Sku}"
+                                               IsVisible="{Binding SelectedProduct.HasSku, FallbackValue=False}"
+                                               FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                </StackPanel>
+                                <TextBlock Grid.Column="1"
+                                           Text="{loc:Loc 'Select a product in the table to change this view'}"
+                                           VerticalAlignment="Center"
+                                           FontSize="12" FontStyle="Italic"
+                                           Foreground="{DynamicResource TextSecondaryBrush}" />
+                            </Grid>
+
+                            <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Height="220">
+                                <!-- Trend chart -->
+                                <Panel Grid.Column="0">
+                                    <lvc:CartesianChart Tag="{x:Static enums:ChartDataType.ProductRevenueTrend}"
+                                                        Title="{Binding ProductRevenueTrendTitle}"
+                                                        PointerPressed="OnChartPointerPressed"
+                                                        PointerReleased="OnChartPointerReleased"
+                                                        Series="{Binding ProductRevenueTrendSeries}"
+                                                        XAxes="{Binding ProductRevenueTrendXAxes}"
+                                                        YAxes="{Binding ProductRevenueTrendYAxes}"
+                                                        ZoomMode="Both"
+                                                        IsVisible="{Binding HasProductTrendData}" />
+                                    <controls:ChartEmptyState
+                                        IsVisible="{Binding !HasProductTrendData}"
+                                        DefaultMessage="{loc:Loc 'No revenue data for this product in the selected period'}"
+                                        ShowDateRangeMessage="{Binding ShowFinancialDateRangeMessage}" />
+                                </Panel>
+
+                                <!-- Mini KPIs -->
+                                <StackPanel Grid.Column="1" Width="220" Margin="20,0,0,0" VerticalAlignment="Center" Spacing="0">
+                                    <Grid ColumnDefinitions="*,Auto" Margin="0,7">
+                                        <TextBlock Grid.Column="0" Text="{loc:Loc 'Units sold'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                        <TextBlock Grid.Column="1" Text="{Binding SelectedProduct.UnitsDisplay}" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    </Grid>
+                                    <Border Height="1" Background="{DynamicResource BorderBrush}" />
+                                    <Grid ColumnDefinitions="*,Auto" Margin="0,7">
+                                        <TextBlock Grid.Column="0" Text="{loc:Loc Revenue}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                        <TextBlock Grid.Column="1" Text="{Binding SelectedProduct.RevenueDisplay}" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    </Grid>
+                                    <Border Height="1" Background="{DynamicResource BorderBrush}" />
+                                    <Grid ColumnDefinitions="*,Auto" Margin="0,7">
+                                        <TextBlock Grid.Column="0" Text="{loc:Loc 'Avg sale price'}" FontSize="13" Foreground="{DynamicResource TextSecondaryBrush}" />
+                                        <TextBlock Grid.Column="1" Text="{Binding SelectedProduct.AvgSalePriceDisplay}" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource TextPrimaryBrush}" />
+                                    </Grid>
+                                </StackPanel>
+                            </Grid>
+                        </Grid>
+                    </Border>
+            </Grid>
+        </Panel>
     </Grid>
 
     <!-- Customer Activity Info Modal -->
@@ -2075,6 +2256,23 @@
     </Panel>
 
     <UserControl.Styles>
+        <!-- Sales by Product table rows -->
+        <Style Selector="Button.product-row">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.product-row:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource TableRowHoverBrush}" />
+        </Style>
+        <!-- Selected row: theme-aware tint plus a primary left accent -->
+        <Style Selector="Button.product-row Border.selected">
+            <Setter Property="Background" Value="{DynamicResource TableRowSelectedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryBrush}" />
+            <Setter Property="BorderThickness" Value="3,0,0,1" />
+        </Style>
+
         <!-- TabControl - page tabs styling -->
         <Style Selector="TabControl.page-tabs">
             <Setter Property="Background" Value="Transparent" />

--- a/ArgoBooks/Views/AnalyticsPage.axaml.cs
+++ b/ArgoBooks/Views/AnalyticsPage.axaml.cs
@@ -62,6 +62,21 @@ public partial class AnalyticsPage : UserControl
         }
     }
 
+    /// <summary>
+    /// Keeps the Product Profitability table's columns sized to the available width.
+    /// </summary>
+    private void OnProductsHeaderSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        if (DataContext is AnalyticsPageViewModel vm && e.WidthChanged)
+            vm.ProductsResponsiveHeader.HeaderWidth = e.NewSize.Width;
+    }
+
+    private void OnProductsTableSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        if (DataContext is AnalyticsPageViewModel vm && e.WidthChanged)
+            vm.ProductColumns.SetAvailableWidth(e.NewSize.Width);
+    }
+
     protected override void OnLoaded(RoutedEventArgs e)
     {
         base.OnLoaded(e);

--- a/docs/Calculations.md
+++ b/docs/Calculations.md
@@ -283,6 +283,8 @@ Bank Matching (`BankMatchingService`) is a non-financial reference layer: it imp
 | Overdue Invoices stat | `EffectiveBalanceUSD` | — | **No** (by design) | n/a |
 | Revenue page list | `EffectiveTotalUSD` | — | **No** (shows all) | n/a |
 | Income Statement / GL | `EffectiveSubtotalUSD` | `EffectiveSubtotalUSD` | Per-report setting | Per-report setting |
+| Sales by Product (Analytics tab) | `EffectiveTotalUSD` (allocated per line item) | — | Yes | Not applied (see §13) |
+| Sales by Product (Report) | `EffectiveTotalUSD` (allocated per line item) | — | No (accrual) | Not applied (see §13) |
 
 ---
 
@@ -312,3 +314,44 @@ When writing or reviewing aggregation code:
 - All aggregations stay in USD. Convert to display currency only at the presentation boundary (stat card binding, chart series construction).
 - For any new chart or stat card, look at the table in §11 to decide which column you fall under, and copy the pattern from a neighbor that is already correct.
 - If you can't find an answer here, the rule does not exist yet, propose one before writing the code.
+
+---
+
+## 13. Sales by product
+
+The Analytics "Products" tab and the Report Builder "Sales by Product" template both break **revenue and units** down per product. `ProductSalesService` is the single source of truth; both surfaces call it so their math never diverges, only the basis differs (see below).
+
+**Why revenue, not profit.** Per-product *profit* is deliberately **not** computed. Profit would need a trustworthy cost of goods sold per product, and Argo can't produce one: a product's cost is an optional, manually-entered default (`Product.CostPrice`), the system does no COGS matching (§10: stock is expensed when bought, never matched to the sale), and anything you assemble or make (a pizza built from flour and cheese) has no purchasable "cost of itself" at all. Rather than show a misleading margin, these surfaces report only what is always true: how much each product sold for and how many units moved.
+
+### Revenue per product (gross, USD)
+
+A transaction's `Effective*USD` properties live at the transaction level, not the line item. To attribute revenue to a product, allocate each line item's share of the transaction's **gross** USD total in proportion to its native pre-tax subtotal:
+
+```
+lineItemsTotal = Σ over LineItem of li.Subtotal          (native currency, pre-tax)
+revenueUSD(li) = lineItemsTotal != 0
+               ? round(li.Subtotal / lineItemsTotal × txn.EffectiveTotalUSD, 2)
+               : 0
+```
+
+Revenue is **gross** (`EffectiveTotalUSD`, tax-inclusive), matching every other revenue display in the app per Rule 1 (Total Revenue card, Top Customers, etc.). The allocation weight is the line's pre-tax subtotal, which is the only per-line figure available; tax is distributed in the same proportion. Line items with no `ProductId` group under "Unknown". A transaction with **no line items at all** has no product to attribute to and is excluded from these surfaces entirely.
+
+### Units and average price
+
+```
+unitsSold(product) = Σ over its line items of li.Quantity
+avgSalePriceUSD(product) = unitsSold != 0 ? revenueUSD / unitsSold : 0
+```
+
+`avgSalePrice` is gross revenue per unit (it carries the same tax-inclusive basis as the revenue column).
+
+### Basis: cash for analytics, accrual for the report
+
+Consistent with Rule 2 and §10, the two surfaces deliberately differ and `ProductSalesService` takes a single `cashBasis` flag to switch:
+
+- **Analytics Products tab** (`cashBasis: true`): filters revenues with `RevenueAggregator.IsCollected` first, like every other analytics tab. Its aggregate revenue is close to the Total Revenue stat card for the same range but does not reconcile exactly, and the two differences pull opposite ways: it does **not** subtract refunds (so it reads higher than the card by the refund amount, see below), and it excludes revenue on transactions with **no line items** (so it reads lower than the card by that amount).
+- **Report Builder template** (`cashBasis: false`): counts all invoiced revenue in range, like the Income Statement.
+
+### Refunds are not attributed per-product
+
+Refunds are recorded as invoice-level `Payment` rows (§8) with no line-item breakdown, so there is no reliable way to subtract a refund from the specific product it concerned. Per-product revenue therefore does **not** subtract refunds, and will read slightly high for products that were later refunded. Customer-returned items and lost/damaged stock already have their own per-product surfaces (Returns by Product, Losses by Product).


### PR DESCRIPTION
## Summary

Adds a per-product **sales** view in two places, both backed by a single `ProductSalesService` so the numbers stay in sync:

1. **New Analytics "Products" tab** (positioned right after Dashboard): a searchable, sortable, paginated table of **units, gross revenue, and average sale price** per product, plus a click-to-drill detail panel with a per-product **revenue-over-time** chart. It lives in its own bounded layout so the table fills the full width like the other table pages.
2. **New "Sales by Product" report template** in the Report Builder.

## Calculations

- Revenue is **gross** (`EffectiveTotalUSD`) allocated across line items by pre-tax subtotal share, matching every other revenue figure in the app (Calculations.md Rule 1).
- Analytics tab is **cash-basis**; the report is **accrual**, consistent with the rest of the app.
- Documented in `Calculations.md` §13.

## Why revenue-only (no profit/margin)

Per-product cost/profit/margin are deliberately **not** shown. Argo has no trustworthy per-product cost: `Product.CostPrice` is an optional manual field, there is no COGS matching (stock is expensed when bought, never matched to a sale), and assembled/made goods (e.g. a pizza built from ingredients) have no purchasable cost-of-self. Showing only revenue and units keeps every number true for any business type.

## Tests

Adds `ProductSalesServiceTests` (9 tests, all passing): gross-revenue allocation, multi-line splits, cash vs accrual, multi-currency, no-line-item exclusion, date filtering, unknown product, and per-day reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)